### PR TITLE
Fix typo and center title in steering-committee.html

### DIFF
--- a/steering-committee.html
+++ b/steering-committee.html
@@ -86,7 +86,7 @@
 <a name="main-content"></a>
 <header id="main-content-header">
 <a name="main-content"></a>
-<h1 id="page-title" ng-non-bindable="">Steering Committe</h1>
+<h1 align="center" id="page-title" ng-non-bindable="">Steering Committee</h1>
 </header>
 
 <!--front panel regions beg-->


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://github.com/geoschem/geoschem.github.io/blob/main/CONTRIBUTING.md)

### Describe the update

1. "Steering Committe" -> "Steering Committee"
2. Now centers the page title