### PR TITLE
Migrate "subscribing to GC email lists" from the wiki to this website

### DIFF
--- a/dropdown-menu.js
+++ b/dropdown-menu.js
@@ -26,7 +26,8 @@ function inlineDropDownMenu() {
       <li><a href="steering-committee.html" >Steering Committee</a></li>\
       <li><a href="working-groups.html" >Working Groups</a></li>\
       <li><a href="support-team.html" >Support Team</a></li>\
-    </ul>\
+      <li><a href="email-lists.html" >Email Lists</a></li>\
+   </ul>\
   </li>\
   <li class="menuparent"><a class="menu-heading">Research</a>\
     <ul>\
@@ -65,8 +66,6 @@ function inlineDropDownMenu() {
       <li><a href="http://wiki.geos-chem.org/Guide_to_GEOS-Chem_simulations" >Simulations</a></li>\
       <li><a href="http://wiki.geos-chem.org/GEOS-Chem_benchmarking"  title="">Benchmarking</a></li>\
       <li><a href="https://hemco.readthedocs.io" >HEMCO</a></li>\
-      <li><a href="http://wiki.geos-chem.org/Emissions_overview"  title="">Emissions Overview</a></li>\
-      <li><a href="http://wiki.geos-chem.org/Guide_to_GEOS-Chem_performance"  title="">Performance</a></li>\
       <li><a href="https://gchp.readthedocs.io" >GCHP</a></li>\
       <li><a href="http://wrf.geos-chem.org/" >WRF-GC</a></li>\
       <li><a href="logo.html" >GEOS-Chem logo</a></li>\

--- a/email-lists.html
+++ b/email-lists.html
@@ -1,0 +1,283 @@
+<!DOCTYPE html>
+<!--[if IEMobile 7]><html class="iem7"  lang="en" dir="ltr"><![endif]-->
+<!--[if lte IE 6]><html class="lt-ie9 lt-ie8 lt-ie7"  lang="en" dir="ltr"><![endif]-->
+<!--[if (IE 7)&(!IEMobile)]><html class="lt-ie9 lt-ie8"  lang="en" dir="ltr"><![endif]-->
+<!--[if IE 8]><html class="lt-ie9"  lang="en" dir="ltr"><![endif]-->
+<!--[if (gte IE 9)|(gt IEMobile 7)]><!--><html  lang="en" dir="ltr"><!--<![endif]-->
+<head>
+<meta charset="utf-8" />
+<!--<base href="/" />-->
+<link rel="shortcut icon" href="img/geos-chem-logo-favicon.png" />
+<link rel="canonical" href="index.html" />
+<link rel="shortlink" href="index.html" />
+<meta property="og:type" content="company" />
+<meta property="og:title" content="GEOS-Chem website" />
+<meta name="twitter:card" content="summary" />
+<meta name="twitter:title" content="GEOS-Chem website" />
+<meta name="twitter:description" content="GEOS-Chem website" />
+<meta name="twitter:image" content="https://geos-chem.org" />
+<title>Subscribing to the GEOS-Chem email lists</title>
+<meta http-equiv="x-ua-compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<link type="text/css" rel="stylesheet" href="css/css_xE-rWrJf-fncB6ztZfd2huxqgxu4WO-qwma6Xer30m4%EF%B9%96m=1675397288.css" media="all" />
+<link type="text/css" rel="stylesheet" href="css/css_1kR8T1_c-l5pBT6ZwbDT7BFda-4fyqW9Jjum29_2IY8%EF%B9%96m=1675397312.css" media="all" />
+<link type="text/css" rel="stylesheet" href="css/css_YnlUIvHP13qgpYEqubzE8JyDwlSxUnVibfnVkSoSDb0%EF%B9%96m=1675397273.css" media="all" />
+<link type="text/css" rel="stylesheet" href="css/css_lzv2lyRoD9TGLNsrZeaAEIHqW0mWI04uBXQ8K1MSwY0%EF%B9%96m=1675397576.css" media="all" />
+<link type="text/css" rel="stylesheet" href="css/css_vprtFTrWyg23GbY50_zJZHWGYMNfS8vsrRS26i4-ISk%EF%B9%96m=1675397406.css" media="screen" />
+<link type="text/css" rel="stylesheet" href="css/css_dW-aNNrctRhQNc-KECjtQd0PxuW-h19IEum-TX2MeEk%EF%B9%96m=1675397301.css" media="print" />
+<link type="text/css" rel="stylesheet" href="css/css_SH2Lx3Qprh0GZo_9xRp85U9NsWfkSXn_Bi-rJoMY1sw%EF%B9%96m=1675397273.css" media="screen" />
+<link type="text/css" rel="stylesheet" href="css/css_uaIDKcYMUK5osSQXuirpr3ZleXtnnpBN-eiECm7N0M0%EF%B9%96m=1675397395.css" media="all" />
+<link type="text/css" rel="stylesheet" href="css/blue_sky.css" media="all" />
+<link type="text/css" rel="stylesheet" href="css/responsive.blue_sky.css" media="all" />
+<link type="text/css" rel="stylesheet" href="css/geos-chem.css" media="all"/>
+<script type="text/javascript" src="dropdown-menu.js"></script>
+<!--[if lte IE 8]>
+<script type="text/javascript">
+  var os_c = document.createElement;os_c('header');os_c('nav');os_c('section');os_c('article');os_c('aside');os_c('footer');os_c('hgroup');os_c('figure');
+</script>
+<![endif]-->
+</head>
+
+<body class="html front not-logged-in no-sidebars page-home og-context og-context-node og-context-node-1585652 navbar-on">
+<div id="skip-link">
+<a href="#main-content" class="element-invisible element-focusable" tabindex="1">Skip to main content</a>
+</div>
+
+<div id="page_wrap" class="page_wrap">
+<div id="page" class="container page header-main content-top footer-none">
+<div id="page-wrapper">
+		
+<!--header regions beg-->
+<header id="header" class="clearfix" role="banner">
+<div id="header-container">
+<div id="header-panels" class="at-panel gpanel panel-display three-col clearfix">
+<div class="region region-header-second">
+<div class="region-inner clearfix">
+<section id="block-boxes-1630413211" class="block block-boxes block-boxes-os_boxes_html"  module="boxes" delta="1630413211">
+<div class="block-inner clearfix">  
+<h2 class="block-title" ng-non-bindable="">Site-Logo</h2>
+<div class="block-content content" ng-non-bindable="">
+<div id='boxes-box-1630413211' class='boxes-box'>
+<div class="boxes-box-content">
+<p style="text-align:center"><a href="index.html" title=""><img alt="Welcome to the GEOS-Chem website" src="img/geos-chem-logo.png" style="width:420px" /></a></p>
+</div>
+</div>
+</div>
+</div>
+</section>
+</div>
+</div>
+</div>
+</div>
+</header>
+<!--header regions end-->
+
+<!--main menu region beg-->
+<div id="menu-bar" class="nav region-menu-bar clearfix">
+<nav id="block-os-primary-menu" class="block block-os no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="primary-menu">
+<script>inlineDropDownMenu();</script>
+</nav>
+</div>
+<!--main menu region end-->	
+
+<div id="columns" class="clearfix">
+<div class="hg-container">
+<div id="content-column" role="main">
+<div class="content-inner">
+<a name="main-content"></a>
+<header id="main-content-header">
+<a name="main-content"></a>
+<h1 id="page-title" ng-non-bindable="">Subscribing to the GEOS-Chem email lists</h1> 
+</header>
+			
+<!--front panel regions beg-->
+<div id="content-panels" class="at-panel gpanel panel-display content clearfix">
+<div class="region region-content-top">
+<div class="region-inner clearfix">
+<div id="block-os-pages-main-content" class="block block-os-pages no-title"  module="os_pages" delta="main_content">
+<div class="block-inner clearfix">  
+<div class="block-content content" ng-non-bindable="">
+<article id="node-1585688" class="node node-page article clearfix" role="article">
+<div class="node-content" ng-non-bindable="">
+<div class="field field-name-body field-type-text-with-summary field-label-hidden view-mode-full">
+<div class="field-items">
+<div class="field-item even">
+
+<p>We use several email lists to share information among the GEOS-Chem user community. There is a "general" GEOS-Chem email list, plus an email list for each <a href="https://geos-chem.seas.harvard.edu/geos-working-groups">GEOS-Chem Working Group</a>. You should subscribe to the general email list which gives crucial information about new versions, bugs, meetings, etc. You should also subscribe to the email lists of the Working Groups in which you are interested. You can see the complete list of all GEOS-Chem email lists at this link: <a href="https://groups.google.com/a/g.harvard.edu/forum/#!forumsearch/geos-chem">https://groups.google.com/a/g.harvard.edu/forum/#!forumsearch/geos-chem</a></p>
+<p>Please inform the <a href="GEOS-Chem_Support_Team" title="wikilink">GEOS-Chem Support Team</a> if you suspect mail is not being delivered properly.</p>
+<table>
+<thead>
+<tr class="header">
+<th width="33%"><p>GEOS-Chem email list name<br />
+(Follow link for web interface)</p></th>
+<th width="30%"><p>Send messages here<br />
+(Add @g.harvard.edu)</p></th>
+<th><p>Intended audience</p></th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td><p><a href="https://groups.google.com/a/g.harvard.edu/forum/#!forum/geos-chem">GEOS-Chem</a></p></td>
+<td><p><code>geos-chem</code></p></td>
+<td><p>All GEOS-Chem users and developers<br /><br />
+<strong><em>This is the "general" email list to which information about new model versions, bugs &amp; fixes, meetings etc. will be sent. You should subscribe to this list, in addition to any of the other lists that are relevant to the area of your research.</em></strong></p></td>
+</tr>
+<tr class="even">
+<td><p><a href="https://groups.google.com/a/g.harvard.edu/forum/#!forum/geos-chem-adjoint">GEOS-Chem Adjoint and Data Assimilation</a></p></td>
+<td><p><code>geos-chem-adjoint</code></p></td>
+<td><p><a href="http://wiki.geos-chem.org/GEOS-Chem_Adjoint" title="wikilink">Adjoint Working Group</a> and<br />
+    <a href="http://wiki.geos-chem.org/GEOS-Chem_Data_Assimilation_Working_Group" title="wikilink">Data Assimilation Working Group</a></p></td>
+</tr>
+<tr class="odd">
+<td><p><a href="https://groups.google.com/a/g.harvard.edu/forum/#!forum/geos-chem-aerosols">GEOS-Chem Aerosols</a></p></td>
+<td><p><code>geos-chem-aerosols</code></p></td>
+<td><p><a href="http://wiki.geos-chem.org/Aerosols_Working_Group" title="wikilink">Aerosols Working Group</a></p></td>
+</tr>
+<tr class="even">
+<td><p><a href="https://groups.google.com/a/g.harvard.edu/forum/#!forum/geos-chem-carbon">GEOS-Chem Carbon Cycle</a></p></td>
+<td><p><code>geos-chem-carbon</code></p></td>
+<td><p><a href="http://wiki.geos-chem.org/Carbon_Cycle_Working_Group" title="wikilink">Carbon Cycle Working Group</a></p></td>
+</tr>
+<tr class="odd">
+<td><p><a href="https://groups.google.com/a/g.harvard.edu/forum/#!forum/geos-chem-organics">GEOS-Chem Chemistry</a></p></td>
+<td><p><code>geos-chem-organics</code></p></td>
+<td><p><a href="http://wiki.geos-chem.org/Chemistry_Working_Group" title="wikilink">Chemistry Working Group</a></p></td>
+</tr>
+<tr class="even">
+<td><p><a href="https://groups.google.com/a/g.harvard.edu/forum/#!forum/geos-chem-chemistry-climate">GEOS-Chem Chemistry-Climate</a></p></td>
+<td><p><code>geos-chem-chemistry-climate</code></p></td>
+<td><p><a href="http://wiki.geos-chem.org/Chemistry-Climate_Working_Group" title="wikilink">Chemistry-Climate Working Group</a></p></td>
+</tr>
+<tr class="odd">
+<td><p><a href="https://groups.google.com/a/g.harvard.edu/forum/#!forum/geos-chem-emissions">GEOS-Chem Emissions</a></p></td>
+<td><p><code>geos-chem-emissions</code></p></td>
+<td><p><a href="http://wiki.geos-chem.org/Emissions_Working_Group" title="wikilink">Emissions Working Group</a></p></td>
+</tr>
+<tr class="even">
+<td><p><a href="https://groups.google.com/a/g.harvard.edu/forum/#!forum/geos-chem-hg-pop">GEOS-Chem Hg and POPs</a></p></td>
+<td><p><code>geos-chem-hg-pop</code></p></td>
+<td><p><a href="http://wiki.geos-chem.org/Hg_and_POPs_Working_Group" title="wikilink">Hg and POPs Working Group</a></p></td>
+</tr>
+<tr class="odd">
+<td><p><a href="https://groups.google.com/a/g.harvard.edu/forum/#!forum/geos-chem-software-eng">GEOS-Chem Software Engineering</a></p></td>
+<td><p><code>geos-chem-software-eng</code></p></td>
+<td><p><a href="http://wiki.geos-chem.org/Software_Engineering_Working_Group" title="wikilink">Software Engineering Working Group</a></p></td>
+</tr>
+<tr class="even">
+<td><p><a href="https://groups.google.com/a/g.harvard.edu/forum/#!forum/geos-chem-stratosphere">GEOS-Chem Stratosphere</a></p></td>
+<td><p><code>geos-chem-stratosphere</code></p></td>
+<td><p><a href="http://wiki.geos-chem.org/Stratospheric_Working_Group" title="wikilink">Stratospheric Working Group</a></p></td>
+</tr>
+<tr class="odd">
+<td><p><a href="https://groups.google.com/a/g.harvard.edu/forum/#!forum/geos-chem-sfc-atmos-exchange">GEOS-Chem Surface-Atmosphere Exchange</a></p></td>
+<td><p><code>geos-chem-sfc-atmos-exchange</code></p></td>
+<td><p><a href="http://wiki.geos-chem.org/Surface-Atmosphere_Exchange_Working_Group" title="wikilink">Surface-Atmosphere Exchange Working Group</a></p></td>
+</tr>
+<tr class="even">
+<td><p><a href="https://groups.google.com/a/g.harvard.edu/forum/#!forum/geos-chem-transport">GEOS-Chem Transport</a></p></td>
+<td><p><code>geos-chem-transport</code></p></td>
+<td><p><a href="http://wiki.geos-chem.org/Transport_Working_Group" title="wikilink">Transport Working Group</a></p></td>
+</tr>
+</tbody>
+</table>
+<p>We invite you to join the Working Group that is most appropriate to your research and to subscribe to the relevant email list. Consider joining more than one Working Group (and email list) if your research spans several topics.</p>
+<h2 id="subscribing_to_a_list">Subscribing to a list</h2>
+<p>To subscribe to any of the GEOS-Chem email lists, simply send an email to one (or more) of the addresses listed above with <code>+subscribe</code> appended to the email address (e.g. <code>geos-chem+subscribe [at] g.harvard.edu; geos-chem-adjoint+subscribe [at] g.harvard.edu</code>). Please include your name, affiliation, and research area in the email body as it will speed up the approval process. A moderator will examine your subscription request before issuing final approval.</p>
+<h2 id="unsubscribing_from_a_list">Unsubscribing from a list</h2>
+<p>To unsubscribe from any of the GEOS-Chem email lists, simply send an email to one (or more) of the addresses listed above with <code>+unsubscribe</code> appended to the email address (e.g. <code>geos-chem+unsubscribe [at] g.harvard.edu; geos-chem-adjoint+unsubscribe [at] g.harvard.edu</code>). This information is also provided at the bottom of each email sent to the Google Group. For example:</p>
+<blockquote>
+  <tt>
+   --<br />
+   You received this message because you are subscribed to the Google Groups "GEOS-Chem" group.<br />
+   To unsubscribe from this group and stop receiving emails from it, send an email to geos-chem+unsubscribe@g.harvard.edu. <br />
+   To view this discussion on the web visit <a href="https://groups.google.com/a/g.harvard.edu/">https://groups.google.com/a/g.harvard.edu/</a>...
+ </tt>
+</blockquote>
+<h2 id="anti_spam_measures">Anti-spam measures</h2>
+<p>Each subscription request shall be approved by the <a href="GEOS-Chem_Support_Team" title="wikilink">GEOS-Chem Support Team</a>. Requests from persons who are not recognized GEOS-Chem users shall be discarded.</p>
+<p>To prevent spam, the GEOS-Chem email lists will reject mail from unrecognized addresses. When sending an email message to a list, make sure that you send your message from the same email address under which you subscribed to that list. Otherwise your message may not get delivered.</p>
+<p>If you are having difficulties sending mail to a list, then please contact the GEOS-Chem Support Team for assistance.</p>
+
+  
+</div>
+</div>
+</div>
+</div>
+</article>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<!--front panel regions end-->
+
+</div>
+</div>
+</div>
+</div>
+
+<!--footer region beg-->
+<footer id="footer" class="clearfix" role="contentinfo">
+
+<!-- Three column 3x33 Gpanel -->
+<div class="at-panel gpanel panel-display footer clearfix">
+<div class="region region-footer-bottom">
+<div class="region-inner clearfix">
+<div id="block-boxes-1616879798" class="block block-boxes block-boxes-os_boxes_media no-title"  module="boxes" delta="1616879798">
+<div class="block-inner clearfix">
+<div class="block-content content">
+<div id='boxes-box-1616879798' class='boxes-box'>
+<div class="boxes-box-content">
+<div id="file-3900146" class="file file-html file-html-embed">
+<h2 class="element-invisible"><a href="">css-brand</a></h2>
+<div class="content">
+<div class="file-info"></div>
+<div class="field field-name-field-html-code field-type-text-long field-label-hidden view-mode-full">
+<div class="field-items">
+<div class="field-item even">
+
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+
+<!--footer region end-->
+</footer>
+</div> 
+</div>
+
+<!--page area ends-->
+<div id="extradiv"></div>
+
+<!-- /page_wrap -->
+<script src="https://static.projects.iq.harvard.edu/profiles/openscholar/libraries/respondjs/respond.min.js?rpidw0"></script>
+<script src="https://static.projects.iq.harvard.edu/files/js/js_s7yA-hwRxnKty__ED6DuqmTMKG39xvpRyrtyCrbWH4M.js?m=1675397499"></script>
+<script>jQuery.extend(Drupal.settings, {"basePath":"\/","pathPrefix":"","setHasJsCookie":0,"ajaxPageState":{"theme":"hwpi_classic","theme_token":"_6fb0ek-d3DNHvu__ay82XqKvLZnQF2zUrGWRwUeZ2Q"},"colorbox":{"opacity":"0.85","current":"{current} of {total}","previous":"\u00ab Prev","next":"Next \u00bb","close":"Close","maxWidth":"98%","maxHeight":"98%","fixed":true,"mobiledetect":true,"mobiledevicewidth":"480px"},"jcarousel":{"ajaxPath":"https:\/\/geos-chem.seas.harvard.edu\/jcarousel\/ajax\/views"},"spaces":{"id":"1585652","path":"Welcome to the GEOS-Chem Web Site"},"os_ga":{"trackOutbound":1,"trackMailto":1,"trackDownload":1,"trackDownloadExtensions":"7z|aac|arc|arj|asf|asx|avi|bin|csv|docx?|exe|flv|gif|gz|gzip|hqx|jar|jpe?g|js|mp(2|3|4|e?g)|mov(ie)?|msi|msp|pdf|phps|png|ppt|qtm?|ra(m|r)?|sea|sit|tar|tgz|torrent|txt|wav|wma|wmv|wpd|xlsx?|xml|z|zip","trackNavigation":1},"paths":{"api":"\/api","siteCreationForm":"\/profiles\/openscholar\/modules\/frontend\/os_site_creation\/templates","siteCreationModuleRoot":"\/profiles\/openscholar\/modules\/frontend\/os_site_creation","hasOsId":false},"user":{"uid":0,"name":null},"admin_panel":{"purl_base_domain":"https:\/\/projects.iq.harvard.edu","base_domain":"https:\/\/geos-chem.seas.harvard.edu"},"version":{"siteCreationForm":"1.0.4"},"site_creation":{"subsite_types":{"personal":"personal","project":"project","department":"department"},"privacy_levels":{"0":"Public on the web. \u003Cbr\u003E\u003Cspan class=\u0022description\u0022\u003EAnyone on the Internet can view your site. Your site will show in search results. No sign-in required.\u003C\/span\u003E","2":"Anyone with the link. \u003Cbr\u003E\u003Cspan class=\u0022description\u0022\u003EAnyone who has the URL to your site can view your site. Your site will not be indexed by search engines.\u003C\/span\u003E","1":"Site members only. \u003Cbr\u003E\u003Cspan class=\u0022description\u0022\u003EThis setting can be useful during site creation. Your site will not be indexed by search engines.\u003C\/span\u003E","presets":{"os_department_minimal":{"name":"os_department_minimal","title":"Minimal","description":"Blank site with no pre-set menu links or pages.","site_type":"department"},"os_department":{"name":"os_department","title":"Academic","description":"Pre-set menu links and pages: Academics, Research, Activities, People, Resources, News \u0026amp; Events, About","site_type":"department"},"os_project":{"name":"os_project","title":"Minimal","description":"Blank site with no pre-set menu links or pages.","site_type":"project"},"os_scholar":{"name":"os_scholar","title":"Minimal","description":"Blank site with no pre-set menu links or pages.","site_type":"personal"},"osllc_preset_gradstudent":{"name":"osllc_preset_gradstudent","title":"Grad Student\/Adjunct","description":"A site for grad students or adjuncts currently in the job market","site_type":"personal"},"osllc_preset_medical_professional":{"name":"osllc_preset_medical_professional","title":"Medical Professional","description":"A site for doctors and other medical professionals.","site_type":"personal"},"osllc_preset_project":{"name":"osllc_preset_project","title":"Project Site","description":"A site for a project, separate from any individual involved.","site_type":"personal"},"hwp_administrative":{"name":"hwp_administrative","title":"Administrative","description":"The Harvard Web Publishing standard Adminstrative Department site.","site_type":"department"},"hwp_lab_research_group":{"name":"hwp_lab_research_group","title":"Lab\/Research Group","description":"The Harvard Web Publishing standard Lab and Research Group site.","site_type":"project"},"hwp_project":{"name":"hwp_project","title":"Project","description":"The Harvard Web Publishing standard Project site.","site_type":"project"},"hwp_personal":{"name":"hwp_personal","title":"Personal","description":"The Harvard Web Publishing standard Personal site.","site_type":"personal"},"hwp_event_conference":{"name":"hwp_event_conference","title":"Event\/Conference","description":"The Harvard Web Publishing standard Event or Conference site.","site_type":"project"}},"default_individual_scholar":"os_scholar","default_project_lab_small_group":"os_project","default_department_school":"os_department_minimal"},"urlIsAjaxTrusted":{"https:\/\/geos-chem.seas.harvard.edu\/search\/site":true},"nice_menus_options":{"delay":800,"speed":"slow"},"ogContext":{"groupType":"node","gid":"1585652"},"password":{"strengthTitle":"Password compliance:"},"type":"setting"});</script>
+<script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.6/angular.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.6/angular-sanitize.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.6/angular-cookies.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/ngStorage/0.3.9/ngStorage.min.js"></script>
+<script src="https://static.projects.iq.harvard.edu/files/js/js_0NmK99JLIjRqsIlFqFNNbx8Ujgexpza5nVIcHEw_ZTg.js?m=1675397495"></script>
+<script src="https://static.projects.iq.harvard.edu/files/js/js_Y1FBKf83E3J9MQtFPjbc5aPABrOfDhLHCFnDQJdtDSk.js?m=1675397528"></script>
+<script>window.CKEDITOR_BASEPATH = '/profiles/openscholar/libraries/ckeditor/'</script>
+<script>var _gaq = _gaq || [];_gaq.push(["_setAccount", "UA-17689007-1"]);_gaq.push(["_gat._anonymizeIp"]);_gaq.push(["_trackPageview"]);_gaq.push(['_setCustomVar',1,'Site homepage','https://geos-chem.seas.harvard.edu/',3]);(function() {var ga = document.createElement("script");ga.type = "text/javascript";ga.async = true;ga.src = ("https:" == document.location.protocol ? "https://ssl" : "http://www") + ".google-analytics.com/ga.js";var s = document.getElementsByTagName("script")[0];s.parentNode.insertBefore(ga, s);})();var addthis_config = {data_ga_social: true, data_ga_property: {"addthis_default":false}};</script>
+<script src="https://static.projects.iq.harvard.edu/files/js/js_LiusrpwJT3Sg0H0ZmGojUVryUYFnHLCv1UjzLbWcgsw.js?m=1675397537"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_CHTML"></script>
+<script src="https://static.projects.iq.harvard.edu/files/js/js_Gn6CPUOXDTurT1_dttEf_0ILEDturfDpbAqZFd3d6g4.js?m=1675397512"></script>
+<script>(function ($) { angular.module('openscholar', ['SiteCreationForm']); })();</script>
+<script src="https://static.projects.iq.harvard.edu/files/js/js_TF0j_xSQPq-6QP1Il7NFw8ppuW60PTAxM0BwHtQXBsA.js?m=1675397525"></script>
+<script src="https://static.projects.iq.harvard.edu/files/js/js_qluyoBMkmyevXrrhnKB_2ie6cLJ7DL5g_0nHm6hyXwA.js?m=1675397503"></script>
+
+</body>
+
+</html>


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://github.com/geoschem/geoschem.github.io/blob/main/CONTRIBUTING.md)

### Describe the update

1. Created a page `email-lists.txt` describing how to subscribe to the email lists.  Context migrated from GC wiki.
2. Updated the `dropdown-menu.js` file:
  - Add link to `email-lists.html`
  - Removed obsolete Emissions Overview link to GC wiki
  - Removed obsolete Performance link to GC wiki 

### Expected changes
This adds a page about how to subscribe to GEOS-Chem email lists.