### PR TITLE
Add link to GEOS-Chem 2023, issue 2 newsletter on GCSC page

### DIFF
--- a/steering-committee.html
+++ b/steering-committee.html
@@ -582,7 +582,7 @@ The <em><a href="https://drive.google.com/file/d/1SJSCa64wxvolTDMLDnhc6WlpJy_Ejs
       <p>
       <a href="https://drive.google.com/file/d/1dioG7pR0p9IEVQZ_1T2rUJOje3a9uXrd/view?usp=sharing"Carbon Working Group update</a><br />
       <a href="https://drive.google.com/file/d/1lnSn07OwfXwJneGBG0W4veX-zRA7SSkK/view?usp=sharing">Chemistry Working Group update</a><br/>
-      <a href="">GEOS-Chem Newsletter 2023, Issue 3</a>
+      <a href="https://drive.google.com/drive/u/0/folders/1Zh9faail7CaNAD9G1nF_go3guiQEmXzh">GEOS-Chem Newsletter 2023, Issue 2</a>
       </p>
     </td>
   </tr>
@@ -597,7 +597,6 @@ The <em><a href="https://drive.google.com/file/d/1SJSCa64wxvolTDMLDnhc6WlpJy_Ejs
       <p>
       <a href="https://drive.google.com/file/d/1mti_Xz9hHdNXQHwCLStvtWqf1T70-FTn/view?usp=drive_link">Software Engineering Working Group update</a><br />
       <a href="https://drive.google.com/file/d/1jS0Sq1jpQPbEJtlrHPG92ar9UPBIGwtp/view?usp=drive_link">Emissions Working Group update</a><br/>
-      <a href="https://drive.google.com/file/d/1iaBc_QyuJqQuWXElVjrwj5w_MnQzUPgs/view?usp=drive_link">GEOS-Chem Newsletter 2023, Issue 2</a>
       </p>
     </td>
   </tr>


### PR DESCRIPTION
### Name and Institution (Required)

Name: Melissa Sulprizio
Institution: Harvard / GCST

### Describe the update


Link to PDF of the Newsletter 2023, Issue 2 in Google Drive under the September GCSC meeting minutes.

Also removed the link to this newsletter under the previous GCSC meeting minutes since it was never released to the community due to the delayed release of 14.2.0.