### PR TITLE
Add link to September 25, 2024 GCSC meeting minutes

### DIFF
--- a/steering-committee.html
+++ b/steering-committee.html
@@ -580,7 +580,7 @@ The <em><a href="https://drive.google.com/file/d/1SJSCa64wxvolTDMLDnhc6WlpJy_Ejs
       <a href="https://drive.google.com/file/d/1gWwwKFJMb8Np3M178wkD9mdWhn-mPP8G/view?usp=sharing" target="blank">Minutes [PDF]</a>
     </td>
     <td align="center">
-      GEOS-Chem Newsletter 2024, Issue 2
+      <a href='https://drive.google.com/file/d/1lUsMZkO0prJGc2eAR1hSxAlYlRooDwK5/view?usp=sharing' target='blank'>GEOS-Chem Newsletter 2024, Issue 2</a>
     </td>
   </tr>
     <td align="center">

--- a/steering-committee.html
+++ b/steering-committee.html
@@ -572,6 +572,17 @@ The <em><a href="https://drive.google.com/file/d/1SJSCa64wxvolTDMLDnhc6WlpJy_Ejs
     </th>
   </tr>
   <tr>
+  <tr>
+    <td align="center">
+      25 Sep 2024
+    </td>
+    <td align="center">
+      <a href="https://drive.google.com/file/d/1gWwwKFJMb8Np3M178wkD9mdWhn-mPP8G/view?usp=sharing" target="blank">Minutes [PDF]</a>
+    </td>
+    <td align="center">
+      GEOS-Chem Newsletter 2024, Issue 2
+    </td>
+  </tr>
     <td align="center">
       14 Jun 2024
     </td>


### PR DESCRIPTION
### Name and Institution (Required)

Name: Melissa Sulprizio
Institution: Harvard

### Describe the update

The GCSC page has been updated to add a row or the September 25, 2024 GEOS-Chem Steering Committee. Meeting minutes are linked. A placeholder has been added for the latest newsletter, but we still need to add a link.