### PR TITLE
Add options for specifying WG breakout and tutorial preferences to GCA2 registration page

### DIFF
--- a/gca2-register.html
+++ b/gca2-register.html
@@ -167,19 +167,48 @@ To submit your registration, please send an email to <a href="mailto:gca2nuist@1
 	<td>(May be changed later)</td>
   </tr>	 
   <tr>  
+    <th colspan="2"><b>Breakout Sessions</b></th>
+   <tr>
+  	<td>(6) Specify up to <b>two</b> working group breakouts you would like to attend</td>	
+  	<td> Options are:
+  	  <ul>
+  		<li>Aerosols</li>
+  		<li>Carbon Cycle</li>
+  		<li>Chemistry</li>
+  		<li>Chemistry-Climate</li>
+  		<li>Emissions</li>
+  		<li>Hg and POPs</li>
+  		<li>Inverse Modeling & Data Assimilation</li>
+  		<li>Software Engineering</li>
+  		<li>Stratosphere</li>
+  		<li>Surface-Atmosphere Exchange</li>
+  		<li>Transport</li>
+  	  </ul>
+  	</td>
+  </tr>
+	<td>(7) Specify up to <b>two</b> tutorials that you would like to attend</td>
+	<td>Options are:
+	  <ul>
+  		<li>Getting Started with GEOS-Chem</li>
+  		<li>Working with the high-performance GEOS-Chem (GCHP)</li>
+		<li>Running GEOS-Chem with WRF (WRF-GC)</li>
+		<li>Working with the GEOS-Chem adjoint</li>
+		<li>Running GC within CESM</li>
+		<li>Running GISS-GC/GCAP/ICECAP</li>
+		<li>Using CHEEREIO LETKF</li>
+  	  </ul>
+	</td>
+  </tr>	
+  <tr>  
     <th colspan="2"><b>If Hotel reservation was needed</b></th>
    <tr>
-  	<td>(6) Your arrival and departure date<br>+ Total nights</td>	
+  	<td>(8) Your arrival and departure date + total nights</td>	
   	<td> </td>
   </tr>
-	<td>(7) Hotel selection</td>
+	<td>(9) Hotel selection</td>
 	<td>(<a href="gca2-logistics.html">Hotel A or Hotel B</a> +<br>Single or Standard room)</td>
   </tr>	  
-   
 </table>
-
-
-
 
 </div>
 </div>


### PR DESCRIPTION
### Name and Institution (Required)

Name: Melissa Sulprizio
Institution: Harvard

### Describe the update

The GCA2 developers requested we  an option for registrants to identify up to two WG breakouts and two tutorials that they would like to attend? The WGs are those of the Steering Committee and the tutorials can be those from IGC11."