### PR TITLE
General HTML cleanup and removal of useless code

### DIFF
--- a/community-tools.html
+++ b/community-tools.html
@@ -29,14 +29,14 @@
 <div id="page_wrap" class="page_wrap">
 <div id="page" class="container page header-main content-top footer-none">
 <div id="page-wrapper">
-		
+
 <!--header regions beg-->
 <header id="header" class="clearfix" role="banner">
 <div id="header-container">
 <div id="header-panels" class="at-panel gpanel panel-display three-col clearfix">
 <div class="region region-header-second"><div class="region-inner clearfix">
 <section id="block-boxes-1630413211" class="block block-boxes block-boxes-os_boxes_html"  module="boxes" delta="1630413211">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <h2 class="block-title" ng-non-bindable="">Site-Logo</h2>
 <div class="block-content content" ng-non-bindable="">
 <div id='boxes-box-1630413211' class='boxes-box'>
@@ -60,7 +60,7 @@
 <script>inlineDropDownMenu();</script>
 </nav>
 </div>
-<!--main menu region end-->	
+<!--main menu region end-->
 
 <div id="columns" class="clearfix">
 <div class="hg-container">
@@ -68,7 +68,7 @@
 <div class="content-inner">
 <a name="main-content"></a>
 <header id="main-content-header">
-<a name="main-content"></a>		
+<a name="main-content"></a>
 <h1 id="page-title" ng-non-bindable="">Software tools maintained by GEOS-Chem community members</h1>
 </header>
 
@@ -77,7 +77,7 @@
 <div class="region region-content-top">
 <div class="region-inner clearfix">
 <div id="block-os-pages-main-content" class="block block-os-pages no-title"  module="os_pages" delta="main_content">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <div class="block-content content" ng-non-bindable="">
 <article id="node-1585687" class="node node-page article clearfix" role="article">
 <div class="node-content" ng-non-bindable="">
@@ -85,17 +85,9 @@
 <div class="field-items">
 <div class="field-item even">
 
-<p>
-  On this page we list software packages that are maintained by members of the
-  <a href="https://geoschem.github.io/geos-chem-people-projects-map/">International GEOS-Chem User Community</a>.
-</p>
+<p>On this page we list software packages that are maintained by members of the <a href="https://geoschem.github.io/geos-chem-people-projects-map/">International GEOS-Chem User Community</a>.</p>
 
-<p>
-  NOTE: The <a href="https://geoschem.github.io/support-team.html">GEOS-Chem Support Team</a>
-  takes no responsibility for these tools (other than maintaining this list).
-  If you should encounter problems with the tools and/or related documentation,
-  please contact the maintainer(s).
-</p>
+<p>NOTE: The <a href="https://geoschem.github.io/support-team.html">GEOS-Chem Support Team</a>  takes no responsibility for these tools (other than maintaining this list). If you should encounter problems with the tools and/or related documentation, please contact the maintainer(s).</p>
 
 <table border="1" cellspacing="0" cellpadding="5">
   <tr valign="top" bgcolor="#CCCCCC">
@@ -259,43 +251,15 @@
 </div>
 </div>
 
-<!--footer region beg-->
+<!--footer-->
 <footer id="footer" class="clearfix" role="contentinfo">
-
-<!-- Three column 3x33 Gpanel -->
-<div class="at-panel gpanel panel-display footer clearfix">
-<div class="region region-footer-bottom">
-<div class="region-inner clearfix">
-<div id="block-boxes-1616879798" class="block block-boxes block-boxes-os_boxes_media no-title"  module="boxes" delta="1616879798">
-<div class="block-inner clearfix">
-<div class="block-content content">
-<div id='boxes-box-1616879798' class='boxes-box'>
 <div class="boxes-box-content">
-<div id="file-3900146" class="file file-html file-html-embed">
-<h2 class="element-invisible"><a href="">css-brand</a></h2>
-<div class="content">
-<div class="file-info">
+  <p style="text-align:center">
+    Copyright © 2026 by the International GEOS-Chem Community. All rights reserved.
+  </p>
 </div>
-<div class="field field-name-field-html-code field-type-text-long field-label-hidden view-mode-full">
-<div class="field-items">
-<div class="field-item even">
-
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-
-<!--footer region end-->
 </footer>
+
 </div>
 </div>
 

--- a/cube-sphere-comparison.html
+++ b/cube-sphere-comparison.html
@@ -1,9 +1,4 @@
 <!DOCTYPE html>
-<!--[if IEMobile 7]><html class="iem7"  lang="en" dir="ltr"><![endif]-->
-<!--[if lte IE 6]><html class="lt-ie9 lt-ie8 lt-ie7"  lang="en" dir="ltr"><![endif]-->
-<!--[if (IE 7)&(!IEMobile)]><html class="lt-ie9 lt-ie8"  lang="en" dir="ltr"><![endif]-->
-<!--[if IE 8]><html class="lt-ie9"  lang="en" dir="ltr"><![endif]-->
-<!--[if (gte IE 9)|(gt IEMobile 7)]><!--><html  lang="en" dir="ltr"><!--<![endif]-->
 <head>
 <meta charset="utf-8" />
 <!--<base href="/cubesphere_comparison" />-->
@@ -18,23 +13,12 @@
 <title>Cube-Sphere Grid Comparision</title>
 <meta http-equiv="x-ua-compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<link type="text/css" rel="stylesheet" href="css/css_xE-rWrJf-fncB6ztZfd2huxqgxu4WO-qwma6Xer30m4%EF%B9%96m=1675397288.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_1kR8T1_c-l5pBT6ZwbDT7BFda-4fyqW9Jjum29_2IY8%EF%B9%96m=1675397312.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_YnlUIvHP13qgpYEqubzE8JyDwlSxUnVibfnVkSoSDb0%EF%B9%96m=1675397273.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_Ku-3OcT9qU9h7dnGig5e23q6EVryY8orK4wzVDxsweE%EF%B9%96m=1675397367.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_vprtFTrWyg23GbY50_zJZHWGYMNfS8vsrRS26i4-ISk%EF%B9%96m=1675397406.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_dW-aNNrctRhQNc-KECjtQd0PxuW-h19IEum-TX2MeEk%EF%B9%96m=1675397301.css" media="print" />
-<link type="text/css" rel="stylesheet" href="css/css_SH2Lx3Qprh0GZo_9xRp85U9NsWfkSXn_Bi-rJoMY1sw%EF%B9%96m=1675397273.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_uaIDKcYMUK5osSQXuirpr3ZleXtnnpBN-eiECm7N0M0%EF%B9%96m=1675397395.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/responsive.blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/geos-chem.css" media="all"/>
 <script type="text/javascript" src="dropdown-menu.js"></script>
-<!--[if lte IE 8]>
-<script type="text/javascript">
-  var os_c = document.createElement;os_c('header');os_c('nav');os_c('section');os_c('article');os_c('aside');os_c('footer');os_c('hgroup');os_c('figure');
-</script>
-<![endif]-->
 </head>
 
 <body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-1585687 node-type-page og-context og-context-node og-context-node-1585652 navbar-on">
@@ -190,48 +174,16 @@ e.setOptions(this.idLayerLine,"setLayoutProperty",r.line.layout),e.setOptions(th
 </div>
 </div>
 
-<!--footer region beg-->
+<!--footer-->
 <footer id="footer" class="clearfix" role="contentinfo">
-
-<!-- Three column 3x33 Gpanel -->
-<div class="at-panel gpanel panel-display footer clearfix">
-<div class="region region-footer-bottom">
-<div class="region-inner clearfix">
-<div id="block-boxes-1616879798" class="block block-boxes block-boxes-os_boxes_media no-title"  module="boxes" delta="1616879798">
-<div class="block-inner clearfix">
-<div class="block-content content">
-<div id='boxes-box-1616879798' class='boxes-box'>
 <div class="boxes-box-content">
-<div id="file-3900146" class="file file-html file-html-embed">
-<h2 class="element-invisible"><a href="">css-brand</a></h2>
-<div class="content">
-<div class="file-info">
+  <p style="text-align:center">
+    Copyright © 2026 by the International GEOS-Chem Community. All rights reserved.
+  </p>
 </div>
-<div class="field field-name-field-html-code field-type-text-long field-label-hidden view-mode-full">
-<div class="field-items">
-<div class="field-item even">
-
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-
-<!--footer region end-->
 </footer>
-</div>
-</div>
 
-<!--page area ends-->
-<div id="extradiv"></div>
+</div>
 </div>
 
 </body>

--- a/cube-sphere-step.html
+++ b/cube-sphere-step.html
@@ -1,9 +1,4 @@
 <!DOCTYPE html>
-<!--[if IEMobile 7]><html class="iem7"  lang="en" dir="ltr"><![endif]-->
-<!--[if lte IE 6]><html class="lt-ie9 lt-ie8 lt-ie7"  lang="en" dir="ltr"><![endif]-->
-<!--[if (IE 7)&(!IEMobile)]><html class="lt-ie9 lt-ie8"  lang="en" dir="ltr"><![endif]-->
-<!--[if IE 8]><html class="lt-ie9"  lang="en" dir="ltr"><![endif]-->
-<!--[if (gte IE 9)|(gt IEMobile 7)]><!--><html  lang="en" dir="ltr"><!--<![endif]-->
 <head>
 <meta charset="utf-8" />
 <!--<base href="/cubespherestep-step" />-->
@@ -18,23 +13,12 @@
 <title>Cube-Sphere Step by Step</title>
 <meta http-equiv="x-ua-compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<link type="text/css" rel="stylesheet" href="css/css_xE-rWrJf-fncB6ztZfd2huxqgxu4WO-qwma6Xer30m4%EF%B9%96m=1675397288.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_1kR8T1_c-l5pBT6ZwbDT7BFda-4fyqW9Jjum29_2IY8%EF%B9%96m=1675397312.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_YnlUIvHP13qgpYEqubzE8JyDwlSxUnVibfnVkSoSDb0%EF%B9%96m=1675397273.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_Ku-3OcT9qU9h7dnGig5e23q6EVryY8orK4wzVDxsweE%EF%B9%96m=1675397367.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_vprtFTrWyg23GbY50_zJZHWGYMNfS8vsrRS26i4-ISk%EF%B9%96m=1675397406.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_dW-aNNrctRhQNc-KECjtQd0PxuW-h19IEum-TX2MeEk%EF%B9%96m=1675397301.css" media="print" />
-<link type="text/css" rel="stylesheet" href="css/css_SH2Lx3Qprh0GZo_9xRp85U9NsWfkSXn_Bi-rJoMY1sw%EF%B9%96m=1675397273.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_uaIDKcYMUK5osSQXuirpr3ZleXtnnpBN-eiECm7N0M0%EF%B9%96m=1675397395.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/responsive.blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/geos-chem.css" media="all"/>
 <script type="text/javascript" src="dropdown-menu.js"></script>
-<!--[if lte IE 8]>
-<script type="text/javascript">
-  var os_c = document.createElement;os_c('header');os_c('nav');os_c('section');os_c('article');os_c('aside');os_c('footer');os_c('hgroup');os_c('figure');
-</script>
-<![endif]-->
 </head>
 
 <body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-1585687 node-type-page og-context og-context-node og-context-node-1585652 navbar-on">
@@ -193,48 +177,16 @@ e.setOptions(this.idLayerLine,"setLayoutProperty",r.line.layout),e.setOptions(th
 </div>
 </div>
 
-<!--footer region beg-->
+<!--footer-->
 <footer id="footer" class="clearfix" role="contentinfo">
-
-<!-- Three column 3x33 Gpanel -->
-<div class="at-panel gpanel panel-display footer clearfix">
-<div class="region region-footer-bottom">
-<div class="region-inner clearfix">
-<div id="block-boxes-1616879798" class="block block-boxes block-boxes-os_boxes_media no-title"  module="boxes" delta="1616879798">
-<div class="block-inner clearfix">
-<div class="block-content content">
-<div id='boxes-box-1616879798' class='boxes-box'>
 <div class="boxes-box-content">
-<div id="file-3900146" class="file file-html file-html-embed">
-<h2 class="element-invisible"><a href="">css-brand</a></h2>
-<div class="content">
-<div class="file-info">
+  <p style="text-align:center">
+    Copyright © 2026 by the International GEOS-Chem Community. All rights reserved.
+  </p>
 </div>
-<div class="field field-name-field-html-code field-type-text-long field-label-hidden view-mode-full">
-<div class="field-items">
-<div class="field-item even">
-
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-
-<!--footer region end-->
 </footer>
-</div>
-</div>
 
-<!--page area ends-->
-<div id="extradiv"></div>
+</div>
 </div>
 
 </body>

--- a/cube-sphere.html
+++ b/cube-sphere.html
@@ -1,9 +1,4 @@
 <!DOCTYPE html>
-<!--[if IEMobile 7]><html class="iem7"  lang="en" dir="ltr"><![endif]-->
-<!--[if lte IE 6]><html class="lt-ie9 lt-ie8 lt-ie7"  lang="en" dir="ltr"><![endif]-->
-<!--[if (IE 7)&(!IEMobile)]><html class="lt-ie9 lt-ie8"  lang="en" dir="ltr"><![endif]-->
-<!--[if IE 8]><html class="lt-ie9"  lang="en" dir="ltr"><![endif]-->
-<!--[if (gte IE 9)|(gt IEMobile 7)]><!--><html  lang="en" dir="ltr"><!--<![endif]-->
 <head>
 <meta charset="utf-8" />
 <!--<base href="/cubedsphere" />-->
@@ -18,23 +13,12 @@
 <title>Cubed-sphere grid illustrations</title>
 <meta http-equiv="x-ua-compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<link type="text/css" rel="stylesheet" href="css/css_xE-rWrJf-fncB6ztZfd2huxqgxu4WO-qwma6Xer30m4%EF%B9%96m=1675397288.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_1kR8T1_c-l5pBT6ZwbDT7BFda-4fyqW9Jjum29_2IY8%EF%B9%96m=1675397312.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_YnlUIvHP13qgpYEqubzE8JyDwlSxUnVibfnVkSoSDb0%EF%B9%96m=1675397273.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_Ku-3OcT9qU9h7dnGig5e23q6EVryY8orK4wzVDxsweE%EF%B9%96m=1675397367.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_vprtFTrWyg23GbY50_zJZHWGYMNfS8vsrRS26i4-ISk%EF%B9%96m=1675397406.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_dW-aNNrctRhQNc-KECjtQd0PxuW-h19IEum-TX2MeEk%EF%B9%96m=1675397301.css" media="print" />
-<link type="text/css" rel="stylesheet" href="css/css_SH2Lx3Qprh0GZo_9xRp85U9NsWfkSXn_Bi-rJoMY1sw%EF%B9%96m=1675397273.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_uaIDKcYMUK5osSQXuirpr3ZleXtnnpBN-eiECm7N0M0%EF%B9%96m=1675397395.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/responsive.blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/geos-chem.css" media="all"/>
 <script type="text/javascript" src="dropdown-menu.js"></script>
-<!--[if lte IE 8]>
-<script type="text/javascript">
-  var os_c = document.createElement;os_c('header');os_c('nav');os_c('section');os_c('article');os_c('aside');os_c('footer');os_c('hgroup');os_c('figure');
-</script>
-<![endif]-->
 </head>
 
 <body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-1585687 node-type-page og-context og-context-node og-context-node-1585652 navbar-on">
@@ -45,14 +29,14 @@
 <div id="page_wrap" class="page_wrap">
 <div id="page" class="container page header-main content-top footer-none">
 <div id="page-wrapper">
-		
+
 <!--header regions beg-->
 <header id="header" class="clearfix" role="banner">
 <div id="header-container">
 <div id="header-panels" class="at-panel gpanel panel-display three-col clearfix">
 <div class="region region-header-second"><div class="region-inner clearfix">
 <section id="block-boxes-1630413211" class="block block-boxes block-boxes-os_boxes_html"  module="boxes" delta="1630413211">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <h2 class="block-title" ng-non-bindable="">Site-Logo</h2>
 <div class="block-content content" ng-non-bindable="">
 <div id='boxes-box-1630413211' class='boxes-box'>
@@ -76,7 +60,7 @@
 <script>inlineDropDownMenu();</script>
 </nav>
 </div>
-<!--main menu region end-->	
+<!--main menu region end-->
 
 <div id="columns" class="clearfix">
 <div class="hg-container">
@@ -93,7 +77,7 @@
 <div class="region region-content-top">
 <div class="region-inner clearfix">
 <div id="block-os-pages-main-content" class="block block-os-pages no-title"  module="os_pages" delta="main_content">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <div class="block-content content" ng-non-bindable="">
 <article id="node-1585687" class="node node-page article clearfix" role="article">
 <div class="node-content" ng-non-bindable="">
@@ -138,48 +122,16 @@
 </div>
 </div>
 
-<!--footer region beg-->
+<!--footer-->
 <footer id="footer" class="clearfix" role="contentinfo">
-
-<!-- Three column 3x33 Gpanel -->
-<div class="at-panel gpanel panel-display footer clearfix">
-<div class="region region-footer-bottom">
-<div class="region-inner clearfix">
-<div id="block-boxes-1616879798" class="block block-boxes block-boxes-os_boxes_media no-title"  module="boxes" delta="1616879798">
-<div class="block-inner clearfix">
-<div class="block-content content">
-<div id='boxes-box-1616879798' class='boxes-box'>
 <div class="boxes-box-content">
-<div id="file-3900146" class="file file-html file-html-embed">
-<h2 class="element-invisible"><a href="">css-brand</a></h2>
-<div class="content">
-<div class="file-info">
+  <p style="text-align:center">
+    Copyright © 2026 by the International GEOS-Chem Community. All rights reserved.
+  </p>
 </div>
-<div class="field field-name-field-html-code field-type-text-long field-label-hidden view-mode-full">
-<div class="field-items">
-<div class="field-item even">
-
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-
-<!--footer region end-->
 </footer>
-</div>
-</div>
 
-<!--page area ends-->
-<div id="extradiv"></div>
+</div>
 </div>
 
 </body>

--- a/email-lists.html
+++ b/email-lists.html
@@ -1,9 +1,4 @@
 <!DOCTYPE html>
-<!--[if IEMobile 7]><html class="iem7"  lang="en" dir="ltr"><![endif]-->
-<!--[if lte IE 6]><html class="lt-ie9 lt-ie8 lt-ie7"  lang="en" dir="ltr"><![endif]-->
-<!--[if (IE 7)&(!IEMobile)]><html class="lt-ie9 lt-ie8"  lang="en" dir="ltr"><![endif]-->
-<!--[if IE 8]><html class="lt-ie9"  lang="en" dir="ltr"><![endif]-->
-<!--[if (gte IE 9)|(gt IEMobile 7)]><!--><html  lang="en" dir="ltr"><!--<![endif]-->
 <head>
 <meta charset="utf-8" />
 <!--<base href="/" />-->
@@ -24,18 +19,10 @@
 <link type="text/css" rel="stylesheet" href="css/css_YnlUIvHP13qgpYEqubzE8JyDwlSxUnVibfnVkSoSDb0%EF%B9%96m=1675397273.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_lzv2lyRoD9TGLNsrZeaAEIHqW0mWI04uBXQ8K1MSwY0%EF%B9%96m=1675397576.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_vprtFTrWyg23GbY50_zJZHWGYMNfS8vsrRS26i4-ISk%EF%B9%96m=1675397406.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_dW-aNNrctRhQNc-KECjtQd0PxuW-h19IEum-TX2MeEk%EF%B9%96m=1675397301.css" media="print" />
-<link type="text/css" rel="stylesheet" href="css/css_SH2Lx3Qprh0GZo_9xRp85U9NsWfkSXn_Bi-rJoMY1sw%EF%B9%96m=1675397273.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_uaIDKcYMUK5osSQXuirpr3ZleXtnnpBN-eiECm7N0M0%EF%B9%96m=1675397395.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/responsive.blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/geos-chem.css" media="all"/>
 <script type="text/javascript" src="dropdown-menu.js"></script>
-<!--[if lte IE 8]>
-<script type="text/javascript">
-  var os_c = document.createElement;os_c('header');os_c('nav');os_c('section');os_c('article');os_c('aside');os_c('footer');os_c('hgroup');os_c('figure');
-</script>
-<![endif]-->
 </head>
 
 <body class="html front not-logged-in no-sidebars page-home og-context og-context-node og-context-node-1585652 navbar-on">
@@ -106,85 +93,90 @@
 <p>We use several email lists to share information among the GEOS-Chem user community. There is a "general" GEOS-Chem email list, plus an email list for each <a href="working-groups.html">GEOS-Chem Working Group</a>. You should subscribe to the general email list which gives crucial information about new versions, bugs, meetings, etc. You should also subscribe to the email lists of the Working Groups in which you are interested. You can see the complete list of all GEOS-Chem email lists at this link: <a href="https://groups.google.com/a/g.harvard.edu/forum/#!forumsearch/geos-chem">https://groups.google.com/a/g.harvard.edu/forum/#!forumsearch/geos-chem</a></p>
 <p>Please inform the <a href="support-team.html">GEOS-Chem Support Team</a> if you suspect mail is not being delivered properly.</p>
 <table>
-<thead>
-<tr class="header">
-<th width="33%"><p>GEOS-Chem email list name<br />
-(Follow link for web interface)</p></th>
-<th width="30%"><p>Send messages here<br />
-(Add @g.harvard.edu)</p></th>
-<th><p>Intended audience</p></th>
-</tr>
-</thead>
-<tbody>
-<tr class="odd">
-<td><p><a href="https://groups.google.com/a/g.harvard.edu/forum/#!forum/geos-chem" target="_new">GEOS-Chem</a></p></td>
-<td><p><code>geos-chem</code></p></td>
-<td><p>All GEOS-Chem users and developers<br /><br />
-<strong><em>This is the "general" email list to which information about new model versions, bugs &amp; fixes, meetings etc. will be sent. You should subscribe to this list, in addition to any of the other lists that are relevant to the area of your research.</em></strong></p></td>
-</tr>
-<tr class="even">
-<td><p><a href="https://groups.google.com/a/g.harvard.edu/forum/#!forum/geos-chem-adjoint" target="_new">GEOS-Chem Adjoint and Data Assimilation</a></p></td>
-<td><p><code>geos-chem-adjoint</code></p></td>
-<td><p><a href="http://wiki.geos-chem.org/GEOS-Chem_Adjoint" target="_new">Adjoint Working Group</a> and<br />
-    <a href="http://wiki.geos-chem.org/GEOS-Chem_Data_Assimilation_Working_Group" target="_new">Data Assimilation Working Group</a></p></td>
-</tr>
-<tr class="odd">
-<td><p><a href="https://groups.google.com/a/g.harvard.edu/forum/#!forum/geos-chem-aerosols" target="_new">GEOS-Chem Aerosols</a></p></td>
-<td><p><code>geos-chem-aerosols</code></p></td>
-<td><p><a href="http://wiki.geos-chem.org/Aerosols_Working_Group" target="_new">Aerosols Working Group</a></p></td>
-</tr>
-<tr class="even">
-<td><p><a href="https://groups.google.com/a/g.harvard.edu/forum/#!forum/geos-chem-carbon" target="_new">GEOS-Chem Carbon Cycle</a></p></td>
-<td><p><code>geos-chem-carbon</code></p></td>
-<td><p><a href="http://wiki.geos-chem.org/Carbon_Cycle_Working_Group" target="_new">Carbon Cycle Working Group</a></p></td>
-</tr>
-<tr class="odd">
-<td><p><a href="https://groups.google.com/a/g.harvard.edu/forum/#!forum/geos-chem-oxidants" target="_new">GEOS-Chem Chemistry</a></p></td>
-<td><p><code>geos-chem-oxidants</code></p></td>
-<td><p><a href="http://wiki.geos-chem.org/Chemistry_Working_Group" target="_new">Chemistry Working Group</a></p></td>
-</tr>
-<tr class="even">
-<td><p><a href="https://groups.google.com/a/g.harvard.edu/forum/#!forum/geos-chem-chemistry-climate" target="_new">GEOS-Chem Chemistry-Climate</a></p></td>
-<td><p><code>geos-chem-chemistry-climate</code></p></td>
-<td><p><a href="http://wiki.geos-chem.org/Chemistry-Climate_Working_Group" target="_new">Chemistry-Climate Working Group</a></p></td>
-</tr>
-<tr class="odd">
-<td><p><a href="https://groups.google.com/a/g.harvard.edu/forum/#!forum/geos-chem-emissions" target="_new">GEOS-Chem Emissions</a></p></td>
-<td><p><code>geos-chem-emissions</code></p></td>
-<td><p><a href="http://wiki.geos-chem.org/Emissions_Working_Group" target="_new">Emissions Working Group</a></p></td>
-</tr>
-<tr class="even">
-<td><p><a href="https://groups.google.com/a/g.harvard.edu/forum/#!forum/geos-chem-hg-pop" target="_new">GEOS-Chem Hg and POPs</a></p></td>
-<td><p><code>geos-chem-hg-pop</code></p></td>
-<td><p><a href="http://wiki.geos-chem.org/Hg_and_POPs_Working_Group" target="_new">Hg and POPs Working Group</a></p></td>
-</tr>
-<tr class="odd">
-<td><p><a href="https://groups.google.com/a/g.harvard.edu/forum/#!forum/geos-chem-software-eng" target="_new">GEOS-Chem Software Engineering</a></p></td>
-<td><p><code>geos-chem-software-eng</code></p></td>
-<td><p><a href="http://wiki.geos-chem.org/Software_Engineering_Working_Group" target="_new">Software Engineering Working Group</a></p></td>
-</tr>
-<tr class="even">
-<td><p><a href="https://groups.google.com/a/g.harvard.edu/forum/#!forum/geos-chem-stratosphere" target="_new">GEOS-Chem Stratosphere</a></p></td>
-<td><p><code>geos-chem-stratosphere</code></p></td>
-<td><p><a href="http://wiki.geos-chem.org/Stratospheric_Working_Group" target="_new">Stratospheric Working Group</a></p></td>
-</tr>
-<tr class="odd">
-<td><p><a href="https://groups.google.com/a/g.harvard.edu/forum/#!forum/geos-chem-sfc-atmos-exchange" target="_new">GEOS-Chem Surface-Atmosphere Exchange</a></p></td>
-<td><p><code>geos-chem-sfc-atmos-exchange</code></p></td>
-<td><p><a href="http://wiki.geos-chem.org/Surface-Atmosphere_Exchange_Working_Group" target="_new">Surface-Atmosphere Exchange Working Group</a></p></td>
-</tr>
-<tr class="even">
-<td><p><a href="https://groups.google.com/a/g.harvard.edu/forum/#!forum/geos-chem-transport" target="_new">GEOS-Chem Transport</a></p></td>
-<td><p><code>geos-chem-transport</code></p></td>
-<td><p><a href="http://wiki.geos-chem.org/Transport_Working_Group" target="_new">Transport Working Group</a></p></td>
-</tr>
-</tbody>
+  <thead>
+    <tr class="header">
+      <th width="33%"><p>GEOS-Chem email list name<br />
+	  (Follow link for web interface)</p></th>
+      <th width="30%"><p>Send messages here<br />
+	  (Add @g.harvard.edu)</p></th>
+      <th><p>Intended audience</p></th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr class="odd">
+      <td><p><a href="https://groups.google.com/a/g.harvard.edu/forum/#!forum/geos-chem" target="_new">GEOS-Chem</a></p></td>
+      <td><p><code>geos-chem</code></p></td>
+      <td><p>All GEOS-Chem users and developers<br /><br />
+	  <strong><em>This is the "general" email list to which information about new model versions, bugs &amp; fixes, meetings etc. will be sent. You should subscribe to this list, in addition to any of the other lists that are relevant to the area of your research.</em></strong></p></td>
+    </tr>
+    <tr class="even">
+      <td><p><a href="https://groups.google.com/a/g.harvard.edu/forum/#!forum/geos-chem-adjoint" target="_new">GEOS-Chem Adjoint and Data Assimilation</a></p></td>
+      <td><p><code>geos-chem-adjoint</code></p></td>
+      <td><p><a href="http://wiki.geos-chem.org/GEOS-Chem_Adjoint" target="_new">Adjoint Working Group</a> and<br /><a href="http://wiki.geos-chem.org/GEOS-Chem_Data_Assimilation_Working_Group" target="_new">Data Assimilation Working Group</a></p></td>
+    </tr>
+    <tr class="odd">
+      <td><p><a href="https://groups.google.com/a/g.harvard.edu/forum/#!forum/geos-chem-aerosols" target="_new">GEOS-Chem Aerosols</a></p></td>
+      <td><p><code>geos-chem-aerosols</code></p></td>
+      <td><p><a href="http://wiki.geos-chem.org/Aerosols_Working_Group" target="_new">Aerosols Working Group</a></p></td>
+    </tr>
+    <tr class="even">
+      <td><p><a href="https://groups.google.com/a/g.harvard.edu/forum/#!forum/geos-chem-carbon" target="_new">GEOS-Chem Carbon Cycle</a></p></td>
+      <td><p><code>geos-chem-carbon</code></p></td>
+      <td><p><a href="http://wiki.geos-chem.org/Carbon_Cycle_Working_Group" target="_new">Carbon Cycle Working Group</a></p></td>
+    </tr>
+    <tr class="odd">
+      <td><p><a href="https://groups.google.com/a/g.harvard.edu/forum/#!forum/geos-chem-oxidants" target="_new">GEOS-Chem Chemistry</a></p></td>
+      <td><p><code>geos-chem-oxidants</code></p></td>
+      <td><p><a href="http://wiki.geos-chem.org/Chemistry_Working_Group" target="_new">Chemistry Working Group</a></<p></p>></td>
+    </tr>
+    <tr class="even">
+      <td><p><a href="https://groups.google.com/a/g.harvard.edu/forum/#!forum/geos-chem-chemistry-climate" target="_new">GEOS-Chem Chemistry-Climate</a></p></td>
+      <td><p><code>geos-chem-chemistry-climate</code></p></td>
+      <td><p><a href="http://wiki.geos-chem.org/Chemistry-Climate_Working_Group" target="_new">Chemistry-Climate Working Group</a></p></td>
+    </tr>
+    <tr class="odd">
+      <td><p><a href="https://groups.google.com/a/g.harvard.edu/forum/#!forum/geos-chem-emissions" target="_new">GEOS-Chem Emissions</a></p></td>
+      <td><p><code>geos-chem-emissions</code></p></td>
+      <td><p><a href="http://wiki.geos-chem.org/Emissions_Working_Group" target="_new">Emissions Working Group</a></p></td>
+    </tr>
+    <tr class="even">
+      <td><p><a href="https://groups.google.com/a/g.harvard.edu/forum/#!forum/geos-chem-hg-pop" target="_new">GEOS-Chem Hg and POPs</a></p></td>
+      <td><p><code>geos-chem-hg-pop</code></p></td>
+      <td><p><a href="http://wiki.geos-chem.org/Hg_and_POPs_Working_Group" target="_new">Hg and POPs Working Group</a></p></td>
+    </tr>
+    <tr class="odd">
+      <td><p><a href="https://groups.google.com/a/g.harvard.edu/forum/#!forum/geos-chem-software-eng" target="_new">GEOS-Chem Software Engineering</a></p></td>
+      <td><p><code>geos-chem-software-eng</code></p></td>
+      <td><p><a href="http://wiki.geos-chem.org/Software_Engineering_Working_Group" target="_new">Software Engineering Working Group</a></p></td>
+    </tr>
+    <tr class="even">
+      <td><p><a href="https://groups.google.com/a/g.harvard.edu/forum/#!forum/geos-chem-stratosphere" target="_new">GEOS-Chem Stratosphere</a></p></td>
+      <td><p><code>geos-chem-stratosphere</code></p></td>
+      <td><p><a href="http://wiki.geos-chem.org/Stratospheric_Working_Group" target="_new">Stratospheric Working Group</a></p></td>
+    </tr>
+    <tr class="odd">
+      <td><p><a href="https://groups.google.com/a/g.harvard.edu/forum/#!forum/geos-chem-sfc-atmos-exchange" target="_new">GEOS-Chem Surface-Atmosphere Exchange</a></p></td>
+      <td><p><code>geos-chem-sfc-atmos-exchange</code></p></td>
+      <td><p><a href="http://wiki.geos-chem.org/Surface-Atmosphere_Exchange_Working_Group" target="_new">Surface-Atmosphere Exchange Working Group</a></p></td>
+    </tr>
+    <tr class="even">
+      <td><p><a href="https://groups.google.com/a/g.harvard.edu/forum/#!forum/geos-chem-transport" target="_new">GEOS-Chem Transport</a></p></td>
+      <td><p><code>geos-chem-transport</code></p></td>
+      <td><p><a href="http://wiki.geos-chem.org/Transport_Working_Group" target="_new">Transport Working Group</a></p></td>
+    </tr>
+  </tbody>
 </table>
+
 <p>We invite you to join the Working Group that is most appropriate to your research and to subscribe to the relevant email list. Consider joining more than one Working Group (and email list) if your research spans several topics.</p>
+
 <h2 id="subscribing_to_a_list">Subscribing to a list</h2>
+
 <p>To subscribe to any of the GEOS-Chem email lists, simply send an email to one (or more) of the addresses listed above with <code>+subscribe</code> appended to the email address (e.g. <code>geos-chem+subscribe [at] g.harvard.edu; geos-chem-adjoint+subscribe [at] g.harvard.edu</code>). Please include your name, affiliation, and research area in the email body as it will speed up the approval process. A moderator will examine your subscription request before issuing final approval.</p>
+
 <h2 id="unsubscribing_from_a_list">Unsubscribing from a list</h2>
+
 <p>To unsubscribe from any of the GEOS-Chem email lists, simply send an email to one (or more) of the addresses listed above with <code>+unsubscribe</code> appended to the email address (e.g. <code>geos-chem+unsubscribe [at] g.harvard.edu; geos-chem-adjoint+unsubscribe [at] g.harvard.edu</code>). This information is also provided at the bottom of each email sent to the Google Group. For example:</p>
+
 <blockquote>
   <tt>
    --<br />
@@ -193,9 +185,12 @@
    To view this discussion on the web visit <a href="https://groups.google.com/a/g.harvard.edu/" target="_new">https://groups.google.com/a/g.harvard.edu/</a>...
  </tt>
 </blockquote>
+
 <h2 id="anti_spam_measures">Anti-spam measures</h2>
 <p>Each subscription request shall be approved by the <a href="support-team.html">GEOS-Chem Support Team</a>. Requests from persons who are not recognized GEOS-Chem users shall be discarded.</p>
+
 <p>To prevent spam, the GEOS-Chem email lists will reject mail from unrecognized addresses. When sending an email message to a list, make sure that you send your message from the same email address under which you subscribed to that list. Otherwise your message may not get delivered.</p>
+
 <p>If you are having difficulties sending mail to a list, then please contact the GEOS-Chem Support Team for assistance.</p>
 
   
@@ -217,47 +212,17 @@
 </div>
 </div>
 
-<!--footer region beg-->
+<!--footer-->
 <footer id="footer" class="clearfix" role="contentinfo">
-
-<!-- Three column 3x33 Gpanel -->
-<div class="at-panel gpanel panel-display footer clearfix">
-<div class="region region-footer-bottom">
-<div class="region-inner clearfix">
-<div id="block-boxes-1616879798" class="block block-boxes block-boxes-os_boxes_media no-title"  module="boxes" delta="1616879798">
-<div class="block-inner clearfix">
-<div class="block-content content">
-<div id='boxes-box-1616879798' class='boxes-box'>
 <div class="boxes-box-content">
-<div id="file-3900146" class="file file-html file-html-embed">
-<h2 class="element-invisible"><a href="">css-brand</a></h2>
-<div class="content">
-<div class="file-info"></div>
-<div class="field field-name-field-html-code field-type-text-long field-label-hidden view-mode-full">
-<div class="field-items">
-<div class="field-item even">
-
+  <p style="text-align:center">
+    Copyright © 2026 by the International GEOS-Chem Community. All rights reserved.
+  </p>
 </div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-
-<!--footer region end-->
 </footer>
+
 </div> 
 </div>
-
-<!--page area ends-->
-<div id="extradiv"></div>
 
 </body>
 </html>

--- a/gca1-presentations.html
+++ b/gca1-presentations.html
@@ -1,9 +1,4 @@
 <!DOCTYPE html>
-<!--[if IEMobile 7]><html class="iem7"  lang="en" dir="ltr"><![endif]-->
-<!--[if lte IE 6]><html class="lt-ie9 lt-ie8 lt-ie7"  lang="en" dir="ltr"><![endif]-->
-<!--[if (IE 7)&(!IEMobile)]><html class="lt-ie9 lt-ie8"  lang="en" dir="ltr"><![endif]-->
-<!--[if IE 8]><html class="lt-ie9"  lang="en" dir="ltr"><![endif]-->
-<!--[if (gte IE 9)|(gt IEMobile 7)]><!--><html  lang="en" dir="ltr"><!--<![endif]-->
 <head>
 <meta charset="utf-8" />
 <!--<base href="/gca1-presentations" />-->
@@ -18,23 +13,12 @@
 <title>The 1st Regional GEOS-Chem Asia Meeting</title>
 <meta http-equiv="x-ua-compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<link type="text/css" rel="stylesheet" href="css/css_xE-rWrJf-fncB6ztZfd2huxqgxu4WO-qwma6Xer30m4%EF%B9%96m=1675397288.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_1kR8T1_c-l5pBT6ZwbDT7BFda-4fyqW9Jjum29_2IY8%EF%B9%96m=1675397312.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_YnlUIvHP13qgpYEqubzE8JyDwlSxUnVibfnVkSoSDb0%EF%B9%96m=1675397273.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_Ku-3OcT9qU9h7dnGig5e23q6EVryY8orK4wzVDxsweE%EF%B9%96m=1675397367.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_vprtFTrWyg23GbY50_zJZHWGYMNfS8vsrRS26i4-ISk%EF%B9%96m=1675397406.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_dW-aNNrctRhQNc-KECjtQd0PxuW-h19IEum-TX2MeEk%EF%B9%96m=1675397301.css" media="print" />
-<link type="text/css" rel="stylesheet" href="css/css_SH2Lx3Qprh0GZo_9xRp85U9NsWfkSXn_Bi-rJoMY1sw%EF%B9%96m=1675397273.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_uaIDKcYMUK5osSQXuirpr3ZleXtnnpBN-eiECm7N0M0%EF%B9%96m=1675397395.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/responsive.blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/geos-chem.css" media="all"/>
 <script type="text/javascript" src="dropdown-menu.js"></script>
-<!--[if lte IE 8]>
-<script type="text/javascript">
-  var os_c = document.createElement;os_c('header');os_c('nav');os_c('section');os_c('article');os_c('aside');os_c('footer');os_c('hgroup');os_c('figure');
-</script>
-<![endif]-->
 </head>
 
 <body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-1585687 node-type-page og-context og-context-node og-context-node-1585652 navbar-on">
@@ -45,7 +29,7 @@
 <div id="page_wrap" class="page_wrap">
 <div id="page" class="container page header-main content-top footer-none">
 <div id="page-wrapper">
-		
+
 <!--header regions beg-->
 <header id="header" class="clearfix" role="banner">
 <div id="header-container">
@@ -53,14 +37,12 @@
 <div class="region region-header-second">
 <div class="region-inner clearfix">
 <div id="block-boxes-1617807424" class="block block-boxes block-boxes-os_boxes_html no-title"  module="boxes" delta="1617807424">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <div class="block-content content" ng-non-bindable="">
 <div id='boxes-box-1617807424' class='boxes-box'>
 <div class="boxes-box-content">
-<h2 class="css-brand--css-geos-meetings-header-h2-xxxlarge">
-<a href="https://geoschem.github.io/"><img height="600" width="1034" style="float: right; width: 350px; height: 203px;" class="media-element file-default file-os-files-xxlarge" src="https://static.projects.iq.harvard.edu/files/styles/os_files_xxlarge/public/acmg-geos/files/img-meeting-geos_chem.png?m=1617458080&amp;itok=C1YHyVwv" alt="" title="" /></a>
-The First Regional GEOS-Chem Asia Meeting May 21-23, 2018
-</h2>
+<a href="https://geoschem.github.io/"><img height="600" width="1034" style="float: right; width: 350px; height: 203px;" class="media-element file-default file-os-files-xxlarge" src="img/gca2_nuist.png" alt="" title="" /></a>
+<h2 class="css-brand--css-geos-meetings-header-h2-xxxlarge">The First Regional GEOS-Chem Asia Meeting<br>May 21-23, 2018</h2>
 </div>
 </div>
 </div>
@@ -76,15 +58,16 @@ The First Regional GEOS-Chem Asia Meeting May 21-23, 2018
 
 <!--main menu region beg-->
 <div id="menu-bar" class="nav region-menu-bar clearfix">
-<nav id="block-os-gca1" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="gca1">  
-<ul class="nice-menu nice-menu-down nice-menu-gca1" id="nice-menu-gca1">
-  <li class="menu-857293 menu-path-node-1586522  first   odd  "><a href="gca1.html"  class="active">Home</a></li>
-  <li class="menu-857297 menu-path-node-1586523   even   last "><a href="gca1-presentations.html" >Presentations and Posters</a></li>
+<nav id="block-os-gca1" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="gca1">
+<ul class="nice-menu nice-menu-down">
+  <li><a href="gca1.html" class="active">GCA1 Home</a></li>
+  <li><a href="gca1-presentations.html">Presentations and Posters</a></li>
+  <li><a href="index.html">GEOS-Chem Home</a></li>
 </ul>
 </nav>
 </div>
 <!--main menu region end-->
-		
+
 <div id="columns" class="clearfix">
 <div class="hg-container">
 <div id="content-column" role="main">
@@ -100,345 +83,348 @@ The First Regional GEOS-Chem Asia Meeting May 21-23, 2018
 <div class="region region-content-top">
 <div class="region-inner clearfix">
 <div id="block-os-pages-main-content" class="block block-os-pages no-title"  module="os_pages" delta="main_content">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <div class="block-content content" ng-non-bindable="">
 <article id="node-1585687" class="node node-page article clearfix" role="article">
 <div class="node-content" ng-non-bindable="">
 <div class="field field-name-body field-type-text-with-summary field-label-hidden view-mode-full">
 <div class="field-items">
 <div class="field-item even">
-    
+
 <p align="justify">
-	<strong>Mon, May 21: <a href="#MonA">Overview and Invited Talks</a> | <a href="#MonB">WG Introductions</a> | <a href="#MonC">Aerosols</a> | <a href="#MonD">Chemistry</a> | <a href="#MonE">Poster Session A</a></strong><br class="clearfix" /><strong>Tue, May 22 : <a href="#TueA">Regional &amp; Global Air Quality</a> | <a href="#TueB">Organics &amp; Mercury</a> | <a href="#TueC">Transport &amp; Sources/Sinks</a> | <a href="#TueE">Poster Session B</a></strong><br class="clearfix" /><strong>Wed, May 23: <a href="#WedA">Chemistry-Ecosystems-climate</a> | <a href="#WedB">WG Breakout Reports and Discussion</a></strong>
+  <strong>Mon, May 21: <a href="#MonA">Overview and Invited Talks</a> | <a href="#MonB">WG Introductions</a> | <a href="#MonC">Aerosols</a> | <a href="#MonD">Chemistry</a> | <a href="#MonE">Poster Session A</a></strong><br class="clearfix" /><strong>Tue, May 22 : <a href="#TueA">Regional &amp; Global Air Quality</a> | <a href="#TueB">Organics &amp; Mercury</a> | <a href="#TueC">Transport &amp; Sources/Sinks</a> | <a href="#TueE">Poster Session B</a></strong><br class="clearfix" /><strong>Wed, May 23: <a href="#WedA">Chemistry-Ecosystems-climate</a> | <a href="#WedB">WG Breakout Reports and Discussion</a></strong>
 </p>
 
-<h2>
-	Monday, May 21
-</h2>
+<h2>Monday, May 21</h2>
 <a name="MonA" id="MonA"></a>
 
-<h4>
-	GEOS-Chem Overview and Invited Talks (Chair: Hong Liao)
-</h4>
+<h4>GEOS-Chem Overview and Invited Talks (Chair: Hong Liao)</h4>
 
-<ul><li>
-		<a href="https://drive.google.com/file/d/1fe1LA42YcJWoTUUVR129pyR1SpAowgRL/view?usp=drive_link" target="_blank">GEOS-Chem Model Overview</a> (Daniel Jacob, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1RAwnZ0nj4Gyp2p6a0cif5WhprtIYsCuX/view?usp=drive_link" target="_blank">Atmospheric Chemistry and anthropogenic influence over the Amazon tropical forest</a> (Scot Martin, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1IrttTZRl5a360fnG79v0gDAB8cl3lhVG/view?usp=drive_link" target="_blank">Overview of J3 regional campaign on heavy air pollution in winter</a> (Yuanhang Zhang, Peking U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1AtQuA_EYn04UMNbkDB3ToBMkvHgIxRDV/view?usp=drive_link" target="_blank">Evolution and impacts of anthropogenic emissions in China</a> (Kebin He, Tsinghua U. )
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1j_AQGYrXJbib6Ztc7uYJDF5ib-K5cn5y/view?usp=drive_link" target="_blank">New particle formation in China</a> (Min Hu, Peking U)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1ew0EtCW3uqo_V2Opeq041cMDDCP2wvXg/view?usp=drive_link" target="_blank">Bridging the gap between modeled and observed SOA: Implication from field campaigns and chamber simulation </a> (Xinming Wang, Guangzhou Institute of Geochemistry, CAS)
-	</li>
-</ul><h4>
-	<a name="MonB" id="MonB"></a>GEOS-Chem Working Group Introductions (Chair: Daniel Jacob)
-</h4>
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1fe1LA42YcJWoTUUVR129pyR1SpAowgRL/view?usp=drive_link" target="_blank">GEOS-Chem Model Overview</a> (Daniel Jacob, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1RAwnZ0nj4Gyp2p6a0cif5WhprtIYsCuX/view?usp=drive_link" target="_blank">Atmospheric Chemistry and anthropogenic influence over the Amazon tropical forest</a> (Scot Martin, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1IrttTZRl5a360fnG79v0gDAB8cl3lhVG/view?usp=drive_link" target="_blank">Overview of J3 regional campaign on heavy air pollution in winter</a> (Yuanhang Zhang, Peking U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1AtQuA_EYn04UMNbkDB3ToBMkvHgIxRDV/view?usp=drive_link" target="_blank">Evolution and impacts of anthropogenic emissions in China</a> (Kebin He, Tsinghua U. )
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1j_AQGYrXJbib6Ztc7uYJDF5ib-K5cn5y/view?usp=drive_link" target="_blank">New particle formation in China</a> (Min Hu, Peking U)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1ew0EtCW3uqo_V2Opeq041cMDDCP2wvXg/view?usp=drive_link" target="_blank">Bridging the gap between modeled and observed SOA: Implication from field campaigns and chamber simulation </a> (Xinming Wang, Guangzhou Institute of Geochemistry, CAS)
+  </li>
+</ul>
 
-<ul><li>
-		<a href="https://drive.google.com/file/d/1GfrUv4fH2drDHIFWiGWf8SS3Tb1rwJiV/view?usp=drive_link" target="_blank">Adjoint Model and Data Assimilation Working Group</a> (Daven Henze, U. Colorado-boulder and Jun Wang, U. Iowa )
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1NKnFUFtuNGnL0f2IStQ0Dk8gTFTvqOMs/view?usp=drive_link" target="_blank">Transport Working Group </a> (Hongyu Liu, NIA / NASA Langley)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1vp9TdcENsppoDyTrS7sL89cXJMwn2yT4/view?usp=drive_link" target="_blank">Chemistry-Ecosystems-climate Working Group </a> (Hong Liao, NUIST)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1MkjVrEkG0zDUCkZWEcd3EK3xt7hFcsJq/view?usp=drive_link" target="_blank">Emissions and Deposition Working Group</a> (Jintai Lin, Peking U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Xt4P4sEm6Ky_jqzegKZn8qwMct0paUFc/view?usp=drive_link" target="_blank">Nested model Working Group</a> (Yuxuan Wang, U. Houston and Lin Zhang, Peking U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1WvwUjyitIKzFPhHOKfTcr8dHYChVHWzy/view?usp=drive_link" target="_blank">High-performance GEOS-Chem and cloud computing </a> (Jiawei Zhuang, Harvard)
-	</li>
-</ul><h4>
-	<a name="MonC" id="MonC"></a>Aerosols (Chair: Daven Henze)
-</h4>
+<h4><a name="MonB" id="MonB"></a>GEOS-Chem Working Group Introductions (Chair: Daniel Jacob)</h4>
 
-<ul><li>
-		<a href="https://drive.google.com/file/d/1cC-Odjbd5X3gYFqICkfxnYWuaUm2GcAM/view?usp=drive_link" target="_blank">Source attribution of PM2.5 in Korea during the KORUS-aQ campaign</a> (Hyung-Min Lee, Seoul National U)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1fZArU66Xfjvl1P4lHvyvp0ukFMluHa-s/view?usp=drive_link" target="_blank">Observation and simulation of fine particulate matter pollution during G20 conference in Hangzhou</a> (Huan Yu, NUIST)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1eXjYCx90KMKv0orPqv4vNR2TClkqMiQ4/view?usp=drive_link" target="_blank">Seasonal variations of model bias in simulations of major PM2.5 chemical components in China</a> (Ruqian Miao, Peking U.)
-	</li>
-	<li>
-		Investigation of new particle formation events in China using Chemical Ionization Mass Spectrometry (Jun Zheng, NUIST)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1QnuPo3YiXcTKvienQoB0QDPYzKXivpn2/view?usp=drive_link" target="_blank">Effect of aging on cloud nucleating properties of atmospheric aerosols </a> (Yan Ma, NUIST)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1c-BtXzVEMN1UciOnzAcMV0ULxmHpWNM-/view?usp=drive_link" target="_blank">Efficacy of dust aerosol forecasts for East Asia using the adjoint of GEOS-Chem with ground-based observations </a> (Jaein Jeong, Seoul National U.)
-	</li>
-</ul><h4>
-	<a name="MonD" id="MonD"></a>Chemistry (Chair: Lin Zhang)
-</h4>
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1GfrUv4fH2drDHIFWiGWf8SS3Tb1rwJiV/view?usp=drive_link" target="_blank">Adjoint Model and Data Assimilation Working Group</a> (Daven Henze, U. Colorado-boulder and Jun Wang, U. Iowa )
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1NKnFUFtuNGnL0f2IStQ0Dk8gTFTvqOMs/view?usp=drive_link" target="_blank">Transport Working Group </a> (Hongyu Liu, NIA / NASA Langley)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1vp9TdcENsppoDyTrS7sL89cXJMwn2yT4/view?usp=drive_link" target="_blank">Chemistry-Ecosystems-climate Working Group </a> (Hong Liao, NUIST)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1MkjVrEkG0zDUCkZWEcd3EK3xt7hFcsJq/view?usp=drive_link" target="_blank">Emissions and Deposition Working Group</a> (Jintai Lin, Peking U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Xt4P4sEm6Ky_jqzegKZn8qwMct0paUFc/view?usp=drive_link" target="_blank">Nested model Working Group</a> (Yuxuan Wang, U. Houston and Lin Zhang, Peking U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1WvwUjyitIKzFPhHOKfTcr8dHYChVHWzy/view?usp=drive_link" target="_blank">High-performance GEOS-Chem and cloud computing </a> (Jiawei Zhuang, Harvard)
+  </li>
+</ul>
 
-<ul><li>
-		<a href="https://drive.google.com/file/d/1xNQziOeURI7TkC7MnX4Tj_bbw7JoTGKs/view?usp=drive_link" target="_blank">Modeling of tropospheric halogen chemistry: cycling, uncertainty, and impact</a> (Lei Zhu, Harvard U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1ixZtmRIrlXBvQs5OlhMx-xN7gjn64cHq/view?usp=drive_link" target="_blank">Assessing cloud radiative effects on photolysis rates during aircraft campaigns using satellite cloud observations and GEOS-Chem </a> (Hongyu Liu, NIA / NASA Langley)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1ggZNwhcH8iS9iMOuq8NEbaVfCtyf1NkU/view?usp=drive_link" target="_blank">Simulation of NH3 in the UTLS</a> (Jun Wang, U. lowa)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1kR60pg5JDZbCouaxjHfO4VNXKuGuDWNn/view?usp=drive_link" target="_blank">Simulating chloride chemistry in GEOS-Chem </a> (Xuan Wang, Harvard U.)
-	</li>
-	<li>
-		Simulation of the effect of multi-scale interactions on OH Simulation of the effect of multi-scale interactions on OH (Hongjian Weng, Peking U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1-Au5BkueHp-yTUmWkGuhyrSsDYsZbW_H/view?usp=drive_link" target="_blank">POMINO: Explicit aerosols corrections on NO2 satellite retrieval of OMI and Tropomi by using GEOS-Chem and satellite observation </a> (Mengyao Liu, Peking U.)
-	</li>
-</ul><h4>
-	<a name="MonE" id="MonE"></a>Poster Session A
-</h4>
+<h4><a name="MonC" id="MonC"></a>Aerosols (Chair: Daven Henze)</h4>
 
-<ul><li>
-		<a href="https://drive.google.com/file/d/1lPoDO4wNWhrXEi1muk9Bp6NECuBoVJnb/view?usp=drive_link" target="_blank">The impact of increasing atmospheric oxidation capacity on organic aerosol in Beijing-Tianjin-Hebei (BTH), China: A case study</a> (Tian Feng, IEE/CAS)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1BaRlU7HE2B0utmNGz7gBYNT-lLgBXPMj/view?usp=drive_link" target="_blank">Spatiotemporal variations of severe haze episodes in China </a> (Jiandong Li, IAP/CAS)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1DgYs4IysAFJR97sm86ctS3I205Qwjc_f/view?usp=drive_link" target="_blank">Heterogeneous sulfate aerosol formation mechanisms in Chinese haze events: Air quality model assessment using observations of sulfate Δ<sup>17</sup>O in Beijing</a> (Jingyuan Shao, Peking U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1hOhluw_YUySCvFfQO2Qk5RDfUOLfv4w-/view?usp=drive_link" target="_blank">Effects of different types of precipitation on aerosol particles in Beijing </a> (Jin Wu, BJ Meteorological Service )
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1oaYN_JdsH7uQlXboEdcqzMm8X1_DpNW4/view?usp=drive_link" target="_blank">Impact of mixing states on aerosol direct radiative forcing and heating rate based on GEOS-Chem-aPM </a> (Hailing Jia, NUIST)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Md6fPs7fjzAXqd88NEpN4a7Qmgu2l7Ti/view?usp=drive_link" target="_blank">GEOS-Chem CO data assimilation and comparison with the EC-cAS model</a> (Tailong He , U. Toronto)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1JzPzm5b8HqvLv1riRzOoaUYCB1SOK-5C/view?usp=drive_link" target="_blank">Preliminary results on coupling GEOS-Chem with the WRF Model</a> (Haipeng Lin, Peking U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/19Ry5vrv069-l4TGN0LEAxLPGjDGmW_jh/view?usp=drive_link" target="_blank">Global simulation of aerosol effects on tropospheric photolysis frequencies and photochemistry</a> (Rong Tian, NUIST)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1c22C_aMR2YGvvqr2n8VixBvuMC_MlJJV/view?usp=drive_link" target="_blank">Effects of changing meteorlogical on ozone in the YRD region during the Clean Air Action Plan (2013-2017)</a> (Rusha Yan, SAES)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1C_Ug5Wb7VfQ-nqSxLHoTD_bxDOSyjFJl/view?usp=drive_link" target="_blank">Atmospheric emissions to socioeconomic impacts: Assessing the changes in rice mercury contamination under policy</a> (Sae Yun Kwon, POSTECH)
-	</li>
-</ul><h2>
-	Tuesday, May 22
-</h2>
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1cC-Odjbd5X3gYFqICkfxnYWuaUm2GcAM/view?usp=drive_link" target="_blank">Source attribution of PM2.5 in Korea during the KORUS-aQ campaign</a> (Hyung-Min Lee, Seoul National U)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1fZArU66Xfjvl1P4lHvyvp0ukFMluHa-s/view?usp=drive_link" target="_blank">Observation and simulation of fine particulate matter pollution during G20 conference in Hangzhou</a> (Huan Yu, NUIST)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1eXjYCx90KMKv0orPqv4vNR2TClkqMiQ4/view?usp=drive_link" target="_blank">Seasonal variations of model bias in simulations of major PM2.5 chemical components in China</a> (Ruqian Miao, Peking U.)
+  </li>
+  <li>
+    Investigation of new particle formation events in China using Chemical Ionization Mass Spectrometry (Jun Zheng, NUIST)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1QnuPo3YiXcTKvienQoB0QDPYzKXivpn2/view?usp=drive_link" target="_blank">Effect of aging on cloud nucleating properties of atmospheric aerosols </a> (Yan Ma, NUIST)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1c-BtXzVEMN1UciOnzAcMV0ULxmHpWNM-/view?usp=drive_link" target="_blank">Efficacy of dust aerosol forecasts for East Asia using the adjoint of GEOS-Chem with ground-based observations </a> (Jaein Jeong, Seoul National U.)
+  </li>
+</ul>
 
-<h4>
-	<a name="TueA" id="TueA"></a>Regional and global air quality (Chair: Jun Wang)
-</h4>
+<h4><a name="MonD" id="MonD"></a>Chemistry (Chair: Lin Zhang)</h4>
 
-<ul><li>
-		Trend of air quality in China constrained by observations and models (Lu Shen, Harvard)
-	</li>
-	<li>
-		China and globalizing air pollution (Jintai Lin, Peking U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/12SOdcOmUQlMais2RjJwwftyZYR2QGdB-/view?usp=drive_link" target="_blank">Enhanced air pollution health effects studies using source-oriented chemical transport models</a> (Jianlin Hu, NUIST)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1_D2o9zbFlURJmEHYKgnj_mvGKIgyl0sk/view?usp=drive_link" target="_blank">Simulations of aerosol and trace gases in Beijing during the APHH campaign</a> (Matthew Jolleys, U. Edinburgh)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1qlE6txChXgO40qOUv7S2FvXH2DK5D1-r/view?usp=drive_link" target="_blank">Modeling regional air quality using the near-explicit master chemical mechanism</a> (Jingyi Li)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1ogHc2ETxiSeYrNx8AZ9qEd5HFPIxnCar/view?usp=drive_link" target="_blank">Air quality over India in 2030: Avoided premature mortality from emissions reductions</a> (Alex Karambelas, Columbia U.)
-	</li>
-	<li>
-		Fine resolution wind field simulated in the low layer of urban area by a multi-scale urban canopy model (Zhenxin Liu)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Ea73hzsBmY0TlmwtYXPLu84DGfdN95O7/view?usp=drive_link" target="_blank">Local meteorological drivers of summer surface ozone variability in China: Implications for interannual variations of ozone air quality </a> (Ke Li, Harvard U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1YExkWjAUxasGqJCEjziUETlf_CroBv5U/view?usp=drive_link" target="_blank">Local meteorological drivers of summer surface ozone variability in China: Implications for interannual variations of ozone air quality </a> (Ruijun Dang, IAP/CAS)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1dYP8MlNNrbKRwu-aj9J_5eEjclupAjSR/view?usp=drive_link" target="_blank">Impacts of relative humidity on a heavily polluted event over North China Plain in February 2014</a> (Shujing Shi, NUIST)
-	</li>
-</ul><h4>
-	<a name="TueB" id="TueB"></a>Organics and Mercury (Chair: Yuxuan Wang)
-</h4>
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1xNQziOeURI7TkC7MnX4Tj_bbw7JoTGKs/view?usp=drive_link" target="_blank">Modeling of tropospheric halogen chemistry: cycling, uncertainty, and impact</a> (Lei Zhu, Harvard U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1ixZtmRIrlXBvQs5OlhMx-xN7gjn64cHq/view?usp=drive_link" target="_blank">Assessing cloud radiative effects on photolysis rates during aircraft campaigns using satellite cloud observations and GEOS-Chem </a> (Hongyu Liu, NIA / NASA Langley)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1ggZNwhcH8iS9iMOuq8NEbaVfCtyf1NkU/view?usp=drive_link" target="_blank">Simulation of NH3 in the UTLS</a> (Jun Wang, U. lowa)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1kR60pg5JDZbCouaxjHfO4VNXKuGuDWNn/view?usp=drive_link" target="_blank">Simulating chloride chemistry in GEOS-Chem </a> (Xuan Wang, Harvard U.)
+  </li>
+  <li>
+    Simulation of the effect of multi-scale interactions on OH Simulation of the effect of multi-scale interactions on OH (Hongjian Weng, Peking U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1-Au5BkueHp-yTUmWkGuhyrSsDYsZbW_H/view?usp=drive_link" target="_blank">POMINO: Explicit aerosols corrections on NO2 satellite retrieval of OMI and Tropomi by using GEOS-Chem and satellite observation </a> (Mengyao Liu, Peking U.)
+  </li>
+</ul>
 
-<ul><li>
-		<a href="https://drive.google.com/file/d/1aLK-ElNf80-aQlpqmOIfnIZiw3DIHbpZ/view?usp=drive_link" target="_blank">Atmospheric aqueous-phase SOA formation：laboratory investigations and field observations </a> (Xinlei Ge, NUIST)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Yxn5f0yV7rp-_yW-WgNhKwAc0_44u-a6/view?usp=drive_link" target="_blank">Space-based constraints on Chinese non-methane volatile organic compound emissions and impacts on regional air quality</a> (Tzung-May Fu, Peking U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/12h8vhajbyj0ZKWp7t1Om3XEjX_Xsz1BI/view?usp=drive_link" target="_blank">Simulations of organic aerosol in China</a> (Qi Chen, Peking U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1RmO0AAqFFvG19C9N1RRHJnCHRN4XHCCh/view?usp=drive_link" target="_blank">Light absorption and chemical composition of primary and secondary organic aerosol</a> (Mingjie Xie, NUIST)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1fgOvyfVWFJ2mWUaWn9_-pfI7XONAMEUc/view?usp=drive_link" target="_blank">An online coupled model for air-sea exchange of mercury</a> (Yanxu Zhang, Nanjing U)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/10IjeXunNrAc9pnKKkoF3pzVv4qwciXsn/view?usp=drive_link" target="_blank">Mercury inputs to Chinese marginal seas–Impact of industrialization and development of China </a> (Runsheng Yin, GIG/CAS)
-	</li>
-</ul><h4>
-	<a name="TueC" id="TueC"></a>Transport, Sources and Sinks (Chairs: Jintai Lin and Nadine Unger)
-</h4>
+<h4><a name="MonE" id="MonE"></a>Poster Session A</h4>
 
-<ul><li>
-		<a href="https://drive.google.com/file/d/1m0KARs5qpSPKWMmdfsxuBLY4CcPgKyuY/view?usp=drive_link" target="_blank">The importance of Asia as a source of black carbon to the Arctic constrained by aircraft and surface measurements </a> (Junwei Xu, Dalhousie U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1xEGrssuvI7dVlp36XvrpxxVFCl3H_lRB/view?usp=drive_link" target="_blank">NOx emission trends for China derived from OMPS </a> (Yuxuan Wang, Tsinghua U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Pgvq3X3lzMGQbX2wSEUIlUzU2Q2qfD_C/view?usp=drive_link" target="_blank">Unexpected slowdown of US pollutant emission reduction in the past decade </a> (Zhe Jiang, U. Sci. &amp; Tech.China )
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1BYFy39whUfkRZjxycRHCJhReHuFAfCSA/view?usp=drive_link" target="_blank">Transatlantic transport of pollution from Africa to South America </a> (Qiaoqiao Wang, Jinan U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1mc8QfpXIPklBjBza0MZs8iSi5Ga0e-hS/view?usp=drive_link" target="_blank">Impacts of biogenic and anthropogenic emissions on summertime ozone formation in the Guanzhong Basin, China </a> (Nan Li, NUIST)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1MIqzs4H6UUsJdHaDC6pKZdvSlp0puzeE/view?usp=drive_link" target="_blank">Remote sensing of PM2.5 near the ground from satellite observation</a> (Ying Zhang, Inst. of Remote Sensing and Digital Earth, CAS)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1rJpbVBH13blrfTbRnHg5B3aWhakhjvYS/view?usp=drive_link" target="_blank">The importance of vertical resolution in the free troposphere for modeling intercontinental plumes</a> (Jiawei Zhuang, Harvard U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1aYkhun4Wr0YPzNQmj1bjHZmf-4Ziec14/view?usp=drive_link" target="_blank">Emissions and deposition of atmospheric reactive nitrogen over China </a> (Lin Zhang, Peking U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1bvpaJcXMolN89QTZEkQcabRj02oGyACL/view?usp=drive_link" target="_blank">Long-term NOx and SO2 emissions over East Asia simultaneously constrained by OMI observations using GEOS-Chem adjoint</a> (Zhen Qu)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1P-uxzpfXjraSMtgWTm6f8Z4SiEGEIYlO/view?usp=drive_link" target="_blank">Neural network prediction of pollutant emissions from agricultural waste burning in Southern China and application to air quality forecasts</a> (Xu Feng, Peking U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1a_DeCg0Ngdph3bgnpAUj0GXtnOQ9qWjU/view?usp=drive_link" target="_blank">Impact of Southeast Asian smoke on aerosol properties in Southwest China: comparison of model simulations with satellite and ground observations </a> (Jun Zhu, NUIST)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1pr4VybazPZBB909MM7F4ijF_yXANpFbf/view?usp=drive_link" target="_blank">Modeling Impacts of Urbanization and Urban Heat Island Mitigation on Boundary Layer Meteorology and Air Quality in Beijing Under Different Weather Conditions</a> (Lei Chen, NUIST)
-	</li>
-</ul><h4>
-	<a name="TueE" id="TueE"></a>Poster Session B
-</h4>
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1lPoDO4wNWhrXEi1muk9Bp6NECuBoVJnb/view?usp=drive_link" target="_blank">The impact of increasing atmospheric oxidation capacity on organic aerosol in Beijing-Tianjin-Hebei (BTH), China: A case study</a> (Tian Feng, IEE/CAS)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1BaRlU7HE2B0utmNGz7gBYNT-lLgBXPMj/view?usp=drive_link" target="_blank">Spatiotemporal variations of severe haze episodes in China </a> (Jiandong Li, IAP/CAS)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1DgYs4IysAFJR97sm86ctS3I205Qwjc_f/view?usp=drive_link" target="_blank">Heterogeneous sulfate aerosol formation mechanisms in Chinese haze events: Air quality model assessment using observations of sulfate Δ<sup>17</sup>O in Beijing</a> (Jingyuan Shao, Peking U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1hOhluw_YUySCvFfQO2Qk5RDfUOLfv4w-/view?usp=drive_link" target="_blank">Effects of different types of precipitation on aerosol particles in Beijing </a> (Jin Wu, BJ Meteorological Service )
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1oaYN_JdsH7uQlXboEdcqzMm8X1_DpNW4/view?usp=drive_link" target="_blank">Impact of mixing states on aerosol direct radiative forcing and heating rate based on GEOS-Chem-aPM </a> (Hailing Jia, NUIST)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Md6fPs7fjzAXqd88NEpN4a7Qmgu2l7Ti/view?usp=drive_link" target="_blank">GEOS-Chem CO data assimilation and comparison with the EC-cAS model</a> (Tailong He , U. Toronto)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1JzPzm5b8HqvLv1riRzOoaUYCB1SOK-5C/view?usp=drive_link" target="_blank">Preliminary results on coupling GEOS-Chem with the WRF Model</a> (Haipeng Lin, Peking U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/19Ry5vrv069-l4TGN0LEAxLPGjDGmW_jh/view?usp=drive_link" target="_blank">Global simulation of aerosol effects on tropospheric photolysis frequencies and photochemistry</a> (Rong Tian, NUIST)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1c22C_aMR2YGvvqr2n8VixBvuMC_MlJJV/view?usp=drive_link" target="_blank">Effects of changing meteorlogical on ozone in the YRD region during the Clean Air Action Plan (2013-2017)</a> (Rusha Yan, SAES)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1C_Ug5Wb7VfQ-nqSxLHoTD_bxDOSyjFJl/view?usp=drive_link" target="_blank">Atmospheric emissions to socioeconomic impacts: Assessing the changes in rice mercury contamination under policy</a> (Sae Yun Kwon, POSTECH)
+  </li>
+</ul>
 
-<ul><li>
-		<a href="https://drive.google.com/file/d/1TNzoZ99zcK9rlSu3v8c-p-9BT9vrboCw/view?usp=drive_link" target="_blank">Short-term weather patterns modulate air pollution in Eastern China during 2015-2016 winter </a> (Shuyu Zhao, IEE/CAS)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/12k6JnUaaOBTYNZVbbVfZFFe2xpJjokmy/view?usp=drive_link" target="_blank">Simulation on the Impacts of Emissions and Climate Change on Air Quality in China between 2010 and 2040</a> (Heng Tian, Peking U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/15OCaUkSIwsevfgr1ckniMAEYsKjpnWUM/view?usp=drive_link" target="_blank">The impact of aerosol-meteorology interactions on the effectiveness of emission control measures </a> (Mi Zhou, Peking U)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/11lCC0dGiv_GL-GGSaSCAnKNEt7BtcDnF/view?usp=drive_link" target="_blank">Impacts of PBL parameterization on ozone concentration and dry deposition in the WRF-chem model—a case study of Beijing-Tianjin-Hebei region</a> (Yuanhong Zhao, Peking U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1F8YmRdIWLX7wbrHkI01coJTmoNbGefjp/view?usp=drive_link" target="_blank">Changes in ammonia agricultural emissions and their impact on surface PM2.5 pollution in China during 2005-2015 </a> (Youfan Chen, Peking U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1oAHFbi8NBNm3BsCXvVblapr2aOkSsuD3/view?usp=drive_link" target="_blank">Influence of air quality control measures on ozone during G20 Summit in Hangzhou</a> (Ye Wang, NUIST)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1TdamKWiVdyLUFLE60cZbE_NK4P8TjFQv/view?usp=drive_link" target="_blank">The impacts of long-range transport on the spatial and temporal distribution of black carbon in the Tibetan Plateau </a> (Yue Wu, Nanjing U)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1uhTudU1h9_73-cqGgCODUTh0eo59U9jZ/view?usp=drive_link" target="_blank">GEOS-Chem modeling of long-range transport of global tropospheric ozone to China </a> (Jane Liu, Nanjing U./U. Toronto )
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1N1o2D1j6ucZ3nyw5ooYPKtzHBQXPDOcg/view?usp=drive_link" target="_blank">The impact of long-range transport of African ozone on tropospheric ozone over Asia </a> (Han Han, Nanjing U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1pKNRMaTjF6wAUyAbz_Q1MpYjGHaSQ8-v/view?usp=drive_link" target="_blank">Adjoint inversion of Chinese NMVOC emissions using space-based observations of formaldehyde and glyoxal</a> (Hansen Cao, Peking U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Fu8By5y5UmzZTDcJMY3iGIWj3Uol3-fE/view?usp=drive_link" target="_blank">Top-down estimate of isoprene emissions in East Asia using inverse modeling: implication of satellite retrievals from GOME-2 and OMI formaldehyde with KORUS-aQ aircraft observations</a> (Hyung-Min Lee, Seoul National U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1cuW_-YoZ9tVmW0gIfmz30ztYVDWlzxNx/view?usp=drive_link" target="_blank">Impacts of Anthropogenic Emissions on Springtime Mesoscale Convective Systems in South China </a> (Lijuan Zhuang, Peking U.)
-	</li>
-</ul><h2>
-	Wednesday, May 23
-</h2>
+<h2>Tuesday, May 22</h2>
 
-<h4>
-	<a name="WedA" id="WedA"></a>Chemistry-Ecosystems-climate (Chair: Tzung-May Fu)
-</h4>
+<h4><a name="TueA" id="TueA"></a>Regional and global air quality (Chair: Jun Wang)</h4>
 
-<ul><li>
-		<a href="https://drive.google.com/file/d/1Q2ITWA40C55nNlttiLBN-s_VvVByYHw0/view?usp=drive_link" target="_blank">Implications of RCP emissions on future concentration and direct radiative forcing of secondary organic aerosol over China</a> (Yu Zhang, IAP/CAS)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1F-gqdAwtKSmIFooNOF8tOJlOQr-yueSY/view?usp=drive_link" target="_blank">Ozone pollution impacts on crops and forests in China</a> (Nadine Unger, U. Exeter)
-	</li>
-	<li>
-		Aerosol climatic and environmental effects: modeling studies (Xiaoyan Ma, NUIST)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1k0xOzfODeF2VyC5NF5QUQIMHeHfEKahh/view?usp=drive_link" target="_blank">Impact of fire air pollution on global ecosystem productivity </a> (Xu Yue, IAP/CAS )
-	</li>
-	<li>
-		<a href="https://projects.iq.harvard.edu/files/acmg-geos/files/gca1-weda-yuhao_mao.pdf" target="_blank">Impacts of meteorological parameters and emissions on decadal and interannual variations of black carbon in China for 1980-2010 </a> (Yuhao Mao, NUIST)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1D7ggXKoXWA8mkK2KI75Ks3Ewf-lWB_WP/view?usp=drive_link" target="_blank">Development of the China National Climate Center Climate-chemistry Model (BCC-cSM-GEOS-Chem): model development and evaluation for atmospheric chemistry component </a> (Xiao Lu, Peking U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1P7QDWHk-9RsCApku8hTany8BKcNxMI2B/view?usp=drive_link" target="_blank">Observed and GEOS-Chem simulated ozone and PM2.5 change under recent droughts in China</a> (Yuanyu Xie, Tsinghua U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/14KpnNhptj6I9einrmdrzS4DIX6k5vKJJ/view?usp=drive_link" target="_blank">A typical meteorological circulation of severe summertime ozone pollution events in Huabei Plain, China</a> (Cheng Gong, IAP/CAS)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1ff1x4X_NcaCx2uhnBfqTaE-Q7g3LNlbc/view?usp=drive_link" target="_blank">Effects of afforestation on haze pollution in BTH</a> (Xin Long, IEE/CAS)
-	</li>
-</ul><h4>
-	<a name="WedB" id="WedB"></a>Working Group Breakout Reports and Discussion (Chair: Daniel Jacob)
-</h4>
+<ul>
+  <li>
+    Trend of air quality in China constrained by observations and models (Lu Shen, Harvard)
+  </li>
+  <li>
+    China and globalizing air pollution (Jintai Lin, Peking U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/12SOdcOmUQlMais2RjJwwftyZYR2QGdB-/view?usp=drive_link" target="_blank">Enhanced air pollution health effects studies using source-oriented chemical transport models</a> (Jianlin Hu, NUIST)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1_D2o9zbFlURJmEHYKgnj_mvGKIgyl0sk/view?usp=drive_link" target="_blank">Simulations of aerosol and trace gases in Beijing during the APHH campaign</a> (Matthew Jolleys, U. Edinburgh)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1qlE6txChXgO40qOUv7S2FvXH2DK5D1-r/view?usp=drive_link" target="_blank">Modeling regional air quality using the near-explicit master chemical mechanism</a> (Jingyi Li)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1ogHc2ETxiSeYrNx8AZ9qEd5HFPIxnCar/view?usp=drive_link" target="_blank">Air quality over India in 2030: Avoided premature mortality from emissions reductions</a> (Alex Karambelas, Columbia U.)
+  </li>
+  <li>
+    Fine resolution wind field simulated in the low layer of urban area by a multi-scale urban canopy model (Zhenxin Liu)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Ea73hzsBmY0TlmwtYXPLu84DGfdN95O7/view?usp=drive_link" target="_blank">Local meteorological drivers of summer surface ozone variability in China: Implications for interannual variations of ozone air quality </a> (Ke Li, Harvard U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1YExkWjAUxasGqJCEjziUETlf_CroBv5U/view?usp=drive_link" target="_blank">Local meteorological drivers of summer surface ozone variability in China: Implications for interannual variations of ozone air quality </a> (Ruijun Dang, IAP/CAS)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1dYP8MlNNrbKRwu-aj9J_5eEjclupAjSR/view?usp=drive_link" target="_blank">Impacts of relative humidity on a heavily polluted event over North China Plain in February 2014</a> (Shujing Shi, NUIST)
+  </li>
+</ul>
 
-<ul><li>
-		<a href="https://drive.google.com/file/d/1oVxSTdl1agX5MlqbhcnDJQvAqwnWMjyv/view?usp=drive_link" target="_blank">Data Assimilation and Adjoint WG </a>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1mHSpgeJc1h4YjdUj8CW__fS5Soo5BCJK/view?usp=drive_link" target="_blank">GEOS-Chem High Performance WG</a>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/16m8iMbjdyXkXPRbHQQugHrJFIJZ9P7sw/view?usp=drive_link" target="_blank">Nested Model WG</a>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/14sBkO3wTgjFWadNHN7l8jty1wVmgTF_V/view?usp=drive_link" target="_blank">Sources and Surface Sinks WG</a>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1fOhWkYvH2H-QAg_fB8OF0mCFNeoVpC1V/view?usp=drive_link" target="_blank">Transport WG</a>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/10UV87fYKi9wzAhA0MX2UmHyWa2RKLb_R/view?usp=drive_link" target="_blank">Chemistry-Ecosystems-climate WG</a>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1VfKyL658qqJvRzONgH3diR-9HiQdszo7/view?usp=drive_link" target="_blank">Future directions for GEOS-Chem</a>
-	</li>
+<h4><a name="TueB" id="TueB"></a>Organics and Mercury (Chair: Yuxuan Wang)</h4>
+
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1aLK-ElNf80-aQlpqmOIfnIZiw3DIHbpZ/view?usp=drive_link" target="_blank">Atmospheric aqueous-phase SOA formation：laboratory investigations and field observations </a> (Xinlei Ge, NUIST)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Yxn5f0yV7rp-_yW-WgNhKwAc0_44u-a6/view?usp=drive_link" target="_blank">Space-based constraints on Chinese non-methane volatile organic compound emissions and impacts on regional air quality</a> (Tzung-May Fu, Peking U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/12h8vhajbyj0ZKWp7t1Om3XEjX_Xsz1BI/view?usp=drive_link" target="_blank">Simulations of organic aerosol in China</a> (Qi Chen, Peking U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1RmO0AAqFFvG19C9N1RRHJnCHRN4XHCCh/view?usp=drive_link" target="_blank">Light absorption and chemical composition of primary and secondary organic aerosol</a> (Mingjie Xie, NUIST)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1fgOvyfVWFJ2mWUaWn9_-pfI7XONAMEUc/view?usp=drive_link" target="_blank">An online coupled model for air-sea exchange of mercury</a> (Yanxu Zhang, Nanjing U)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/10IjeXunNrAc9pnKKkoF3pzVv4qwciXsn/view?usp=drive_link" target="_blank">Mercury inputs to Chinese marginal seas–Impact of industrialization and development of China </a> (Runsheng Yin, GIG/CAS)
+  </li>
+</ul>
+
+<h4><a name="TueC" id="TueC"></a>Transport, Sources and Sinks (Chairs: Jintai Lin and Nadine Unger)</h4>
+
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1m0KARs5qpSPKWMmdfsxuBLY4CcPgKyuY/view?usp=drive_link" target="_blank">The importance of Asia as a source of black carbon to the Arctic constrained by aircraft and surface measurements </a> (Junwei Xu, Dalhousie U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1xEGrssuvI7dVlp36XvrpxxVFCl3H_lRB/view?usp=drive_link" target="_blank">NOx emission trends for China derived from OMPS </a> (Yuxuan Wang, Tsinghua U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Pgvq3X3lzMGQbX2wSEUIlUzU2Q2qfD_C/view?usp=drive_link" target="_blank">Unexpected slowdown of US pollutant emission reduction in the past decade </a> (Zhe Jiang, U. Sci. &amp; Tech.China )
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1BYFy39whUfkRZjxycRHCJhReHuFAfCSA/view?usp=drive_link" target="_blank">Transatlantic transport of pollution from Africa to South America </a> (Qiaoqiao Wang, Jinan U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1mc8QfpXIPklBjBza0MZs8iSi5Ga0e-hS/view?usp=drive_link" target="_blank">Impacts of biogenic and anthropogenic emissions on summertime ozone formation in the Guanzhong Basin, China </a> (Nan Li, NUIST)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1MIqzs4H6UUsJdHaDC6pKZdvSlp0puzeE/view?usp=drive_link" target="_blank">Remote sensing of PM2.5 near the ground from satellite observation</a> (Ying Zhang, Inst. of Remote Sensing and Digital Earth, CAS)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1rJpbVBH13blrfTbRnHg5B3aWhakhjvYS/view?usp=drive_link" target="_blank">The importance of vertical resolution in the free troposphere for modeling intercontinental plumes</a> (Jiawei Zhuang, Harvard U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1aYkhun4Wr0YPzNQmj1bjHZmf-4Ziec14/view?usp=drive_link" target="_blank">Emissions and deposition of atmospheric reactive nitrogen over China </a> (Lin Zhang, Peking U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1bvpaJcXMolN89QTZEkQcabRj02oGyACL/view?usp=drive_link" target="_blank">Long-term NOx and SO2 emissions over East Asia simultaneously constrained by OMI observations using GEOS-Chem adjoint</a> (Zhen Qu)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1P-uxzpfXjraSMtgWTm6f8Z4SiEGEIYlO/view?usp=drive_link" target="_blank">Neural network prediction of pollutant emissions from agricultural waste burning in Southern China and application to air quality forecasts</a> (Xu Feng, Peking U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1a_DeCg0Ngdph3bgnpAUj0GXtnOQ9qWjU/view?usp=drive_link" target="_blank">Impact of Southeast Asian smoke on aerosol properties in Southwest China: comparison of model simulations with satellite and ground observations </a> (Jun Zhu, NUIST)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1pr4VybazPZBB909MM7F4ijF_yXANpFbf/view?usp=drive_link" target="_blank">Modeling Impacts of Urbanization and Urban Heat Island Mitigation on Boundary Layer Meteorology and Air Quality in Beijing Under Different Weather Conditions</a> (Lei Chen, NUIST)
+  </li>
+</ul>
+
+<h4><a name="TueE" id="TueE"></a>Poster Session B</h4>
+
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1TNzoZ99zcK9rlSu3v8c-p-9BT9vrboCw/view?usp=drive_link" target="_blank">Short-term weather patterns modulate air pollution in Eastern China during 2015-2016 winter </a> (Shuyu Zhao, IEE/CAS)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/12k6JnUaaOBTYNZVbbVfZFFe2xpJjokmy/view?usp=drive_link" target="_blank">Simulation on the Impacts of Emissions and Climate Change on Air Quality in China between 2010 and 2040</a> (Heng Tian, Peking U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/15OCaUkSIwsevfgr1ckniMAEYsKjpnWUM/view?usp=drive_link" target="_blank">The impact of aerosol-meteorology interactions on the effectiveness of emission control measures </a> (Mi Zhou, Peking U)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/11lCC0dGiv_GL-GGSaSCAnKNEt7BtcDnF/view?usp=drive_link" target="_blank">Impacts of PBL parameterization on ozone concentration and dry deposition in the WRF-chem model—a case study of Beijing-Tianjin-Hebei region</a> (Yuanhong Zhao, Peking U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1F8YmRdIWLX7wbrHkI01coJTmoNbGefjp/view?usp=drive_link" target="_blank">Changes in ammonia agricultural emissions and their impact on surface PM2.5 pollution in China during 2005-2015 </a> (Youfan Chen, Peking U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1oAHFbi8NBNm3BsCXvVblapr2aOkSsuD3/view?usp=drive_link" target="_blank">Influence of air quality control measures on ozone during G20 Summit in Hangzhou</a> (Ye Wang, NUIST)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1TdamKWiVdyLUFLE60cZbE_NK4P8TjFQv/view?usp=drive_link" target="_blank">The impacts of long-range transport on the spatial and temporal distribution of black carbon in the Tibetan Plateau </a> (Yue Wu, Nanjing U)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1uhTudU1h9_73-cqGgCODUTh0eo59U9jZ/view?usp=drive_link" target="_blank">GEOS-Chem modeling of long-range transport of global tropospheric ozone to China </a> (Jane Liu, Nanjing U./U. Toronto )
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1N1o2D1j6ucZ3nyw5ooYPKtzHBQXPDOcg/view?usp=drive_link" target="_blank">The impact of long-range transport of African ozone on tropospheric ozone over Asia </a> (Han Han, Nanjing U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1pKNRMaTjF6wAUyAbz_Q1MpYjGHaSQ8-v/view?usp=drive_link" target="_blank">Adjoint inversion of Chinese NMVOC emissions using space-based observations of formaldehyde and glyoxal</a> (Hansen Cao, Peking U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Fu8By5y5UmzZTDcJMY3iGIWj3Uol3-fE/view?usp=drive_link" target="_blank">Top-down estimate of isoprene emissions in East Asia using inverse modeling: implication of satellite retrievals from GOME-2 and OMI formaldehyde with KORUS-aQ aircraft observations</a> (Hyung-Min Lee, Seoul National U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1cuW_-YoZ9tVmW0gIfmz30ztYVDWlzxNx/view?usp=drive_link" target="_blank">Impacts of Anthropogenic Emissions on Springtime Mesoscale Convective Systems in South China </a> (Lijuan Zhuang, Peking U.)
+  </li>
+</ul>
+
+<h2>Wednesday, May 23</h2>
+
+<h4><a name="WedA" id="WedA"></a>Chemistry-Ecosystems-climate (Chair: Tzung-May Fu)</h4>
+
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1Q2ITWA40C55nNlttiLBN-s_VvVByYHw0/view?usp=drive_link" target="_blank">Implications of RCP emissions on future concentration and direct radiative forcing of secondary organic aerosol over China</a> (Yu Zhang, IAP/CAS)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1F-gqdAwtKSmIFooNOF8tOJlOQr-yueSY/view?usp=drive_link" target="_blank">Ozone pollution impacts on crops and forests in China</a> (Nadine Unger, U. Exeter)
+  </li>
+  <li>
+    Aerosol climatic and environmental effects: modeling studies (Xiaoyan Ma, NUIST)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1k0xOzfODeF2VyC5NF5QUQIMHeHfEKahh/view?usp=drive_link" target="_blank">Impact of fire air pollution on global ecosystem productivity </a> (Xu Yue, IAP/CAS )
+  </li>
+  <li>
+    <a href="https://projects.iq.harvard.edu/files/acmg-geos/files/gca1-weda-yuhao_mao.pdf" target="_blank">Impacts of meteorological parameters and emissions on decadal and interannual variations of black carbon in China for 1980-2010 </a> (Yuhao Mao, NUIST)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1D7ggXKoXWA8mkK2KI75Ks3Ewf-lWB_WP/view?usp=drive_link" target="_blank">Development of the China National Climate Center Climate-chemistry Model (BCC-cSM-GEOS-Chem): model development and evaluation for atmospheric chemistry component </a> (Xiao Lu, Peking U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1P7QDWHk-9RsCApku8hTany8BKcNxMI2B/view?usp=drive_link" target="_blank">Observed and GEOS-Chem simulated ozone and PM2.5 change under recent droughts in China</a> (Yuanyu Xie, Tsinghua U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/14KpnNhptj6I9einrmdrzS4DIX6k5vKJJ/view?usp=drive_link" target="_blank">A typical meteorological circulation of severe summertime ozone pollution events in Huabei Plain, China</a> (Cheng Gong, IAP/CAS)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1ff1x4X_NcaCx2uhnBfqTaE-Q7g3LNlbc/view?usp=drive_link" target="_blank">Effects of afforestation on haze pollution in BTH</a> (Xin Long, IEE/CAS)
+  </li>
+</ul>
+
+<h4><a name="WedB" id="WedB"></a>Working Group Breakout Reports and Discussion (Chair: Daniel Jacob)</h4>
+
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1oVxSTdl1agX5MlqbhcnDJQvAqwnWMjyv/view?usp=drive_link" target="_blank">Data Assimilation and Adjoint WG </a>
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1mHSpgeJc1h4YjdUj8CW__fS5Soo5BCJK/view?usp=drive_link" target="_blank">GEOS-Chem High Performance WG</a>
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/16m8iMbjdyXkXPRbHQQugHrJFIJZ9P7sw/view?usp=drive_link" target="_blank">Nested Model WG</a>
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/14sBkO3wTgjFWadNHN7l8jty1wVmgTF_V/view?usp=drive_link" target="_blank">Sources and Surface Sinks WG</a>
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1fOhWkYvH2H-QAg_fB8OF0mCFNeoVpC1V/view?usp=drive_link" target="_blank">Transport WG</a>
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/10UV87fYKi9wzAhA0MX2UmHyWa2RKLb_R/view?usp=drive_link" target="_blank">Chemistry-Ecosystems-climate WG</a>
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1VfKyL658qqJvRzONgH3diR-9HiQdszo7/view?usp=drive_link" target="_blank">Future directions for GEOS-Chem</a>
+  </li>
 </ul>
 
 </div>
@@ -459,64 +445,16 @@ The First Regional GEOS-Chem Asia Meeting May 21-23, 2018
 </div>
 </div>
 
-<!--footer region beg-->
+<!--footer-->
 <footer id="footer" class="clearfix" role="contentinfo">
-
-<!-- Three column 3x33 Gpanel -->
-<div class="at-panel gpanel panel-display footer clearfix">
-<div class="region region-footer">
-<div class="region-inner clearfix">
-<div id="block-boxes-1617037690" class="block block-boxes block-boxes-os_boxes_html no-title"  module="boxes" delta="1617037690">
-<div class="block-inner clearfix">  
-<div class="block-content content" ng-non-bindable="">  
-<div id='boxes-box-1617037690' class='boxes-box'>  
 <div class="boxes-box-content">
   <p style="text-align:center">
-    Copyright © 2023 by the International GEOS-Chem Community. All rights reserved.
+    Copyright © 2026 by the International GEOS-Chem Community. All rights reserved.
   </p>
 </div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-<div class="region region-footer-bottom">  
-<div class="region-inner clearfix">  
-<div id="block-boxes-1616879798" class="block block-boxes block-boxes-os_boxes_media no-title"  module="boxes" delta="1616879798">  
-<div class="block-inner clearfix">  
-<div class="block-content content"> 
-<div id='boxes-box-1616879798' class='boxes-box'> 
-<div class="boxes-box-content"> 
-<div id="file-3900146" class="file file-html file-html-embed">
-<h2 class="element-invisible"><a href="">css-brand</a></h2>
-<div class="content">
-<div class="file-info">
-</div>
-<div class="field field-name-field-html-code field-type-text-long field-label-hidden view-mode-full">
-<div class="field-items">
-<div class="field-item even">
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-
-<!--footer region end-->
 </footer>
-</div>
-</div>
 
-<!--page area ends-->
-<div id="extradiv"></div>
+</div>
 </div>
 
 </body>

--- a/gca1.html
+++ b/gca1.html
@@ -1,9 +1,4 @@
 <!DOCTYPE html>
-<!--[if IEMobile 7]><html class="iem7"  lang="en" dir="ltr"><![endif]-->
-<!--[if lte IE 6]><html class="lt-ie9 lt-ie8 lt-ie7"  lang="en" dir="ltr"><![endif]-->
-<!--[if (IE 7)&(!IEMobile)]><html class="lt-ie9 lt-ie8"  lang="en" dir="ltr"><![endif]-->
-<!--[if IE 8]><html class="lt-ie9"  lang="en" dir="ltr"><![endif]-->
-<!--[if (gte IE 9)|(gt IEMobile 7)]><!--><html  lang="en" dir="ltr"><!--<![endif]-->
 <head>
 <meta charset="utf-8" />
 <!--<base href="/gca1" />-->
@@ -18,23 +13,12 @@
 <title>The 1st Regional GEOS-Chem Asia Meeting</title>
 <meta http-equiv="x-ua-compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<link type="text/css" rel="stylesheet" href="css/css_xE-rWrJf-fncB6ztZfd2huxqgxu4WO-qwma6Xer30m4%EF%B9%96m=1675397288.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_1kR8T1_c-l5pBT6ZwbDT7BFda-4fyqW9Jjum29_2IY8%EF%B9%96m=1675397312.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_YnlUIvHP13qgpYEqubzE8JyDwlSxUnVibfnVkSoSDb0%EF%B9%96m=1675397273.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_Ku-3OcT9qU9h7dnGig5e23q6EVryY8orK4wzVDxsweE%EF%B9%96m=1675397367.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_vprtFTrWyg23GbY50_zJZHWGYMNfS8vsrRS26i4-ISk%EF%B9%96m=1675397406.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_dW-aNNrctRhQNc-KECjtQd0PxuW-h19IEum-TX2MeEk%EF%B9%96m=1675397301.css" media="print" />
-<link type="text/css" rel="stylesheet" href="css/css_SH2Lx3Qprh0GZo_9xRp85U9NsWfkSXn_Bi-rJoMY1sw%EF%B9%96m=1675397273.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_uaIDKcYMUK5osSQXuirpr3ZleXtnnpBN-eiECm7N0M0%EF%B9%96m=1675397395.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/responsive.blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/geos-chem.css" media="all"/>
 <script type="text/javascript" src="dropdown-menu.js"></script>
-<!--[if lte IE 8]>
-<script type="text/javascript">
-  var os_c = document.createElement;os_c('header');os_c('nav');os_c('section');os_c('article');os_c('aside');os_c('footer');os_c('hgroup');os_c('figure');
-</script>
-<![endif]-->
 </head>
 
 <body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-1585687 node-type-page og-context og-context-node og-context-node-1585652 navbar-on">
@@ -45,7 +29,7 @@
 <div id="page_wrap" class="page_wrap">
 <div id="page" class="container page header-main content-top footer-none">
 <div id="page-wrapper">
-		
+
 <!--header regions beg-->
 <header id="header" class="clearfix" role="banner">
 <div id="header-container">
@@ -53,14 +37,12 @@
 <div class="region region-header-second">
 <div class="region-inner clearfix">
 <div id="block-boxes-1617807424" class="block block-boxes block-boxes-os_boxes_html no-title"  module="boxes" delta="1617807424">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <div class="block-content content" ng-non-bindable="">
 <div id='boxes-box-1617807424' class='boxes-box'>
 <div class="boxes-box-content">
-<h2 class="css-brand--css-geos-meetings-header-h2-xxxlarge">
-<a href="https://geoschem.github.io/"><img height="600" width="1034" style="float: right; width: 350px; height: 203px;" class="media-element file-default file-os-files-xxlarge" src="img/GEOS-Chem_Logo_Square_Light_Background_Orig.png" alt="" title="" /></a>
-The First Regional GEOS-Chem Asia Meeting<br>May 21-23, 2018
-</h2>
+<a href="https://geoschem.github.io/"><img height="600" width="1034" style="float: right; width: 350px; height: 203px;" class="media-element file-default file-os-files-xxlarge" src="img/gca2_nuist.png" alt="" title="" /></a>
+<h2 class="css-brand--css-geos-meetings-header-h2-xxxlarge">The First Regional GEOS-Chem Asia Meeting<br>May 21-23, 2018</h2>
 </div>
 </div>
 </div>
@@ -76,15 +58,16 @@ The First Regional GEOS-Chem Asia Meeting<br>May 21-23, 2018
 
 <!--main menu region beg-->
 <div id="menu-bar" class="nav region-menu-bar clearfix">
-<nav id="block-os-gca1" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="gca1">  
-<ul class="nice-menu nice-menu-down nice-menu-gca1" id="nice-menu-gca1">
-  <li class="menu-857293 menu-path-node-1586522  first   odd  "><a href="gca1.html"  class="active">Home</a></li>
-  <li class="menu-857297 menu-path-node-1586523   even   last "><a href="gca1-presentations.html" >Presentations and Posters</a></li>
+<nav id="block-os-gca1" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="gca1">
+<ul class="nice-menu nice-menu-down">
+  <li><a href="gca1.html" class="active">GCA1 Home</a></li>
+  <li><a href="gca1-presentations.html">Presentations and Posters</a></li>
+  <li><a href="index.html">GEOS-Chem Home</a></li>
 </ul>
 </nav>
 </div>
 <!--main menu region end-->
-		
+
 <div id="columns" class="clearfix">
 <div class="hg-container">
 <div id="content-column" role="main">
@@ -94,47 +77,43 @@ The First Regional GEOS-Chem Asia Meeting<br>May 21-23, 2018
 <a name="main-content"></a>
 <h1 id="page-title" ng-non-bindable="">Overview</h1>
 </header>
-														
+
 <!--front panel regions beg-->
 <div id="content-panels" class="at-panel gpanel panel-display content clearfix">
 <div class="region region-content-top">
 <div class="region-inner clearfix">
 <div id="block-os-pages-main-content" class="block block-os-pages no-title"  module="os_pages" delta="main_content">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <div class="block-content content" ng-non-bindable="">
 <article id="node-1585687" class="node node-page article clearfix" role="article">
 <div class="node-content" ng-non-bindable="">
 <div class="field field-name-body field-type-text-with-summary field-label-hidden view-mode-full">
 <div class="field-items">
 <div class="field-item even">
-  
-<p style="text-align:center">
-	<img height="800" width="2000" alt="Group photo" class="media-element file-default file-os-files-xxlarge" src="img/gca1_group_photo.jpg" title="" /></p>
-
-<p>
-	<a href="img/gca1_group_photo.jpg" title="">Click for high-resolution photo!</a>
-</p>
-
-<p>
-	The First Regional GEOS-Chem Asia Meeting (GCA1) was held at Nanjing University of Information Science &amp; Technology (NUIST) on May 21-23, 2018 with 115 participants from 26 institutions and 7 countries. Follow the links for:
-</p>
-
-<ul><li>
-		<a href="gca1-presentations.html" target="_blank" title="">Oral and poster presentations from the meeting</a>;
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/17AhOSn_VKFl32gKguoR1ht0o5oW3LvW0/view?usp=drive_link">GCA1 participants list and contact information</a>.
-	</li>
-</ul><p>
-	The meeting was organized by the NUIST-Harvard <a href="https://projects.iq.harvard.edu/acmg-jlaqc" title="">Joint Laboratory for Air Quality and Climate (JLAQC)</a>.
-</p>
-
-<p>
-	We look forward to seeing you at the 2nd GEOS-Chem Asia meeting at NUIST in May 2020, and before that at the 9th International GEOS-Chem Meeting at Harvard on May 1-4, 2019!
-</p>
 
 <p style="text-align:center">
-	<img height="154" width="389" alt="GSA1 sponsors: Harvard NUIST, Nan Jin, University of Information Science and Technology" class="media-element file-default file-os-files-medium" src="img/gca1_sponsors.png" title="" /></p>
+  <img height="800" width="2000" alt="Group photo" class="media-element file-default file-os-files-xxlarge" src="img/gca1_group_photo.jpg" title="" /></p>
+
+<p>
+  <a href="img/gca1_group_photo.jpg" title="">Click for high-resolution photo!</a>
+</p>
+
+<p>The First Regional GEOS-Chem Asia Meeting (GCA1) was held at Nanjing University of Information Science &amp; Technology (NUIST) on May 21-23, 2018 with 115 participants from 26 institutions and 7 countries. Follow the links for:</p>
+
+<ul>
+  <li>
+    <a href="gca1-presentations.html" target="_blank" title="">Oral and poster presentations from the meeting</a>;
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/17AhOSn_VKFl32gKguoR1ht0o5oW3LvW0/view?usp=drive_link">GCA1 participants list and contact information</a>.
+  </li>
+</ul>
+
+<p>The meeting was organized by the NUIST-Harvard <a href="https://projects.iq.harvard.edu/acmg-jlaqc" title="">Joint Laboratory for Air Quality and Climate (JLAQC)</a>.</p>
+
+<p>We look forward to seeing you at the 2nd GEOS-Chem Asia meeting at NUIST in May 2020, and before that at the 9th International GEOS-Chem Meeting at Harvard on May 1-4, 2019!</p>
+
+<p style="text-align:center"><img height="154" width="389" alt="GSA1 sponsors: Harvard NUIST, Nan Jin, University of Information Science and Technology" class="media-element file-default file-os-files-medium" src="img/gca1_sponsors.png" title="" /></p>
 
 </div>
 </div>
@@ -154,64 +133,16 @@ The First Regional GEOS-Chem Asia Meeting<br>May 21-23, 2018
 </div>
 </div>
 
-<!--footer region beg-->
+<!--footer-->
 <footer id="footer" class="clearfix" role="contentinfo">
-
-<!-- Three column 3x33 Gpanel -->
-<div class="at-panel gpanel panel-display footer clearfix">
-<div class="region region-footer">
-<div class="region-inner clearfix">
-<div id="block-boxes-1617037690" class="block block-boxes block-boxes-os_boxes_html no-title"  module="boxes" delta="1617037690">
-<div class="block-inner clearfix">  
-<div class="block-content content" ng-non-bindable="">  
-<div id='boxes-box-1617037690' class='boxes-box'>  
 <div class="boxes-box-content">
   <p style="text-align:center">
-    Copyright © 2023 by the International GEOS-Chem Community. All rights reserved.
+    Copyright © 2026 by the International GEOS-Chem Community. All rights reserved.
   </p>
 </div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-<div class="region region-footer-bottom">  
-<div class="region-inner clearfix">  
-<div id="block-boxes-1616879798" class="block block-boxes block-boxes-os_boxes_media no-title"  module="boxes" delta="1616879798">  
-<div class="block-inner clearfix">  
-<div class="block-content content"> 
-<div id='boxes-box-1616879798' class='boxes-box'> 
-<div class="boxes-box-content"> 
-<div id="file-3900146" class="file file-html file-html-embed">
-<h2 class="element-invisible"><a href="">css-brand</a></h2>
-<div class="content">
-<div class="file-info">
-</div>
-<div class="field field-name-field-html-code field-type-text-long field-label-hidden view-mode-full">
-<div class="field-items">
-<div class="field-item even">
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-
-<!--footer region end-->
 </footer>
-</div>
-</div>
 
-<!--page area ends-->
-<div id="extradiv"></div>
+</div>
 </div>
 
 </body>

--- a/gca2-presentations.html
+++ b/gca2-presentations.html
@@ -1,9 +1,4 @@
 <!DOCTYPE html>
-<!--[if IEMobile 7]><html class="iem7"  lang="en" dir="ltr"><![endif]-->
-<!--[if lte IE 6]><html class="lt-ie9 lt-ie8 lt-ie7"  lang="en" dir="ltr"><![endif]-->
-<!--[if (IE 7)&(!IEMobile)]><html class="lt-ie9 lt-ie8"  lang="en" dir="ltr"><![endif]-->
-<!--[if IE 8]><html class="lt-ie9"  lang="en" dir="ltr"><![endif]-->
-<!--[if (gte IE 9)|(gt IEMobile 7)]><!--><html  lang="en" dir="ltr"><!--<![endif]-->
 <head>
 <meta charset="utf-8" />
 <!--<base href="/gca2" />-->
@@ -18,23 +13,12 @@
 <title>The 2nd Regional GEOS-Chem Asia Meeting</title>
 <meta http-equiv="x-ua-compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<link type="text/css" rel="stylesheet" href="css/css_xE-rWrJf-fncB6ztZfd2huxqgxu4WO-qwma6Xer30m4%EF%B9%96m=1675397288.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_1kR8T1_c-l5pBT6ZwbDT7BFda-4fyqW9Jjum29_2IY8%EF%B9%96m=1675397312.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_YnlUIvHP13qgpYEqubzE8JyDwlSxUnVibfnVkSoSDb0%EF%B9%96m=1675397273.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_Ku-3OcT9qU9h7dnGig5e23q6EVryY8orK4wzVDxsweE%EF%B9%96m=1675397367.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_vprtFTrWyg23GbY50_zJZHWGYMNfS8vsrRS26i4-ISk%EF%B9%96m=1675397406.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_dW-aNNrctRhQNc-KECjtQd0PxuW-h19IEum-TX2MeEk%EF%B9%96m=1675397301.css" media="print" />
-<link type="text/css" rel="stylesheet" href="css/css_SH2Lx3Qprh0GZo_9xRp85U9NsWfkSXn_Bi-rJoMY1sw%EF%B9%96m=1675397273.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_uaIDKcYMUK5osSQXuirpr3ZleXtnnpBN-eiECm7N0M0%EF%B9%96m=1675397395.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/responsive.blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/geos-chem.css" media="all"/>
 <script type="text/javascript" src="dropdown-menu.js"></script>
-<!--[if lte IE 8]>
-<script type="text/javascript">
-  var os_c = document.createElement;os_c('header');os_c('nav');os_c('section');os_c('article');os_c('aside');os_c('footer');os_c('hgroup');os_c('figure');
-</script>
-<![endif]-->
 </head>
 
 <body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-1585687 node-type-page og-context og-context-node og-context-node-1585652 navbar-on">
@@ -45,7 +29,7 @@
 <div id="page_wrap" class="page_wrap">
 <div id="page" class="container page header-main content-top footer-none">
 <div id="page-wrapper">
-		
+    
 <!--header regions beg-->
 <header id="header" class="clearfix" role="banner">
 <div id="header-container">
@@ -57,11 +41,8 @@
 <div class="block-content content" ng-non-bindable="">
 <div id='boxes-box-1617807424' class='boxes-box'>
 <div class="boxes-box-content">
-
-<h2 class="css-brand--css-geos-meetings-header-h2-xxxlarge">
 <a href="https://geoschem.github.io/"><img height="600" width="1034" style="float: right; width: 350px; height: 203px;" class="media-element file-default file-os-files-xxlarge" src="img/gca2_nuist.png" alt="" title="" /></a>
-The 2nd GEOS-Chem Asia Meeting (GCA2)<br>May 19-21, 2025
-</h2>
+<h2 class="css-brand--css-geos-meetings-header-h2-xxxlarge">The 2nd GEOS-Chem Asia Meeting (GCA2)<br>May 19-21, 2025</h2>
 
 </div>
 </div>
@@ -78,15 +59,16 @@ The 2nd GEOS-Chem Asia Meeting (GCA2)<br>May 19-21, 2025
 
 <!--main menu region beg-->
 <div id="menu-bar" class="nav region-menu-bar clearfix">
-<nav id="block-os-gac2-menu" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="gac2_menu">  
-<ul class="nice-menu nice-menu-down nice-menu-gac2_menu" id="nice-menu-gac2_menu">
-  <li class="menu-854289 menu-path-node-1585795  first   odd active-trail"><a href="gca2.html">Home</a></li>
-  <li class="menu-854305 menu-path-node-1585800   even"><a href="gca2-presentations.html" class="active active">Presentations</a></li>
+<nav id="block-os-gac2-menu" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="gac2_menu">
+<ul class="nice-menu nice-menu-down">
+  <li><a href="gca2.html" class="active">GCA2 Home</a></li>
+  <li><a href="gca2-presentations.html">Presentations and Posters</a></li>
+  <li><a href="index.html">GEOS-Chem Home</a></li>
 </ul>
 </nav>
 </div>
 <!--main menu region end-->
-		
+    
 <div id="columns" class="clearfix">
 <div class="hg-container">
 <div id="content-column" role="main">
@@ -96,7 +78,7 @@ The 2nd GEOS-Chem Asia Meeting (GCA2)<br>May 19-21, 2025
 <a name="main-content"></a>
 <h1 id="page-title" ng-non-bindable="">Presentations and Posters</h1>
 </header>
-														
+                            
 <!--front panel regions beg-->
 <div id="content-panels" class="at-panel gpanel panel-display content clearfix">
 <div class="region region-content-top">
@@ -111,607 +93,577 @@ The 2nd GEOS-Chem Asia Meeting (GCA2)<br>May 19-21, 2025
 <div class="field-item even">
 
 <p align="justify">
-	<strong>Mon, May 19: <a href="#MonA">Overview and Keynote Talks</a> | <a href="#MonB">Chemistry-climate-ecosystems interactions I</a> | <a href="#MonC">Chemistry-climate-ecosystems interactions II</a> | <a href="#MonD">Working group breakouts</a> | <a href="#MonE">Poster Session A</a></strong><br class="clearfix" />
-	<strong>Tue, May 20: <a href="#TueA">Emissions and mitigations</a> | <a href="#TueB">Chemistry</a> | <a href="#TueC">Aerosols</a> | <a href="#TueD">Model tutorials</a> | <a href="#TueE">Poster Sessions B-E</a></strong><br class="clearfix" />
-	<strong>Wed, May 21: <a href="#WedA">Air quality</a> | <a href="#WedB">WG Breakout Reports and Discussion</a></strong>
+  <strong>Mon, May 19: <a href="#MonA">Overview and Keynote Talks</a> | <a href="#MonB">Chemistry-climate-ecosystems interactions I</a> | <a href="#MonC">Chemistry-climate-ecosystems interactions II</a> | <a href="#MonD">Working group breakouts</a> | <a href="#MonE">Poster Session A</a></strong><br class="clearfix" />
+  <strong>Tue, May 20: <a href="#TueA">Emissions and mitigations</a> | <a href="#TueB">Chemistry</a> | <a href="#TueC">Aerosols</a> | <a href="#TueD">Model tutorials</a> | <a href="#TueE">Poster Sessions B-E</a></strong><br class="clearfix" />
+  <strong>Wed, May 21: <a href="#WedA">Air quality</a> | <a href="#WedB">WG Breakout Reports and Discussion</a></strong>
 </p>
 
-<h2>
-	Monday, May 19
-</h2>
+<h2>Monday, May 19</h2>
 
 
-<h4>
-	<a name="MonA" id="MonA"></a><strong>Overview and Keynote talks</strong>
-</h4>
+<h4><a name="MonA" id="MonA"></a><strong>Overview and Keynote talks</strong></h4>
 
 <ul>
-    <li>
-		Welcome (Yan Ma, NUIST)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1XZ9lyexB5SF71PuI_x80lE_ebGfttYXj/view?usp=sharing">GEOS-Chem model overview</a> (Daniel Jacob, Harvard )
-	</li>
-	<li>
-		Keynote: Emissions and health impacts of polycyclic aromatic hydrocarbons (Shu Tao, SUSTech/Peking U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1W3P4KINXudZ7O0ItoO7eRVc-B9N-xvIi/view?usp=sharing">Keynote: Diurnal variation in air quality in Asia as observed by GEMS</a> (Jhoon Kim, Yonsei University)
-	</li>
-	<li>
-		Keynote: Recent progress in atmospheric chemistry research in China (Tong Zhu, Peking U.)
-	</li>
+  <li>
+    Welcome (Yan Ma, NUIST)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1XZ9lyexB5SF71PuI_x80lE_ebGfttYXj/view?usp=sharing">GEOS-Chem model overview</a> (Daniel Jacob, Harvard )
+  </li>
+  <li>
+    Keynote: Emissions and health impacts of polycyclic aromatic hydrocarbons (Shu Tao, SUSTech/Peking U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1W3P4KINXudZ7O0ItoO7eRVc-B9N-xvIi/view?usp=sharing">Keynote: Diurnal variation in air quality in Asia as observed by GEMS</a> (Jhoon Kim, Yonsei University)
+  </li>
+  <li>
+    Keynote: Recent progress in atmospheric chemistry research in China (Tong Zhu, Peking U.)
+  </li>
 </ul>
 
-<h4>
-	<a name="MonB" id="MonB"></a><strong>Chemistry-climate-ecosystems interactions I</strong>
-</h4>
+<h4><a name="MonB" id="MonB"></a><strong>Chemistry-climate-ecosystems interactions I</strong></h4>
 
 <ul>
-    <li>
-		<a href="https://drive.google.com/file/d/1VXQBGF1XkTpwR6YRQ3z6u83vfT_RjMXI/view?usp=sharing">Estimating future climate change impacts on human mortality and crop yields via air pollution with GCAP2</a> (Lee Murray, U. of Rochester)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/13CacNYmyTeCUxzIPy8JOZOMERxC9cuO8/view?usp=sharing">Modeling biosphere-atmosphere interactions within GEOS-Chem via ecophysiology module</a> (Amos Tai, The Chinese U. of Hong Kong)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1KcbQkaR9giQvYLfnOSF3dydrHayCBteO/view?usp=sharing">Integration of atmospheric chemistry and terrestrial biogeochemistry to advance the understanding of global nitrogen cycle</a> (Cheng Gong, Max Planck Institute for Biogeochemistry)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/14DjQlGiM1B2xJyRI5mKRZdt-v4ZrtoZm/view?usp=sharing">Current and future PM2.5 trends in India: Influence of emissions, meteorology and climate change</a> (Mi Zhou, Princeton U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1I2GGSQz4FzJKzf_WVC_hUb_z7bog4xcI/view?usp=sharing">Effects of 2010-2045 climate change on ozone levels in China under carbon neutrality scenario: Key meteorological parameters and processes</a> (Ling Kang, NUIST)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1fUDHhk1q5q4nkPVIwVQ3PSzqKyzO-yu7/view?usp=sharing">Summertime ozone–temperature sensitivity in China and the United States</a> (Shuai Li, Sun Yat-sen U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1aNwg_FZME4_R6j4z04g5P7c38kVTRX4g/view?usp=sharing">Implementation and evaluation of the GEOS-Chem v14.0.1 withi Beijing Climate Centre Earth System Model (BCC-GEOS-Chem v2.0)</a> (Ruize Sun, Peking U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1GYiuAfMXT3YmudJE2YpbHPbSlp_5TwMe/view?usp=sharing">Developing the chemistry module for 27 fluorinated greenhouse gases (F-gases): Reactions, emissions, and implementation in GEOS-Chem</a> (Yali Li, SUSTech)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1ib9IlO1UsNxdi3J-zTFsXWYFIf-bjeLD/view?usp=sharing">Quantifying methane emission baselines and mitigation potential with high-resolution satellite data to support China’s 2023 Action Plan</a> (Huiru Zhong, Peking U.)
-	</li>
+  <li>
+    <a href="https://drive.google.com/file/d/1VXQBGF1XkTpwR6YRQ3z6u83vfT_RjMXI/view?usp=sharing">Estimating future climate change impacts on human mortality and crop yields via air pollution with GCAP2</a> (Lee Murray, U. of Rochester)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/13CacNYmyTeCUxzIPy8JOZOMERxC9cuO8/view?usp=sharing">Modeling biosphere-atmosphere interactions within GEOS-Chem via ecophysiology module</a> (Amos Tai, The Chinese U. of Hong Kong)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1KcbQkaR9giQvYLfnOSF3dydrHayCBteO/view?usp=sharing">Integration of atmospheric chemistry and terrestrial biogeochemistry to advance the understanding of global nitrogen cycle</a> (Cheng Gong, Max Planck Institute for Biogeochemistry)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/14DjQlGiM1B2xJyRI5mKRZdt-v4ZrtoZm/view?usp=sharing">Current and future PM2.5 trends in India: Influence of emissions, meteorology and climate change</a> (Mi Zhou, Princeton U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1I2GGSQz4FzJKzf_WVC_hUb_z7bog4xcI/view?usp=sharing">Effects of 2010-2045 climate change on ozone levels in China under carbon neutrality scenario: Key meteorological parameters and processes</a> (Ling Kang, NUIST)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1fUDHhk1q5q4nkPVIwVQ3PSzqKyzO-yu7/view?usp=sharing">Summertime ozone–temperature sensitivity in China and the United States</a> (Shuai Li, Sun Yat-sen U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1aNwg_FZME4_R6j4z04g5P7c38kVTRX4g/view?usp=sharing">Implementation and evaluation of the GEOS-Chem v14.0.1 withi Beijing Climate Centre Earth System Model (BCC-GEOS-Chem v2.0)</a> (Ruize Sun, Peking U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1GYiuAfMXT3YmudJE2YpbHPbSlp_5TwMe/view?usp=sharing">Developing the chemistry module for 27 fluorinated greenhouse gases (F-gases): Reactions, emissions, and implementation in GEOS-Chem</a> (Yali Li, SUSTech)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1ib9IlO1UsNxdi3J-zTFsXWYFIf-bjeLD/view?usp=sharing">Quantifying methane emission baselines and mitigation potential with high-resolution satellite data to support China’s 2023 Action Plan</a> (Huiru Zhong, Peking U.)
+  </li>
 </ul>
 
-<h4>
-	<a name="MonC" id="MonC"></a><strong>Chemistry-climate-ecosystems interactions II</strong>
-</h4>
+<h4><a name="MonC" id="MonC"></a><strong>Chemistry-climate-ecosystems interactions II</strong></h4>
 
 <ul>
-    <li>
-		<a href="https://drive.google.com/file/d/1V_5T1bgGJ7DRXZGJVILzh9V2aa-Apmew/view?usp=sharing">Keynote: Global nitrogen deposition embodied in international trade</a> (Qiang Zhang, Tsinghua U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1IusLM7l4bj5s5vLzVDCyu3R8q48_aqal/view?usp=sharing">Impacts of afforestation on summer surface ozone in China during 2000-2019</a> (Xu Yue, NUIST)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1gHWP9ijdqHiC3PUI2_aWpp38E3fcloIG/view?usp=sharing">Assessing air quality and health benefits of better managing natural and working lands against wildfires in California</a> (Yang Li, Baylor University)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1sq3Z7En51AnrR_GTcQ06fIUUe1GeRZdB/view?usp=sharing">Anthropogenic and meteorological drivers to surface ozone changes in China</a> (Zhe Jiang, Tianjin U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1ObIIZh_YygGRqtDo-J32Rmy3slv1jr6u/view?usp=sharing">Effect of temperature-dependent anthropogenic VOC emissions on ozone</a> (Wenlu Wu, SUSTech)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/11qAB3L9cZ4Ow7eUu0LbDGMzRj01mP_IG/view?usp=sharing">Role of increased fire emissions in surface ozone</a> (Danyuting Zhang, NUIST)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Hp4ES7xueJJpeY99qAkRX9unS9pX2ZOE/view?usp=sharing">Satellite-based monitoring of methane emissions from China’s rice hub</a> (Ruosi Liang, Westlake U.)
-	</li>
+  <li>
+    <a href="https://drive.google.com/file/d/1V_5T1bgGJ7DRXZGJVILzh9V2aa-Apmew/view?usp=sharing">Keynote: Global nitrogen deposition embodied in international trade</a> (Qiang Zhang, Tsinghua U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1IusLM7l4bj5s5vLzVDCyu3R8q48_aqal/view?usp=sharing">Impacts of afforestation on summer surface ozone in China during 2000-2019</a> (Xu Yue, NUIST)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1gHWP9ijdqHiC3PUI2_aWpp38E3fcloIG/view?usp=sharing">Assessing air quality and health benefits of better managing natural and working lands against wildfires in California</a> (Yang Li, Baylor University)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1sq3Z7En51AnrR_GTcQ06fIUUe1GeRZdB/view?usp=sharing">Anthropogenic and meteorological drivers to surface ozone changes in China</a> (Zhe Jiang, Tianjin U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1ObIIZh_YygGRqtDo-J32Rmy3slv1jr6u/view?usp=sharing">Effect of temperature-dependent anthropogenic VOC emissions on ozone</a> (Wenlu Wu, SUSTech)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/11qAB3L9cZ4Ow7eUu0LbDGMzRj01mP_IG/view?usp=sharing">Role of increased fire emissions in surface ozone</a> (Danyuting Zhang, NUIST)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Hp4ES7xueJJpeY99qAkRX9unS9pX2ZOE/view?usp=sharing">Satellite-based monitoring of methane emissions from China’s rice hub</a> (Ruosi Liang, Westlake U.)
+  </li>
 </ul>
 
-<h4>
-	<a name="MonD" id="MonD"></a><strong>GEOS-Chem working group breakouts</strong>
-</h4>
+<h4><a name="MonD" id="MonD"></a><strong>GEOS-Chem working group breakouts</strong></h4>
 
 <ul>
-    <li>
-		Chemistry-Climate WG (Chair: Lee Murray)
-	</li>
-	<li>
-		Inverse Modeling & Data Assimilation WG (Chair: Jun Wang)
-	</li>
-	<li>
-		Chemistry WG (Chair: Lu Hu)
-	</li>
-	<li>
-		Aerosols WG (Chair: Qi Chen)
-	</li>
-	<li>
-		Emissions WG (Chair: Jintai Lin)
-	</li>
-	<li>
-		Carbon Cycle WG (Chair: Zichong Chen)
-	</li>
-	<li>
-		Surface-Atmosphere Exchange WG (Chair: Amos Tai)
-	</li>
+  <li>
+    Chemistry-Climate WG (Chair: Lee Murray)
+  </li>
+  <li>
+    Inverse Modeling & Data Assimilation WG (Chair: Jun Wang)
+  </li>
+  <li>
+    Chemistry WG (Chair: Lu Hu)
+  </li>
+  <li>
+    Aerosols WG (Chair: Qi Chen)
+  </li>
+  <li>
+    Emissions WG (Chair: Jintai Lin)
+  </li>
+  <li>
+    Carbon Cycle WG (Chair: Zichong Chen)
+  </li>
+  <li>
+    Surface-Atmosphere Exchange WG (Chair: Amos Tai)
+  </li>
 </ul>
 
-<h4>
-	<a name="MonE" id="MonE"></a><strong>Poster Session A</strong>
-</h4>
+<h4><a name="MonE" id="MonE"></a><strong>Poster Session A</strong></h4>
 
 <ul>
-    <li>
-		<a href="https://drive.google.com/file/d/1KGTNuDLi3C1281gsqqzJrRpIA1NEb-h1/view?usp=sharing">A.1 Effects of agricultural ammonia emissions on global air quality under future climate change</a> (Xueyao Chen, The Chinese U. of Hong Kong)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1-nwqrsXzIjt3YoQEbOK-iVPryxkvO0xn/view?usp=sharing">A.2 Spatial optimization and management of crop-livestock system for sustainability</a> (Biao Luo, The Chinese U. of Hong Kong)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1JQUnDGl13QwcPsznvN-Q_beBJTuEa9NL/view?usp=sharing">A.3 Efficient machine learning frameworks predicting China's future air quality trends</a> (Fengwei Wan, Peking U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1w037E9H7mDt_ilu7MBVUQegiQDKIepnz/view?usp=sharing">A.4 Co-benefits between PM2.5 control and carbon reduction revealed by machine learning and GEOS-Chem model</a> (Han Xu, Nankai U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/15B4nk9VSflmmJyzlXEQYiA0AWyWhEn0d/view?usp=sharing">A.5 Shipping emission scenarios in China's Greater Bay Area: GEOS-Chem modeling of carbon-pollutant co-reduction under Dual Carbon policy leverage</a> (Huiran Feng, SUSTech)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1FqUm2MIpLhiIRj9jRCrUvZN9M4CZ0iNL/view?usp=sharing">A.6 Aggravated surface O3 pollution primarily driven by meteorological variations in China during the 2020 COVID-19 pandemic lockdown period</a> (Zhendong Lu, U. of Iowa)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1PsENF_zlxa8JpIqPE3xRuW6yfQUyT8eA/view?usp=sharing">A.7 Uncertainties in tropospheric ozone changes due to natural precursor emissions</a> (Xingpei Ye, Peking U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/15BtjLGyjFhQvgb3m0B-tlaUnLrEJBv58/view?usp=sharing">A.8 High-resolution earth system modeling study on the impact of typhoons on summer ozone in China</a> (Lixuan Wang, Ocean U. of China)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1ZLOJ4-yo1HBzAuUbUDkQTzqD1xbrXZLX/view?usp=sharing">A.9 Tropospheric ozone responses to the El Niño-Southern Oscillation (ENSO): quantification of individual processes and future projections from multiple chemical models</a> (Jingyu Li, Sun Yat-sen U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1HzkUKCKLmOyhRX0Yh1qOIqxM5yKWndLd/view?usp=sharing">A.10 An underappreciated cyclonic-like circulation driving high summer ozone in North China Plain</a> (Wenhao Qiao, NUIST)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/19DrIS2yjy-ilsDA8Bli0qwCmxE_4MsOw/view?usp=sharing">A.11 Synoptic drivers of springtime ozone transport across the Taiwan strait</a> (Xugeng Cheng, Fujian Normal U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Ydzc-vYsq3TZVergZiLTbcCWUb3mbvs8/view?usp=sharing">A.12 Impact of regional transport on high ozone episodes in southeast coastal regions of China</a> (Chende Ge, Fujian Normal U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/12zeommcmDAWx309Fl7WsjYcY2lQEhBT8/view?usp=sharing">A.13 The Impact of super El Niño events on surface ozone in the middle and eastern regions during winter and spring</a> (Liwei Fu, Fujian Normal U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1uI1Jp89_vpBNBvnCupMolYVZDxrREmX_/view?usp=sharing">A.14 Reducing global methane from agriculture and waste emissions to mitigate aerosol warming effect towards carbon neutrality</a> (Huibin Dai, Hong Kong Baptist U.)
-	</li>
-	<li>
-		A.15 The variation characteristics of O3 and PM2.5 in the Beijing-Tianjin-Hebei and Yangtze River Delta regions of China under extreme high temperatures in summer (Peifu Xie, NUIST)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1nh1phrjMv9BwwMMU0n7Up_icBxZFc3SE/view?usp=sharing">A.16 The VOCs-temperature relationship in China quantified by satellite observation and GEOS-Chem model</a> (Wenqing Zhao, NUIST)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Zg8G6rcLK30mMIIL0l569jn7Dp5TkI_2/view?usp=sharing">A.17 Impacts of smoke aerosol on air quality in northeast China: A GEOS-Chem modeling study</a> (Yu Shi, Jilin U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Jj_klbqSLAtZTIOGcoKLaTTTTGTQI5BM/view?usp=sharing">A.18 AI-based GEOS-Chem agent model</a> (Dehao Li, NUIST)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1e3Tfj0cGyrDIWFmMMTKbzXafimYoOq0O/view?usp=sharing">A.19 Enhanced impacts of dust event on photovoltaic potential in China with reduced anthropogenic air pollution</a> (Ke Yin, Sun Yat-sen U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1l-rMhncaD4tc8MSUoFxYe63UoFtVuU3l/view?usp=sharing">A.20 Sources of coarse particulate matter in China: Insights from explainable machine learning of extreme gradient boosting (XGBoost)</a> (Li Tsz Kit, The Chinese U. of Hong Kong)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1LitO8V0dRM4Otjv1lXnWN3qDcZFvHiRV/view?usp=sharing">A.21 Declining atmospheric sulfate deposition stimulates future wetland methane emissions</a> (Lu Shen, Peking U.)
-	</li>
-	<li>
-		A.22 Climate feedback of forest fires amplified by atmospheric chemistry (Wei Chen, Westlake U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/10lo7qAOkCeSg9n3rqkObfPM4WML2CfcE/view?usp=sharing">A.23 Atmospheric reactive nitrogen deposition to the global ocean during the 2010s: interannual variation and source attribution</a> (Shaofei Liu, Ocean U. of China)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1i08cv95rydEwrB_drZXw2LI7vLXrSV-R/view?usp=sharing">A.24 Regional differences and future changes of nitrogen deposition in the northwest pacific ocean</a> (Yizhen Lin, Ocean U. of China)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1R2ub5gfAS0UeBG0vnuEw_xIQP981k_iM/view?usp=sharing">A.25 Global atmospheric transport of microplastics: From emission to deposition</a> (Luyu Xiahou, SUSTech)
-	</li>
-	<li>
-		A.26 Research on data fusion techniques in a GEOS-Chem-based ground-satellite integrated carbon assimilation system (Baozhang Chen, NUIST)
-	</li>
-	<li>
-		A.27 Satellite-based atmospheric inversion of carbon dioxide fluxes at the urban scale (Ying Zhang, Aerospace Information Research Institute, CAS)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1QoZ_I6QT7_nGhDWjtjCWJ-3RplSdWDFd/view?usp=sharing">A.28 Carbon flux inversion based on GEOS-Chem model</a> (Yawen Kong, Aerospace Information Research Institute, CAS)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1N3S499sS_8ESO8mmDzM8yAl0_ClGcT1d/view?usp=sharing">A.29 A machine learning emulator of GHG sensitivities using CNN</a> (Shaomin Pan, Westlake U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1VvFYbLX_NgbnN51w0d7KeVglgZTrhC-u/view?usp=sharing">A.30 Global Rice Paddy Inventory (GRPI): A high-resolution inventory of methane emissions from rice agriculture based on Landsat satellite inundation data</a> (Zichong Chen, Hong Kong U. of Science and Technology Guangzhou)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1qmMRxn-3l5_qcnSNWSvkUMwBmfUPTmYo/view?usp=sharing">A.31 Reconciling the bottom-up and top-down estimates of the methane chemical sink using multiple observations</a> (Yuanhong Zhao, Ocean U. of China)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1n6zL5ZCU7XWgYcB6zJbSSE9tqRI0QFjV/view?usp=sharing">A.32 Influence of anthropogenic and natural emissions on CH4 lifetime since the Industrial Revolution</a> (Shengmin Lu, Ocean U. of China)
-	</li>
-	<li>
-		A.33 Quantify natural gas methane emissions from a city cluster in East China (Yujia Zhao, Zhejiang U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1KPKY5_awdw2soJrKXBiZ32mWoA8Rm-Po/view?usp=sharing">A.34 Quantifying long-term methane emissions and trends in China based on satellite observations</a> (Cheng He, Sun Yat-sen U.)
-	</li>
-	<li>
-		A.35 Towards the optimization of TanSat-2: assessment of a Large-Swath methane measurement (Sihong Zhu, IAP/CAS)
-	</li>
+  <li>
+    <a href="https://drive.google.com/file/d/1KGTNuDLi3C1281gsqqzJrRpIA1NEb-h1/view?usp=sharing">A.1 Effects of agricultural ammonia emissions on global air quality under future climate change</a> (Xueyao Chen, The Chinese U. of Hong Kong)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1-nwqrsXzIjt3YoQEbOK-iVPryxkvO0xn/view?usp=sharing">A.2 Spatial optimization and management of crop-livestock system for sustainability</a> (Biao Luo, The Chinese U. of Hong Kong)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1JQUnDGl13QwcPsznvN-Q_beBJTuEa9NL/view?usp=sharing">A.3 Efficient machine learning frameworks predicting China's future air quality trends</a> (Fengwei Wan, Peking U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1w037E9H7mDt_ilu7MBVUQegiQDKIepnz/view?usp=sharing">A.4 Co-benefits between PM2.5 control and carbon reduction revealed by machine learning and GEOS-Chem model</a> (Han Xu, Nankai U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/15B4nk9VSflmmJyzlXEQYiA0AWyWhEn0d/view?usp=sharing">A.5 Shipping emission scenarios in China's Greater Bay Area: GEOS-Chem modeling of carbon-pollutant co-reduction under Dual Carbon policy leverage</a> (Huiran Feng, SUSTech)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1FqUm2MIpLhiIRj9jRCrUvZN9M4CZ0iNL/view?usp=sharing">A.6 Aggravated surface O3 pollution primarily driven by meteorological variations in China during the 2020 COVID-19 pandemic lockdown period</a> (Zhendong Lu, U. of Iowa)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1PsENF_zlxa8JpIqPE3xRuW6yfQUyT8eA/view?usp=sharing">A.7 Uncertainties in tropospheric ozone changes due to natural precursor emissions</a> (Xingpei Ye, Peking U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/15BtjLGyjFhQvgb3m0B-tlaUnLrEJBv58/view?usp=sharing">A.8 High-resolution earth system modeling study on the impact of typhoons on summer ozone in China</a> (Lixuan Wang, Ocean U. of China)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1ZLOJ4-yo1HBzAuUbUDkQTzqD1xbrXZLX/view?usp=sharing">A.9 Tropospheric ozone responses to the El Niño-Southern Oscillation (ENSO): quantification of individual processes and future projections from multiple chemical models</a> (Jingyu Li, Sun Yat-sen U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1HzkUKCKLmOyhRX0Yh1qOIqxM5yKWndLd/view?usp=sharing">A.10 An underappreciated cyclonic-like circulation driving high summer ozone in North China Plain</a> (Wenhao Qiao, NUIST)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/19DrIS2yjy-ilsDA8Bli0qwCmxE_4MsOw/view?usp=sharing">A.11 Synoptic drivers of springtime ozone transport across the Taiwan strait</a> (Xugeng Cheng, Fujian Normal U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Ydzc-vYsq3TZVergZiLTbcCWUb3mbvs8/view?usp=sharing">A.12 Impact of regional transport on high ozone episodes in southeast coastal regions of China</a> (Chende Ge, Fujian Normal U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/12zeommcmDAWx309Fl7WsjYcY2lQEhBT8/view?usp=sharing">A.13 The Impact of super El Niño events on surface ozone in the middle and eastern regions during winter and spring</a> (Liwei Fu, Fujian Normal U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1uI1Jp89_vpBNBvnCupMolYVZDxrREmX_/view?usp=sharing">A.14 Reducing global methane from agriculture and waste emissions to mitigate aerosol warming effect towards carbon neutrality</a> (Huibin Dai, Hong Kong Baptist U.)
+  </li>
+  <li>
+    A.15 The variation characteristics of O3 and PM2.5 in the Beijing-Tianjin-Hebei and Yangtze River Delta regions of China under extreme high temperatures in summer (Peifu Xie, NUIST)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1nh1phrjMv9BwwMMU0n7Up_icBxZFc3SE/view?usp=sharing">A.16 The VOCs-temperature relationship in China quantified by satellite observation and GEOS-Chem model</a> (Wenqing Zhao, NUIST)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Zg8G6rcLK30mMIIL0l569jn7Dp5TkI_2/view?usp=sharing">A.17 Impacts of smoke aerosol on air quality in northeast China: A GEOS-Chem modeling study</a> (Yu Shi, Jilin U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Jj_klbqSLAtZTIOGcoKLaTTTTGTQI5BM/view?usp=sharing">A.18 AI-based GEOS-Chem agent model</a> (Dehao Li, NUIST)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1e3Tfj0cGyrDIWFmMMTKbzXafimYoOq0O/view?usp=sharing">A.19 Enhanced impacts of dust event on photovoltaic potential in China with reduced anthropogenic air pollution</a> (Ke Yin, Sun Yat-sen U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1l-rMhncaD4tc8MSUoFxYe63UoFtVuU3l/view?usp=sharing">A.20 Sources of coarse particulate matter in China: Insights from explainable machine learning of extreme gradient boosting (XGBoost)</a> (Li Tsz Kit, The Chinese U. of Hong Kong)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1LitO8V0dRM4Otjv1lXnWN3qDcZFvHiRV/view?usp=sharing">A.21 Declining atmospheric sulfate deposition stimulates future wetland methane emissions</a> (Lu Shen, Peking U.)
+  </li>
+  <li>
+    A.22 Climate feedback of forest fires amplified by atmospheric chemistry (Wei Chen, Westlake U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/10lo7qAOkCeSg9n3rqkObfPM4WML2CfcE/view?usp=sharing">A.23 Atmospheric reactive nitrogen deposition to the global ocean during the 2010s: interannual variation and source attribution</a> (Shaofei Liu, Ocean U. of China)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1i08cv95rydEwrB_drZXw2LI7vLXrSV-R/view?usp=sharing">A.24 Regional differences and future changes of nitrogen deposition in the northwest pacific ocean</a> (Yizhen Lin, Ocean U. of China)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1R2ub5gfAS0UeBG0vnuEw_xIQP981k_iM/view?usp=sharing">A.25 Global atmospheric transport of microplastics: From emission to deposition</a> (Luyu Xiahou, SUSTech)
+  </li>
+  <li>
+    A.26 Research on data fusion techniques in a GEOS-Chem-based ground-satellite integrated carbon assimilation system (Baozhang Chen, NUIST)
+  </li>
+  <li>
+    A.27 Satellite-based atmospheric inversion of carbon dioxide fluxes at the urban scale (Ying Zhang, Aerospace Information Research Institute, CAS)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1QoZ_I6QT7_nGhDWjtjCWJ-3RplSdWDFd/view?usp=sharing">A.28 Carbon flux inversion based on GEOS-Chem model</a> (Yawen Kong, Aerospace Information Research Institute, CAS)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1N3S499sS_8ESO8mmDzM8yAl0_ClGcT1d/view?usp=sharing">A.29 A machine learning emulator of GHG sensitivities using CNN</a> (Shaomin Pan, Westlake U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1VvFYbLX_NgbnN51w0d7KeVglgZTrhC-u/view?usp=sharing">A.30 Global Rice Paddy Inventory (GRPI): A high-resolution inventory of methane emissions from rice agriculture based on Landsat satellite inundation data</a> (Zichong Chen, Hong Kong U. of Science and Technology Guangzhou)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1qmMRxn-3l5_qcnSNWSvkUMwBmfUPTmYo/view?usp=sharing">A.31 Reconciling the bottom-up and top-down estimates of the methane chemical sink using multiple observations</a> (Yuanhong Zhao, Ocean U. of China)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1n6zL5ZCU7XWgYcB6zJbSSE9tqRI0QFjV/view?usp=sharing">A.32 Influence of anthropogenic and natural emissions on CH4 lifetime since the Industrial Revolution</a> (Shengmin Lu, Ocean U. of China)
+  </li>
+  <li>
+    A.33 Quantify natural gas methane emissions from a city cluster in East China (Yujia Zhao, Zhejiang U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1KPKY5_awdw2soJrKXBiZ32mWoA8Rm-Po/view?usp=sharing">A.34 Quantifying long-term methane emissions and trends in China based on satellite observations</a> (Cheng He, Sun Yat-sen U.)
+  </li>
+  <li>
+    A.35 Towards the optimization of TanSat-2: assessment of a Large-Swath methane measurement (Sihong Zhu, IAP/CAS)
+  </li>
 </ul>
 
-<h2>
-	Tuesday, May 20
-</h2>
+<h2>Tuesday, May 20</h2>
 
-<h4>
-	<a name="TueA" id="TueA"></a><strong>Emissions and mitigations</strong>
-</h4>
+<h4><a name="TueA" id="TueA"></a><strong>Emissions and mitigations</strong></h4>
 
 <ul>
-    <li>
-		<a href="https://drive.google.com/file/d/1W6f69sazG_TWGWfDu30aNzBWR23n0NIF/view?usp=sharing">Keynote: Towards Health-Oriented Air Pollution Control in China</a> (Shuxiao Wang, Tsinghua U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1QxNo--_3u-1q6Cn5ZjyksNFHvxlN-Aot/view?usp=sharing">Keynote: A new perspective to frame the advances of the tropospheric chemistry for air quality management</a> (Keding Lu, Peking U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1iqCF4SDYIRuD4SGacfQmzi0ekSH0aozn/view?usp=sharing">Towards satellite-based monthly kilometer resolution emission estimates</a> (Jintai Lin, Peking U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1jXxE8vsh91WLP_I5i5gdkkbKbNlANjpE/view?usp=sharing">Climate action has the potential to ameliorate, perpetuate, or exacerbate geopolitical air pollution inequalities</a> (Daven Henze, University of Colorado, Boulder)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1vPi6YVil8LhyVf8rIxQEJKeQMNmY04fD/view?usp=sharing">Provincial economic and air quality-related health impacts of China’s potential partitioned carbon regulation</a> (Mingwei Li, Tsinghua U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1aNpqH1gO8ZnNqrCigj4qssaSUVtIzYi5/view?usp=sharing">Direct and indirect consumption activities drive distinct urban-rural inequalities in air pollution-related mortality in China</a> (Jingxu Wang, Ocean U. of China)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1n1uN9FP9fCxsA7jNg3ePUNQ4DedS3T4V/view?usp=sharing">Tracing sources of city-level PM2.5 exposure in China using GEOS-Chem adjoint model</a> (Yixuan Gu, NUIST)
-	</li>
+  <li>
+    <a href="https://drive.google.com/file/d/1W6f69sazG_TWGWfDu30aNzBWR23n0NIF/view?usp=sharing">Keynote: Towards Health-Oriented Air Pollution Control in China</a> (Shuxiao Wang, Tsinghua U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1QxNo--_3u-1q6Cn5ZjyksNFHvxlN-Aot/view?usp=sharing">Keynote: A new perspective to frame the advances of the tropospheric chemistry for air quality management</a> (Keding Lu, Peking U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1iqCF4SDYIRuD4SGacfQmzi0ekSH0aozn/view?usp=sharing">Towards satellite-based monthly kilometer resolution emission estimates</a> (Jintai Lin, Peking U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1jXxE8vsh91WLP_I5i5gdkkbKbNlANjpE/view?usp=sharing">Climate action has the potential to ameliorate, perpetuate, or exacerbate geopolitical air pollution inequalities</a> (Daven Henze, University of Colorado, Boulder)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1vPi6YVil8LhyVf8rIxQEJKeQMNmY04fD/view?usp=sharing">Provincial economic and air quality-related health impacts of China’s potential partitioned carbon regulation</a> (Mingwei Li, Tsinghua U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1aNpqH1gO8ZnNqrCigj4qssaSUVtIzYi5/view?usp=sharing">Direct and indirect consumption activities drive distinct urban-rural inequalities in air pollution-related mortality in China</a> (Jingxu Wang, Ocean U. of China)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1n1uN9FP9fCxsA7jNg3ePUNQ4DedS3T4V/view?usp=sharing">Tracing sources of city-level PM2.5 exposure in China using GEOS-Chem adjoint model</a> (Yixuan Gu, NUIST)
+  </li>
 </ul>
 
-<h4>
-	<a name="TueB" id="TueB"></a><strong>Chemistry</strong>
-</h4>
+<h4><a name="TueB" id="TueB"></a><strong>Chemistry</strong></h4>
 
 <ul>
-    <li>
-		Simulation of PyroCB impact on stratospheric chemistry in GEOS-Chem (Jun Wang, U. of Iowa)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1TEUds7RUQknQMkGGWQWAbthLERS5zk7b/view?usp=sharing">Increased urban ozone in heat waves due to temperature-induced emissions of anthropogenic volatile organic compounds</a> (Jianlin Hu, NUIST)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1TUQxCRJWnjvTW_h2dgtCeG33a0qtXsby/view?usp=sharing">Acidity-driven gas-particle partitioning of nitrate through the industrial era</a> (Shohei Hattori, Nanjing U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1f4rbySkhECkBkpdVt3wVgi1jsC5hP3K0/view?usp=sharing">Tropospheric reactive chlorine chemistry modeling</a> (Qianjie Chen, The Hong Kong Polytechnic U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1KwY6WbCNNnGKxczlXtIbGUJ_kY-87T_m/view?usp=sharing">Modelling of iodic acid and its impact on aerosol mass</a> (Leyang Liu, City U. of Hong Kong)
-	</li>
-	<li>
-		Modeling comparison of multiple chemical pathways’ contributions to sulfate formation (Xinyi Dong, Nanjing U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1W-fe2hof8PjfBGxBtXQN_rsb97Cm6Lnj/view?usp=sharing">Revisiting the global atmospheric glyoxal budget: updates in secondary production from terrestrial and marine precursors and evaluations against satellite observations</a> (Aoxing Zhang, SUSTech)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1GPYMafBb577VX0k2JhrLZJP9cGfNID9I/view?usp=sharing">Observing atmospheric composition (CO, NH3, O3, SO2, VOCs) from China's FengYun LEO and GEO satellites</a> (Zhaocheng Zeng, Peking U.)
-	</li>
-	<li>
-		Quantify natural gas methane emissions from a city cluster in East China (Yuzhong Zhang, Westlake U.)
-	</li>
+  <li>
+    Simulation of PyroCB impact on stratospheric chemistry in GEOS-Chem (Jun Wang, U. of Iowa)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1TEUds7RUQknQMkGGWQWAbthLERS5zk7b/view?usp=sharing">Increased urban ozone in heat waves due to temperature-induced emissions of anthropogenic volatile organic compounds</a> (Jianlin Hu, NUIST)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1TUQxCRJWnjvTW_h2dgtCeG33a0qtXsby/view?usp=sharing">Acidity-driven gas-particle partitioning of nitrate through the industrial era</a> (Shohei Hattori, Nanjing U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1f4rbySkhECkBkpdVt3wVgi1jsC5hP3K0/view?usp=sharing">Tropospheric reactive chlorine chemistry modeling</a> (Qianjie Chen, The Hong Kong Polytechnic U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1KwY6WbCNNnGKxczlXtIbGUJ_kY-87T_m/view?usp=sharing">Modelling of iodic acid and its impact on aerosol mass</a> (Leyang Liu, City U. of Hong Kong)
+  </li>
+  <li>
+    Modeling comparison of multiple chemical pathways’ contributions to sulfate formation (Xinyi Dong, Nanjing U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1W-fe2hof8PjfBGxBtXQN_rsb97Cm6Lnj/view?usp=sharing">Revisiting the global atmospheric glyoxal budget: updates in secondary production from terrestrial and marine precursors and evaluations against satellite observations</a> (Aoxing Zhang, SUSTech)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1GPYMafBb577VX0k2JhrLZJP9cGfNID9I/view?usp=sharing">Observing atmospheric composition (CO, NH3, O3, SO2, VOCs) from China's FengYun LEO and GEO satellites</a> (Zhaocheng Zeng, Peking U.)
+  </li>
+  <li>
+    Quantify natural gas methane emissions from a city cluster in East China (Yuzhong Zhang, Westlake U.)
+  </li>
 </ul>
 
-<h4>
-	<a name="TueC" id="TueC"></a><strong>Aerosols</strong>
-</h4>
+<h4><a name="TueC" id="TueC"></a><strong>Aerosols</strong></h4>
 
 <ul>
-    <li>
-		<a href="https://drive.google.com/file/d/10wa4gHFBfi6kpPSftdCjYqa7reNGZsnO/view?usp=sharing">Keynote: Aerosol organic nitrogen: measurements, ambient abundance and sources</a> (Jianzhen Yu, Hong Kong U. of Science and Technology)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1L3w50PmBbn7472cGHO1_HxynAySpOpz7/view?usp=sharing">Nitrogen dominates global organic aerosol absorption</a> (Tzung-May Fu, SUSTech)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1GWMwWp86gBTcDvl5nXq6PFhmdOry34Zr/view?usp=sharing">Revisiting global organic aerosol budget based on a unified I/SVOC modeling framework</a> (Qi Chen, Peking U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1oKzneak5fQ1yllFHoqHm5cfVXU33ShGe/view?usp=sharing">Estimates of IVOCs emission and its contribution to SOA in China</a> (Qiaoqiao Wang, Jinan U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1EoYFLsnfauyBYDq9SxwqQpNrS5AblnrH/view?usp=sharing">Modeling the Global Impact of Chlorine Chemistry on Secondary Organic Aerosols</a> (Xi Liu, City U. of Hong Kong)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1ev4jvkK55iemMknIVPZpGdtRqT33zxDc/view?usp=sharing">GEOS-Chem modeling of dust aerosol outbreaks in Northeast China</a> (Gennadii Milinevsky, Jilin U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1tQ59mE2QUF3XJwD0njt7_Lv-Nla4c8pk/view?usp=sharing">Using machine learning calibrated GEOS-Chem outputs to estimate global daily fire-sourced air pollution</a> (Rongbin Xu, Chongqing U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/163bLH7mXraS9h7qA57xG0yCcmRoJQsdn/view?usp=sharing">Identifying cost-effective emission control pathways to meet air quality targets in key regions of China with adjoint method</a> (Ni Lu, Peking U.)
-	</li>
+  <li>
+    <a href="https://drive.google.com/file/d/10wa4gHFBfi6kpPSftdCjYqa7reNGZsnO/view?usp=sharing">Keynote: Aerosol organic nitrogen: measurements, ambient abundance and sources</a> (Jianzhen Yu, Hong Kong U. of Science and Technology)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1L3w50PmBbn7472cGHO1_HxynAySpOpz7/view?usp=sharing">Nitrogen dominates global organic aerosol absorption</a> (Tzung-May Fu, SUSTech)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1GWMwWp86gBTcDvl5nXq6PFhmdOry34Zr/view?usp=sharing">Revisiting global organic aerosol budget based on a unified I/SVOC modeling framework</a> (Qi Chen, Peking U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1oKzneak5fQ1yllFHoqHm5cfVXU33ShGe/view?usp=sharing">Estimates of IVOCs emission and its contribution to SOA in China</a> (Qiaoqiao Wang, Jinan U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1EoYFLsnfauyBYDq9SxwqQpNrS5AblnrH/view?usp=sharing">Modeling the Global Impact of Chlorine Chemistry on Secondary Organic Aerosols</a> (Xi Liu, City U. of Hong Kong)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1ev4jvkK55iemMknIVPZpGdtRqT33zxDc/view?usp=sharing">GEOS-Chem modeling of dust aerosol outbreaks in Northeast China</a> (Gennadii Milinevsky, Jilin U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1tQ59mE2QUF3XJwD0njt7_Lv-Nla4c8pk/view?usp=sharing">Using machine learning calibrated GEOS-Chem outputs to estimate global daily fire-sourced air pollution</a> (Rongbin Xu, Chongqing U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/163bLH7mXraS9h7qA57xG0yCcmRoJQsdn/view?usp=sharing">Identifying cost-effective emission control pathways to meet air quality targets in key regions of China with adjoint method</a> (Ni Lu, Peking U.)
+  </li>
 </ul>
 
-<h4>
-	<a name="TueD" id="TueD"></a><strong>GEOS-Chem model tutorials</strong>
-</h4>
+<h4><a name="TueD" id="TueD"></a><strong>GEOS-Chem model tutorials</strong></h4>
 
 <ul>
-    <li>
-		<a href="https://drive.google.com/file/d/1cnXYmxuPQE1f5u8EJxwcEoSGzr3-SMma/view?usp=sharing">Running GEOS-Chem with WRF (WRF-GC)</a> (Aoxing Zhang and Ao Ding, SUSTech)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1pr9d9YFTSi-AVoNlZBj3jvcMAFPogrjL/view?usp=sharing">Working with the high-performance</a> GEOS-Chem (GCHP) (Xingpei Ye, Peking U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1HIBZ9hXokcNHUbz983mCvRUqtfapYYpw/view?usp=sharing">Working with the GEOS-Chem adjoint</a> (Daven Henze, CU Boulder)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/106difw2sH-hWH2wgYprJgGFkvFb8Qsrd/view?usp=sharing">Running GC within CESM</a> (Haipeng Lin, NCAR)
-	</li>
+  <li>
+    <a href="https://drive.google.com/file/d/1cnXYmxuPQE1f5u8EJxwcEoSGzr3-SMma/view?usp=sharing">Running GEOS-Chem with WRF (WRF-GC)</a> (Aoxing Zhang and Ao Ding, SUSTech)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1pr9d9YFTSi-AVoNlZBj3jvcMAFPogrjL/view?usp=sharing">Working with the high-performance</a> GEOS-Chem (GCHP) (Xingpei Ye, Peking U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1HIBZ9hXokcNHUbz983mCvRUqtfapYYpw/view?usp=sharing">Working with the GEOS-Chem adjoint</a> (Daven Henze, CU Boulder)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/106difw2sH-hWH2wgYprJgGFkvFb8Qsrd/view?usp=sharing">Running GC within CESM</a> (Haipeng Lin, NCAR)
+  </li>
 </ul>
 
-<h4>
-	<a name="TueE" id="TueE"></a><strong>Poster Sessions B-E</strong>
-</h4>
+<h4><a name="TueE" id="TueE"></a><strong>Poster Sessions B-E</strong></h4>
 
 <ul>
-    <li>
-		<a href="https://drive.google.com/file/d/1jTKS6n4ZT2UwDcKaivTHy1vPv1UFGjh5/view?usp=sharing">B.1 Inversion of high temporal resolution NOx emissions over China</a> (Yi Wang, China U. of Geosciences)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1ZtjFBtyQ4TougOGBZDjCxwToA1cYe2bv/view?usp=sharing">B.2 Significant inequality shown in Chinese provincial export-related PM2.5 pollution and their contributors</a> (Zhengzhong Liu, Ocean U. of China)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1L_HS-mEbK0HpvjQsdyJCzTpCZb74IRQ8/view?usp=sharing">B.3 Tracing Hg Indian anthropogenic emissions over the Indian region</a> (Malasani Chakradhar Reddy, Indian Institute of Technology Madras)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1sUSZt-eNHyrs8IWbJCB7MYjGqZ1g_ZVO/view?usp=sharing">B.4 Optimize anthropogenic coarse particulate matter (ACPM) emissions using Bayesian inverse analysis with observations</a> (Yuxin Sun, City U. of Hong Kong)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1FUhlaan8uC2rcW423cZvohvQI3ImQf9n/view?usp=sharing">B.5 Global anthropogenic continental emissions of atmospheric bromine</a> (Yixuan Chen, City U. of Hong Kong)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1BBSU0RvaI0Ouh0f-2Nbs8bWihI0ig0Iw/view?usp=sharing">B.6 Unexpected high ammonia emissions from boreal fires in 2021 and 2023</a> (Qiwen Chen, Ocean U. of China)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1I7-4jVijIVm_zqf-1zbJnytwvYQWYkFb/view?usp=sharing">B.7 Impact of two Sentinel 5 NO2 data products on assimilation of anthropogenic NOx emissions</a> (Wenhui Dong, China U. of Geosciences)
-	</li>
-	<li>
-		B.8 Black carbon emission inversion over China during the Clean Air Action Plan (Li Fang, NUIST)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Gb3LAhCAUwAFXUQ3FH-ou2rT5-7JRoNa/view?usp=sharing">B.9 South Asia anthropogenic ammonia emission inversion through assimilating IASI observations</a> (Ji Xia, NUIST)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1S0IXue445ppZuRiRYnpFBiFNVoorMDou/view?usp=sharing">B.10 NMVOCs emission optimization in China through assimilating formaldehyde retrievals from multiple satellite products</a> (Canjie Xu, NUIST)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1-IQmiBdTu0Op4-eMU2bQvfHrIRf6X03U/view?usp=sharing">C.1 Assessing GEOS-Chem chemical mechanism in fresh biomass burning smoke</a> (Lu Hu, U. of Montana)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1j_10l0OMAUUtnHI-WPXncrf5Nw1BpTiF/view?usp=sharing">C.2 Tagging-based source attribution of expanded odd oxygen family (Oy) to volatile organic compounds (VOCs): a case study of heavy ozone pollution episode over the East China</a> (Wei Tao, SUSTech)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1JMeT_9ShpuVSdk2nxUIeQARtKW5lfK3B/view?usp=sharing">C.3 Evaluating key OVOCs in China using GEOS-Chem (14.4.1): model performance, chemical budgets, and implications for ozone simulation</a> (Enyu Xiong, SUSTech)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1rSPuFInWPLqOf94tyQicyKLWqUJp97_s/view?usp=sharing">C.4 Intercomparison of diurnal HCHO variations from GEMS and GEOS-Chem: Implications on NMVOC emission</a> (Weitao Fu, SUSTech)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/16pUc4W42XFimbbJm0b2rhMrlHiZH7Pnx/view?usp=sharing">C.5 Impact of key HONO heterogeneous processes on ozone formation in China</a> (Yaqing Zhou, Jinan U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/19WsGzbqEQ2a-v2BzklMMscKlccG3bEoU/view?usp=sharing">C.6 Physically-based parameterization of the sub-grid variability in biogenic volatile organic compound emissions for resolutionindependent estimates using the MEGAN v2.1 algorithm</a> (Yiheng Chen, SUSTech)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1L4OYvm6jrcetg8u4qAJF1_WIbI8x3jfT/view?usp=sharing">C.7 Atmospheric source of mercury to the ocean constrained by isotopic model</a> (Zhengcheng Song, Nanjing U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1HVKNnIBKB16VACflHnTm0aA79R-THYak/view?usp=sharing">C.8 Impact of anthropogenic chlorine chemistry over Indian region</a> (Ankit Patel, Indian Institute of Technology Madras)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1O-HrF6yyz81PIEkmKGhe8FFfS_TlE3kp/view?usp=sharing">C.9 Sulfate isotope constrain SO2 oxidation pathways in global model</a> (Yan Yang, The Hong Kong Polytechnic U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1DWKTvdLx82wwaLYdYj4gEREgN9Gtj9Wj/view?usp=sharing">C.10 Investigating NOx sources and sinks over the Tibet Plateau with GEMS satellite observations and GEOS-Chem model simulations</a> (Xue Zhang, SUSTech)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1ZcGCRSihlG6a1yoFAov-UCSYtxfqGGpo/view?usp=sharing">D.1 Warming by water-insoluble dark brown carbon from biomass burning</a> (Xuan Wang, City U. of Hong Kong)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1W3lvEeieKqa_z4IwjHcISVEZhzr9Ui9q/view?usp=sharing">D.2 Global high-resolution fire-sourced PM2.5 concentrations for 2000–2023</a> (Chenguang Tian, NUIST)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1fu1_-KSfA9K6JKUHdG6v1nt9d3IDBzH9/view?usp=sharing">D.3 Environmental and climate effects of agricultural reactive nitrogen and methane under carbon neutrality scenarios</a> (Tian Tian, NUIST)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1ZJ2hQ2fyZQGaVRVyaiBSVK4QQKzejiaT/view?usp=sharing">D.4 Comparative assessment of global fire emission inventories: long-term trends and case studies</a> (Hanyue Zheng, Xi'an Jiaotong-Liverpool U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/15D4pZVxXAckYsdV45qyNY-9Qj1ikYACq/view?usp=sharing">D.5 Impacts of stubble burning in northwestern India on Delhi's air quality during post-monsoon season</a> (Haoyu Wei, NUIST)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1vZ_sqdWOmvbnaGt63KP5RP6gbTe4s19Y/view?usp=sharing">D.6 GEOS-Chem simulations of hydroxymethanesulfonate aerosols in North China Plain</a> (Shaojie Song, Nankai U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/13sF8DfghAishaftfp81G_H1DtRKQ36XN/view?usp=sharing">D7. Analysis of new particle formation events: Comparison of particle number concentrations based on GEOS-Chem-APM in North China Plain</a> (Yingying Ku, NUIST)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/14ameuEJE_0vAAtdz1Wlo1r0n5o-UuFNz/view?usp=sharing">D.8 Calculation of triple oxygen isotope tracers in methanosulfonate (MSA) for tracing atmospheric DMS chemistry</a> (Yihang Hong, Nanjing U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1se8GlQWae3OJJ9jYdJyLMaFC_6R3dNzM/view?usp=sharing">D.9 Evaluating simulations of volatility distribution and oxygenation state of organic aerosols in eastern China</a> (Momei Qin, NUIST)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/11PsB3xsz2Uf7E0l3Oqi2ZTLNh1P9PYbS/view?usp=sharing">D.10 Underappreciated contributions of secondary organic aerosol from mobile sources to air quality in China</a> (Ruqian Miao, Peking U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1NHLsjfuSYscUsbA3q9DfKcP9VjaOngPE/view?usp=sharing">D.11 Global modeling of organic aerosols based on a new full-volatility emission inventory and an updated mechanism in GEOS-Chem</a> (Ruochong Xu, Tsinghua U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Blmv8f44sbY4LQlnlcvq-5j1EoZWlD57/view?usp=sharing">D.12 Effects of organic coatings, seed aerosols, and acidity on the generation of isoprene-epoxydiol-derived secondary organic aerosols in Eastern China</a> (Fengyi Chang, NUIST)
-	</li>
-	<li>
-		D.13 Fractal geometry of aerosol particles model and its impact on atmospheric optical properties and land surface radiation budget (Zhenxin Liu, NUIST)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1-6ZvTkmfWFdyd7G2UTq9l3O4gYrDvVYQ/view?usp=sharing">D.14 Simulations and Predictions of Long-Term Trends in Inorganic Aerosol Water Content and Acidity for Winter in the North China Plain</a>  (Haoqi Wang, Nankai U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1oBQcRswIXNW54WULBC_es2zBZdmi0UbI/view?usp=sharing">D.15 Freeze-thaw process boosts penguin-derived NH3 emissions and enhances climate-relevant particles formation in Antarctica</a> (Rong Tian, Third Institute of Oceanography)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/117Ee05ZFzHqFI1M4_P-MMj5zB4T8huo2/view?usp=sharing">E.1 Utilizing GEOS-Chem aerosol prediction for investigating ultrafine particles and supporting air quality management in Thailand</a> (Si Thu Kyaw, Chulalongkorn U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/10LjNiDmpEX5NyhPLjALyvSI0fUVF_2yl/view?usp=sharing">E.2 Simulation of fine particulate matter pollution in the Indo-Gangetic Plain</a> (Siyi Liu, Peking U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1FODMfg1F6UoA7YROLQZAqRikEcvimJ1p/view?usp=sharing">E.3 Modelling global levoglucosan concentration with chemical loss and its inisight into biomass burning contribution to OC</a> (Xingyu Nan, SUSTech)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/185qKM3s-867A_FewoC6OzO2AIyqyn3Hg/view?usp=sharing">E.4 Reassessing O3 and PM2.5 concentrations in urban and suburban China with GEOS-Chem model</a> (Ning Yang, Jinan U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1gBEnwNIvKv_yT0PQRDMxyTuYjGQRd8GA/view?usp=sharing">E.5 Day and night, outdoor and indoor variations of aerosol properties and air quality in Changchun</a> (Xuanyi Wei, Jilin U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1lOQ-vUZP6W6_wGoin7L-HVQYwz0Xqpy2/view?usp=sharing">E.6 Opportunities to mitigate PM2.5 and nitrogen deposition through agricultural NH3 control strategies in China’s Beijing-Tianjin-Hebei region</a> (Lu Li, Peking U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1g7PRfyF451k2ZqlySJXnwkr3bE8_KCLr/view?usp=sharing">E.7 Evolving global oceanic nitrogen deposition under future emission pathways and responses to nitrogen emission reductions</a> (Jialin Deng, Peking U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1SkMFSyEtr7Oq96Mk_8eiDvbISfE2Gg4q/view?usp=sharing">E.8 Regional transport of peroxyacetyl nitrate (PAN) within Eastern China and its impact on ozone</a> (Tiangang Yuan, The Chinese U. of Hong Kong)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1V4UFy7LM2Sng1dfsa_ZSZTG-THSzeAmN/view?usp=sharing">E.9 Evaluating long term trend atmospheric oxidation capacity in China using GC14.3.1</a> (Tianci Jiang, SUSTech)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Y-BFVsJHAT07qfDul6jiipNNYIxkIV22/view?usp=sharing">E.10 Satellite data constraints for emissions inventories</a> (Herizo Narivelo, Université de Toulouse)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/17QDr_25c1BBw6UJOpTmrXTz0Tz2CrpYI/view?usp=sharing">E.11 The role of diurnally varying African biomass burning emissions on tropospheric ozone</a> (Haolin Wang, Hong Kong Baptist U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1FjUtN3xZlV8T6IEzMJXJUru7vj9ROXrJ/view?usp=sharing">E.12 Source of tropospheric ozone over Eastern China interpreted by IAGOS, ozonesonde, and GEOS-Chem</a> (Guowen He, Sun Yat-sen U.)
-	</li>
-	<li>
-		E.13 Exploring seasonal features and source contributions to future background ozone over China (Mengyun Li, NUIST)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1FklVn2XnNwvV5fVQdeJqKrSIS55ekWkp/view?usp=sharing">E.14 A comprehensive review of background ozone: Definitions, estimation methods, and meta-analysis of its spatiotemporal distribution in China</a> (Chujun Chen, Jinan U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1iTIsjfGWOwi_q1nA5G4BK55LdnS8y1t3/view?usp=sharing">E.15 Surface and tropospheric ozone over East Asia and Southeast Asia from observations: distributions, trends, and variability</a> (Ke Li, NUIST)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1QWDoSo0W5sOHSU7E9__SUDXW6obkCX2K/view?usp=sharing">E.16 Tropospheric ozone trends over East Asia in 1995-2019</a> (Xiao Lu, Sun Yat-sen U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1THV_JQnVCD0CpBC9VmIa8fuMlTO92Q3h/view?usp=sharing">E.17 Difference in the sensitivity of ozone formation in different regions of China</a> (Jinglan Lin, Jinan U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/17djCXCQnSEWmPbqj38ln3zEN0EVHe5iY/view?usp=sharing">E.18 Evaluating the performance of WRF-GC in simulating summertime surface ozone concentrations over China</a> (Jiajia Mo, SUSTech)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1ElGwBmCP49SkNTk8N7VEiwDVXJGOZOo2/view?usp=sharing">E.19 Strategies towards the development of semi-explicit, synergistic photochemical mechanisms for O3 and SOA formation: the case of aromatics</a> (Wang Xiang, SUSTech)
-	</li>
-	<li>
-		E.20 A synchronized estimation of hourly surface concentrations of six criteria air pollutants with GEMS data (Qianqian Yang, Hong Kong Baptist U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1vOdyFVCMAhPbd57diYgeAu6IzXhr4ILf/view?usp=sharing">E.21 Interpretation of Geostationary Environment Monitoring Spectrometer (GEMS) observations of NO2 and HCHO over the Pear River Delta (PRD)</a> (Xicheng Li, SUSTech)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1TySEYjtSdCEmy26advuv1_LXUQbiuOUk/view?usp=sharing">E.22 Relating aerosol optical depth (AOD) to surface fine particulate matter (PM2.5) under a fast-changing environment: implication for surface ozone air quality</a> (Zheng Yu, The Chinese U. of Hong Kong)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1dIgvMg1iJPH9EasIvaRrkWymroGtU12N/view?usp=sharing">E.23 Soil emissions of reactive oxidized nitrogen reduce the effectiveness of anthropogenic source control in China</a> (Yurun Wang, The Hong Kong Polytechnic U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1lxWTQrE883YkPpRn_2J2YbqX0MNFtN-9/view?usp=sharing">E.24 Biogenic sources and impacts on air quality over the Pearl River Delta: results from in-situ observations and WRF-GC simulation</a> (Yangyang Cao, Sun Yat-sen U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1eTamYUiHxXgMJCiVEinH0i1S0S4eLQ9e/view?usp=sharing">E.25 Turbulent transport and dry deposition of air pollutants over real urban surfaces: a building-resolving large-eddy simulation study</a> (Wai-Chi Cheng, SUSTech)
-	</li>
+  <li>
+    <a href="https://drive.google.com/file/d/1jTKS6n4ZT2UwDcKaivTHy1vPv1UFGjh5/view?usp=sharing">B.1 Inversion of high temporal resolution NOx emissions over China</a> (Yi Wang, China U. of Geosciences)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1ZtjFBtyQ4TougOGBZDjCxwToA1cYe2bv/view?usp=sharing">B.2 Significant inequality shown in Chinese provincial export-related PM2.5 pollution and their contributors</a> (Zhengzhong Liu, Ocean U. of China)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1L_HS-mEbK0HpvjQsdyJCzTpCZb74IRQ8/view?usp=sharing">B.3 Tracing Hg Indian anthropogenic emissions over the Indian region</a> (Malasani Chakradhar Reddy, Indian Institute of Technology Madras)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1sUSZt-eNHyrs8IWbJCB7MYjGqZ1g_ZVO/view?usp=sharing">B.4 Optimize anthropogenic coarse particulate matter (ACPM) emissions using Bayesian inverse analysis with observations</a> (Yuxin Sun, City U. of Hong Kong)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1FUhlaan8uC2rcW423cZvohvQI3ImQf9n/view?usp=sharing">B.5 Global anthropogenic continental emissions of atmospheric bromine</a> (Yixuan Chen, City U. of Hong Kong)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1BBSU0RvaI0Ouh0f-2Nbs8bWihI0ig0Iw/view?usp=sharing">B.6 Unexpected high ammonia emissions from boreal fires in 2021 and 2023</a> (Qiwen Chen, Ocean U. of China)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1I7-4jVijIVm_zqf-1zbJnytwvYQWYkFb/view?usp=sharing">B.7 Impact of two Sentinel 5 NO2 data products on assimilation of anthropogenic NOx emissions</a> (Wenhui Dong, China U. of Geosciences)
+  </li>
+  <li>
+    B.8 Black carbon emission inversion over China during the Clean Air Action Plan (Li Fang, NUIST)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Gb3LAhCAUwAFXUQ3FH-ou2rT5-7JRoNa/view?usp=sharing">B.9 South Asia anthropogenic ammonia emission inversion through assimilating IASI observations</a> (Ji Xia, NUIST)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1S0IXue445ppZuRiRYnpFBiFNVoorMDou/view?usp=sharing">B.10 NMVOCs emission optimization in China through assimilating formaldehyde retrievals from multiple satellite products</a> (Canjie Xu, NUIST)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1-IQmiBdTu0Op4-eMU2bQvfHrIRf6X03U/view?usp=sharing">C.1 Assessing GEOS-Chem chemical mechanism in fresh biomass burning smoke</a> (Lu Hu, U. of Montana)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1j_10l0OMAUUtnHI-WPXncrf5Nw1BpTiF/view?usp=sharing">C.2 Tagging-based source attribution of expanded odd oxygen family (Oy) to volatile organic compounds (VOCs): a case study of heavy ozone pollution episode over the East China</a> (Wei Tao, SUSTech)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1JMeT_9ShpuVSdk2nxUIeQARtKW5lfK3B/view?usp=sharing">C.3 Evaluating key OVOCs in China using GEOS-Chem (14.4.1): model performance, chemical budgets, and implications for ozone simulation</a> (Enyu Xiong, SUSTech)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1rSPuFInWPLqOf94tyQicyKLWqUJp97_s/view?usp=sharing">C.4 Intercomparison of diurnal HCHO variations from GEMS and GEOS-Chem: Implications on NMVOC emission</a> (Weitao Fu, SUSTech)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/16pUc4W42XFimbbJm0b2rhMrlHiZH7Pnx/view?usp=sharing">C.5 Impact of key HONO heterogeneous processes on ozone formation in China</a> (Yaqing Zhou, Jinan U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/19WsGzbqEQ2a-v2BzklMMscKlccG3bEoU/view?usp=sharing">C.6 Physically-based parameterization of the sub-grid variability in biogenic volatile organic compound emissions for resolutionindependent estimates using the MEGAN v2.1 algorithm</a> (Yiheng Chen, SUSTech)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1L4OYvm6jrcetg8u4qAJF1_WIbI8x3jfT/view?usp=sharing">C.7 Atmospheric source of mercury to the ocean constrained by isotopic model</a> (Zhengcheng Song, Nanjing U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1HVKNnIBKB16VACflHnTm0aA79R-THYak/view?usp=sharing">C.8 Impact of anthropogenic chlorine chemistry over Indian region</a> (Ankit Patel, Indian Institute of Technology Madras)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1O-HrF6yyz81PIEkmKGhe8FFfS_TlE3kp/view?usp=sharing">C.9 Sulfate isotope constrain SO2 oxidation pathways in global model</a> (Yan Yang, The Hong Kong Polytechnic U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1DWKTvdLx82wwaLYdYj4gEREgN9Gtj9Wj/view?usp=sharing">C.10 Investigating NOx sources and sinks over the Tibet Plateau with GEMS satellite observations and GEOS-Chem model simulations</a> (Xue Zhang, SUSTech)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1ZcGCRSihlG6a1yoFAov-UCSYtxfqGGpo/view?usp=sharing">D.1 Warming by water-insoluble dark brown carbon from biomass burning</a> (Xuan Wang, City U. of Hong Kong)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1W3lvEeieKqa_z4IwjHcISVEZhzr9Ui9q/view?usp=sharing">D.2 Global high-resolution fire-sourced PM2.5 concentrations for 2000–2023</a> (Chenguang Tian, NUIST)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1fu1_-KSfA9K6JKUHdG6v1nt9d3IDBzH9/view?usp=sharing">D.3 Environmental and climate effects of agricultural reactive nitrogen and methane under carbon neutrality scenarios</a> (Tian Tian, NUIST)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1ZJ2hQ2fyZQGaVRVyaiBSVK4QQKzejiaT/view?usp=sharing">D.4 Comparative assessment of global fire emission inventories: long-term trends and case studies</a> (Hanyue Zheng, Xi'an Jiaotong-Liverpool U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/15D4pZVxXAckYsdV45qyNY-9Qj1ikYACq/view?usp=sharing">D.5 Impacts of stubble burning in northwestern India on Delhi's air quality during post-monsoon season</a> (Haoyu Wei, NUIST)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1vZ_sqdWOmvbnaGt63KP5RP6gbTe4s19Y/view?usp=sharing">D.6 GEOS-Chem simulations of hydroxymethanesulfonate aerosols in North China Plain</a> (Shaojie Song, Nankai U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/13sF8DfghAishaftfp81G_H1DtRKQ36XN/view?usp=sharing">D7. Analysis of new particle formation events: Comparison of particle number concentrations based on GEOS-Chem-APM in North China Plain</a> (Yingying Ku, NUIST)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/14ameuEJE_0vAAtdz1Wlo1r0n5o-UuFNz/view?usp=sharing">D.8 Calculation of triple oxygen isotope tracers in methanosulfonate (MSA) for tracing atmospheric DMS chemistry</a> (Yihang Hong, Nanjing U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1se8GlQWae3OJJ9jYdJyLMaFC_6R3dNzM/view?usp=sharing">D.9 Evaluating simulations of volatility distribution and oxygenation state of organic aerosols in eastern China</a> (Momei Qin, NUIST)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/11PsB3xsz2Uf7E0l3Oqi2ZTLNh1P9PYbS/view?usp=sharing">D.10 Underappreciated contributions of secondary organic aerosol from mobile sources to air quality in China</a> (Ruqian Miao, Peking U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1NHLsjfuSYscUsbA3q9DfKcP9VjaOngPE/view?usp=sharing">D.11 Global modeling of organic aerosols based on a new full-volatility emission inventory and an updated mechanism in GEOS-Chem</a> (Ruochong Xu, Tsinghua U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Blmv8f44sbY4LQlnlcvq-5j1EoZWlD57/view?usp=sharing">D.12 Effects of organic coatings, seed aerosols, and acidity on the generation of isoprene-epoxydiol-derived secondary organic aerosols in Eastern China</a> (Fengyi Chang, NUIST)
+  </li>
+  <li>
+    D.13 Fractal geometry of aerosol particles model and its impact on atmospheric optical properties and land surface radiation budget (Zhenxin Liu, NUIST)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1-6ZvTkmfWFdyd7G2UTq9l3O4gYrDvVYQ/view?usp=sharing">D.14 Simulations and Predictions of Long-Term Trends in Inorganic Aerosol Water Content and Acidity for Winter in the North China Plain</a>  (Haoqi Wang, Nankai U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1oBQcRswIXNW54WULBC_es2zBZdmi0UbI/view?usp=sharing">D.15 Freeze-thaw process boosts penguin-derived NH3 emissions and enhances climate-relevant particles formation in Antarctica</a> (Rong Tian, Third Institute of Oceanography)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/117Ee05ZFzHqFI1M4_P-MMj5zB4T8huo2/view?usp=sharing">E.1 Utilizing GEOS-Chem aerosol prediction for investigating ultrafine particles and supporting air quality management in Thailand</a> (Si Thu Kyaw, Chulalongkorn U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/10LjNiDmpEX5NyhPLjALyvSI0fUVF_2yl/view?usp=sharing">E.2 Simulation of fine particulate matter pollution in the Indo-Gangetic Plain</a> (Siyi Liu, Peking U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1FODMfg1F6UoA7YROLQZAqRikEcvimJ1p/view?usp=sharing">E.3 Modelling global levoglucosan concentration with chemical loss and its inisight into biomass burning contribution to OC</a> (Xingyu Nan, SUSTech)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/185qKM3s-867A_FewoC6OzO2AIyqyn3Hg/view?usp=sharing">E.4 Reassessing O3 and PM2.5 concentrations in urban and suburban China with GEOS-Chem model</a> (Ning Yang, Jinan U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1gBEnwNIvKv_yT0PQRDMxyTuYjGQRd8GA/view?usp=sharing">E.5 Day and night, outdoor and indoor variations of aerosol properties and air quality in Changchun</a> (Xuanyi Wei, Jilin U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1lOQ-vUZP6W6_wGoin7L-HVQYwz0Xqpy2/view?usp=sharing">E.6 Opportunities to mitigate PM2.5 and nitrogen deposition through agricultural NH3 control strategies in China’s Beijing-Tianjin-Hebei region</a> (Lu Li, Peking U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1g7PRfyF451k2ZqlySJXnwkr3bE8_KCLr/view?usp=sharing">E.7 Evolving global oceanic nitrogen deposition under future emission pathways and responses to nitrogen emission reductions</a> (Jialin Deng, Peking U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1SkMFSyEtr7Oq96Mk_8eiDvbISfE2Gg4q/view?usp=sharing">E.8 Regional transport of peroxyacetyl nitrate (PAN) within Eastern China and its impact on ozone</a> (Tiangang Yuan, The Chinese U. of Hong Kong)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1V4UFy7LM2Sng1dfsa_ZSZTG-THSzeAmN/view?usp=sharing">E.9 Evaluating long term trend atmospheric oxidation capacity in China using GC14.3.1</a> (Tianci Jiang, SUSTech)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Y-BFVsJHAT07qfDul6jiipNNYIxkIV22/view?usp=sharing">E.10 Satellite data constraints for emissions inventories</a> (Herizo Narivelo, Université de Toulouse)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/17QDr_25c1BBw6UJOpTmrXTz0Tz2CrpYI/view?usp=sharing">E.11 The role of diurnally varying African biomass burning emissions on tropospheric ozone</a> (Haolin Wang, Hong Kong Baptist U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1FjUtN3xZlV8T6IEzMJXJUru7vj9ROXrJ/view?usp=sharing">E.12 Source of tropospheric ozone over Eastern China interpreted by IAGOS, ozonesonde, and GEOS-Chem</a> (Guowen He, Sun Yat-sen U.)
+  </li>
+  <li>
+    E.13 Exploring seasonal features and source contributions to future background ozone over China (Mengyun Li, NUIST)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1FklVn2XnNwvV5fVQdeJqKrSIS55ekWkp/view?usp=sharing">E.14 A comprehensive review of background ozone: Definitions, estimation methods, and meta-analysis of its spatiotemporal distribution in China</a> (Chujun Chen, Jinan U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1iTIsjfGWOwi_q1nA5G4BK55LdnS8y1t3/view?usp=sharing">E.15 Surface and tropospheric ozone over East Asia and Southeast Asia from observations: distributions, trends, and variability</a> (Ke Li, NUIST)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1QWDoSo0W5sOHSU7E9__SUDXW6obkCX2K/view?usp=sharing">E.16 Tropospheric ozone trends over East Asia in 1995-2019</a> (Xiao Lu, Sun Yat-sen U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1THV_JQnVCD0CpBC9VmIa8fuMlTO92Q3h/view?usp=sharing">E.17 Difference in the sensitivity of ozone formation in different regions of China</a> (Jinglan Lin, Jinan U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/17djCXCQnSEWmPbqj38ln3zEN0EVHe5iY/view?usp=sharing">E.18 Evaluating the performance of WRF-GC in simulating summertime surface ozone concentrations over China</a> (Jiajia Mo, SUSTech)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1ElGwBmCP49SkNTk8N7VEiwDVXJGOZOo2/view?usp=sharing">E.19 Strategies towards the development of semi-explicit, synergistic photochemical mechanisms for O3 and SOA formation: the case of aromatics</a> (Wang Xiang, SUSTech)
+  </li>
+  <li>
+    E.20 A synchronized estimation of hourly surface concentrations of six criteria air pollutants with GEMS data (Qianqian Yang, Hong Kong Baptist U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1vOdyFVCMAhPbd57diYgeAu6IzXhr4ILf/view?usp=sharing">E.21 Interpretation of Geostationary Environment Monitoring Spectrometer (GEMS) observations of NO2 and HCHO over the Pear River Delta (PRD)</a> (Xicheng Li, SUSTech)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1TySEYjtSdCEmy26advuv1_LXUQbiuOUk/view?usp=sharing">E.22 Relating aerosol optical depth (AOD) to surface fine particulate matter (PM2.5) under a fast-changing environment: implication for surface ozone air quality</a> (Zheng Yu, The Chinese U. of Hong Kong)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1dIgvMg1iJPH9EasIvaRrkWymroGtU12N/view?usp=sharing">E.23 Soil emissions of reactive oxidized nitrogen reduce the effectiveness of anthropogenic source control in China</a> (Yurun Wang, The Hong Kong Polytechnic U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1lxWTQrE883YkPpRn_2J2YbqX0MNFtN-9/view?usp=sharing">E.24 Biogenic sources and impacts on air quality over the Pearl River Delta: results from in-situ observations and WRF-GC simulation</a> (Yangyang Cao, Sun Yat-sen U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1eTamYUiHxXgMJCiVEinH0i1S0S4eLQ9e/view?usp=sharing">E.25 Turbulent transport and dry deposition of air pollutants over real urban surfaces: a building-resolving large-eddy simulation study</a> (Wai-Chi Cheng, SUSTech)
+  </li>
 </ul>
 
-<h2>
-	Wednesday, May 21
-</h2>
+<h2>Wednesday, May 21</h2>
 
-<h4>
-	<a name="WedA" id="WedA"></a><strong>Air quality</strong>
-</h4>
+<h4><a name="WedA" id="WedA"></a><strong>Air quality</strong></h4>
 
 <ul>
-    <li>
-		<a href="https://drive.google.com/file/d/1T0fXpC0EGS38C2MYKiWhFyXkwiHewk_7/view?usp=sharing">Keynote: Atmospheric nitrogen deposition: Historic trend, environmental impact and future challenge</a> (Xuejun Liu, China Agricultural University)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1HvB_WFKACDlby5DD5Sd5JQnOHS0vufom/view?usp=sharing">Impacts of global nitrogen emission reductions on PM2.5 air pollution and nitrogen deposition</a> (Lin Zhang, Peking U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Z1gO1QBGW16KJ-WhSytui-Op8D9DZUJp/view?usp=sharing">Undesirable effects of urban greening emissions on air quality are counteracted by transpiration and dry deposition</a> (Meng Gao, Hong Kong Baptist University)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/193lxdYhdjzWay3NPgCfBa2yz3NLSA_O2/view?usp=sharing">Quantifying vegetation-mediated mercury deposition through coupled stomatal conductance modeling in GEOS-Chem</a> (Long Chen, East China Normal U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1AxNgqI3sJNjLz_X5GZC28hSLl_F_qvtE/view?usp=sharing">A Unified Model of Forecasting Ozone</a> (Zhenze Liu, NUIST)
-	</li>
-	<li>
-		Peroxyacetyl nitrate (PAN) over East Asia (Shixian Zhai, The Chinese U. of Hong Kong)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Qc4XzzRt5nZvA36-9_qXy0oxH15qOE9i/view?usp=sharing">Wintertime Peroxyacyl Nitrates (PAN) hotspot over the Sichuan Basin observed from Space: Interpretation of Cross-track Infrared Sounder (CrIS) results using GEOS-Chem</a> (Peng Zhang, SUSTech)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1a8-OE9qatQ85t5B7zcirAhvP7eNScY9I/view?usp=sharing">Enhancing Atmospheric Composition Forecasting over continental United States: Assimilating TEMPO data in Regional Air Quality Models with the ETKF method</a> (Chengze Li, U. of Iowa)
-	</li>
+  <li>
+    <a href="https://drive.google.com/file/d/1T0fXpC0EGS38C2MYKiWhFyXkwiHewk_7/view?usp=sharing">Keynote: Atmospheric nitrogen deposition: Historic trend, environmental impact and future challenge</a> (Xuejun Liu, China Agricultural University)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1HvB_WFKACDlby5DD5Sd5JQnOHS0vufom/view?usp=sharing">Impacts of global nitrogen emission reductions on PM2.5 air pollution and nitrogen deposition</a> (Lin Zhang, Peking U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Z1gO1QBGW16KJ-WhSytui-Op8D9DZUJp/view?usp=sharing">Undesirable effects of urban greening emissions on air quality are counteracted by transpiration and dry deposition</a> (Meng Gao, Hong Kong Baptist University)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/193lxdYhdjzWay3NPgCfBa2yz3NLSA_O2/view?usp=sharing">Quantifying vegetation-mediated mercury deposition through coupled stomatal conductance modeling in GEOS-Chem</a> (Long Chen, East China Normal U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1AxNgqI3sJNjLz_X5GZC28hSLl_F_qvtE/view?usp=sharing">A Unified Model of Forecasting Ozone</a> (Zhenze Liu, NUIST)
+  </li>
+  <li>
+    Peroxyacetyl nitrate (PAN) over East Asia (Shixian Zhai, The Chinese U. of Hong Kong)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Qc4XzzRt5nZvA36-9_qXy0oxH15qOE9i/view?usp=sharing">Wintertime Peroxyacyl Nitrates (PAN) hotspot over the Sichuan Basin observed from Space: Interpretation of Cross-track Infrared Sounder (CrIS) results using GEOS-Chem</a> (Peng Zhang, SUSTech)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1a8-OE9qatQ85t5B7zcirAhvP7eNScY9I/view?usp=sharing">Enhancing Atmospheric Composition Forecasting over continental United States: Assimilating TEMPO data in Regional Air Quality Models with the ETKF method</a> (Chengze Li, U. of Iowa)
+  </li>
 </ul>
 
-<h4>
-	<a name="WedB" id="WedB"></a><strong>WG Breakout Reports and Discussion</strong>
-</h4>
+<h4><a name="WedB" id="WedB"></a><strong>WG Breakout Reports and Discussion</strong></h4>
 
 <ul>
-    <li>
-		<a href="https://drive.google.com/file/d/1YrTKPoTF7yx5fBwFcn4cALn7Qlte1WR3/view?usp=sharing">Chemistry-Climate WG</a>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/16dSUkm97hbGbtuzezIxQkILi4D9F7Qu-/view?usp=sharing">Inverse Modeling & Data Assimilation WG</a>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1GK2Xk-7Mxx9rkew52Kt6-LTWgvdC1KdE/view?usp=sharing">Chemistry WG</a>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1IymAuWMYobrxO8tbX4Bseq_QBFPqDzXW/view?usp=sharing">Aerosols WG</a>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1WmMMmIz1vWgNgYOXPpRdH2X0uNKiwRAP/view?usp=sharing">Emissions WG</a>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/11ae1HCcWfjmanD_MVA0ytIz7gURXyl-o/view?usp=sharing">Carbon Cycle WG</a>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Lf2iEytUJDCjLWW3uO3ZEYa9MUx-DBZ8/view?usp=sharing">Surface-Atmosphere Exchange WG</a>
-	</li>
-	<li>
-		Future directions for GEOS-Chem (Daniel Jacob, discussion leader)
-	</li>
+  <li>
+    <a href="https://drive.google.com/file/d/1YrTKPoTF7yx5fBwFcn4cALn7Qlte1WR3/view?usp=sharing">Chemistry-Climate WG</a>
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/16dSUkm97hbGbtuzezIxQkILi4D9F7Qu-/view?usp=sharing">Inverse Modeling & Data Assimilation WG</a>
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1GK2Xk-7Mxx9rkew52Kt6-LTWgvdC1KdE/view?usp=sharing">Chemistry WG</a>
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1IymAuWMYobrxO8tbX4Bseq_QBFPqDzXW/view?usp=sharing">Aerosols WG</a>
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1WmMMmIz1vWgNgYOXPpRdH2X0uNKiwRAP/view?usp=sharing">Emissions WG</a>
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/11ae1HCcWfjmanD_MVA0ytIz7gURXyl-o/view?usp=sharing">Carbon Cycle WG</a>
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Lf2iEytUJDCjLWW3uO3ZEYa9MUx-DBZ8/view?usp=sharing">Surface-Atmosphere Exchange WG</a>
+  </li>
+  <li>
+    Future directions for GEOS-Chem (Daniel Jacob, discussion leader)
+  </li>
 </ul>
 
 </div>
@@ -732,85 +684,17 @@ The 2nd GEOS-Chem Asia Meeting (GCA2)<br>May 19-21, 2025
 </div>
 </div>
 
-<!--footer region beg-->
+<!--footer-->
 <footer id="footer" class="clearfix" role="contentinfo">
-
-<!-- Three column 3x33 Gpanel -->
-<div class="at-panel gpanel panel-display footer clearfix">
-<div class="region region-footer">
-<div class="region-inner clearfix">
-<div id="block-boxes-1617037690" class="block block-boxes block-boxes-os_boxes_html no-title"  module="boxes" delta="1617037690">
-<div class="block-inner clearfix">  
-<div class="block-content content" ng-non-bindable="">  
-<div id='boxes-box-1617037690' class='boxes-box'>  
 <div class="boxes-box-content">
   <p style="text-align:center">
-    Copyright © 2025 by the International GEOS-Chem Community. All rights reserved.
+    Copyright © 2026 by the International GEOS-Chem Community. All rights reserved.
   </p>
 </div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-<div class="region region-footer-bottom">  
-<div class="region-inner clearfix">  
-<div id="block-boxes-1616879798" class="block block-boxes block-boxes-os_boxes_media no-title"  module="boxes" delta="1616879798">  
-<div class="block-inner clearfix">  
-<div class="block-content content"> 
-<div id='boxes-box-1616879798' class='boxes-box'> 
-<div class="boxes-box-content"> 
-<div id="file-3900146" class="file file-html file-html-embed">
-<h2 class="element-invisible"><a href="">css-brand</a></h2>
-<div class="content">
-<div class="file-info">
-</div>
-<div class="field field-name-field-html-code field-type-text-long field-label-hidden view-mode-full">
-<div class="field-items">
-<div class="field-item even">
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-
-<!--footer region end-->
 </footer>
-</div>
-</div>
 
-<!--page area ends-->
-<div id="extradiv"></div>
 </div>
-
-<!-- /page_wrap -->
-<script src="https://static.projects.iq.harvard.edu/profiles/openscholar/libraries/respondjs/respond.min.js?rpidw0"></script>
-<script src="https://static.projects.iq.harvard.edu/files/js/js_s7yA-hwRxnKty__ED6DuqmTMKG39xvpRyrtyCrbWH4M.js?m=1675397499"></script>
-<script>jQuery.extend(Drupal.settings, {"basePath":"\/","pathPrefix":"","setHasJsCookie":0,"ajaxPageState":{"theme":"hwpi_classic","theme_token":"tDSUo3Snb6uZHXSERNZR3e9UO99uhtK9V2w1eEWHIKw"},"colorbox":{"opacity":"0.85","current":"{current} of {total}","previous":"\u00ab Prev","next":"Next \u00bb","close":"Close","maxWidth":"98%","maxHeight":"98%","fixed":true,"mobiledetect":true,"mobiledevicewidth":"480px"},"jcarousel":{"ajaxPath":"https:\/\/geos-chem.seas.harvard.edu\/jcarousel\/ajax\/views"},"spaces":{"id":"1585652","path":"Welcome to the GEOS-Chem Web Site"},"os_ga":{"trackOutbound":1,"trackMailto":1,"trackDownload":1,"trackDownloadExtensions":"7z|aac|arc|arj|asf|asx|avi|bin|csv|docx?|exe|flv|gif|gz|gzip|hqx|jar|jpe?g|js|mp(2|3|4|e?g)|mov(ie)?|msi|msp|pdf|phps|png|ppt|qtm?|ra(m|r)?|sea|sit|tar|tgz|torrent|txt|wav|wma|wmv|wpd|xlsx?|xml|z|zip","trackNavigation":1},"paths":{"api":"\/api","siteCreationForm":"\/profiles\/openscholar\/modules\/frontend\/os_site_creation\/templates","siteCreationModuleRoot":"\/profiles\/openscholar\/modules\/frontend\/os_site_creation","hasOsId":false},"user":{"uid":0,"name":null},"admin_panel":{"purl_base_domain":"https:\/\/projects.iq.harvard.edu","base_domain":"https:\/\/geos-chem.seas.harvard.edu"},"version":{"siteCreationForm":"1.0.4"},"site_creation":{"subsite_types":{"personal":"personal","project":"project","department":"department"},"privacy_levels":{"0":"Public on the web. \u003Cbr\u003E\u003Cspan class=\u0022description\u0022\u003EAnyone on the Internet can view your site. Your site will show in search results. No sign-in required.\u003C\/span\u003E","2":"Anyone with the link. \u003Cbr\u003E\u003Cspan class=\u0022description\u0022\u003EAnyone who has the URL to your site can view your site. Your site will not be indexed by search engines.\u003C\/span\u003E","1":"Site members only. \u003Cbr\u003E\u003Cspan class=\u0022description\u0022\u003EThis setting can be useful during site creation. Your site will not be indexed by search engines.\u003C\/span\u003E","presets":{"os_department_minimal":{"name":"os_department_minimal","title":"Minimal","description":"Blank site with no pre-set menu links or pages.","site_type":"department"},"os_department":{"name":"os_department","title":"Academic","description":"Pre-set menu links and pages: Academics, Research, Activities, People, Resources, News \u0026amp; Events, About","site_type":"department"},"os_project":{"name":"os_project","title":"Minimal","description":"Blank site with no pre-set menu links or pages.","site_type":"project"},"os_scholar":{"name":"os_scholar","title":"Minimal","description":"Blank site with no pre-set menu links or pages.","site_type":"personal"},"osllc_preset_gradstudent":{"name":"osllc_preset_gradstudent","title":"Grad Student\/Adjunct","description":"A site for grad students or adjuncts currently in the job market","site_type":"personal"},"osllc_preset_medical_professional":{"name":"osllc_preset_medical_professional","title":"Medical Professional","description":"A site for doctors and other medical professionals.","site_type":"personal"},"osllc_preset_project":{"name":"osllc_preset_project","title":"Project Site","description":"A site for a project, separate from any individual involved.","site_type":"personal"},"hwp_administrative":{"name":"hwp_administrative","title":"Administrative","description":"The Harvard Web Publishing standard Adminstrative Department site.","site_type":"department"},"hwp_lab_research_group":{"name":"hwp_lab_research_group","title":"Lab\/Research Group","description":"The Harvard Web Publishing standard Lab and Research Group site.","site_type":"project"},"hwp_project":{"name":"hwp_project","title":"Project","description":"The Harvard Web Publishing standard Project site.","site_type":"project"},"hwp_personal":{"name":"hwp_personal","title":"Personal","description":"The Harvard Web Publishing standard Personal site.","site_type":"personal"},"hwp_event_conference":{"name":"hwp_event_conference","title":"Event\/Conference","description":"The Harvard Web Publishing standard Event or Conference site.","site_type":"project"}},"default_individual_scholar":"os_scholar","default_project_lab_small_group":"os_project","default_department_school":"os_department_minimal"},"urlIsAjaxTrusted":{"https:\/\/geos-chem.seas.harvard.edu\/search\/site":true},"nice_menus_options":{"delay":800,"speed":"slow"},"ogContext":{"groupType":"node","gid":"1585652"},"password":{"strengthTitle":"Password compliance:"},"type":"setting"});</script>
-<script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.6/angular.js"></script>
-<script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.6/angular-sanitize.js"></script>
-<script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.6/angular-cookies.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/ngStorage/0.3.9/ngStorage.min.js"></script>
-<script src="https://static.projects.iq.harvard.edu/files/js/js_0NmK99JLIjRqsIlFqFNNbx8Ujgexpza5nVIcHEw_ZTg.js?m=1675397495"></script>
-<script src="https://static.projects.iq.harvard.edu/files/js/js_Y1FBKf83E3J9MQtFPjbc5aPABrOfDhLHCFnDQJdtDSk.js?m=1675397528"></script>
-<script>window.CKEDITOR_BASEPATH = '/profiles/openscholar/libraries/ckeditor/'</script>
-<script>var _gaq = _gaq || [];_gaq.push(["_setAccount", "UA-17689007-1"]);_gaq.push(["_gat._anonymizeIp"]);_gaq.push(["_trackPageview"]);_gaq.push(['_setCustomVar',1,'Site homepage','https://geos-chem.seas.harvard.edu/',3]);(function() {var ga = document.createElement("script");ga.type = "text/javascript";ga.async = true;ga.src = ("https:" == document.location.protocol ? "https://ssl" : "http://www") + ".google-analytics.com/ga.js";var s = document.getElementsByTagName("script")[0];s.parentNode.insertBefore(ga, s);})();var addthis_config = {data_ga_social: true, data_ga_property: {"addthis_default":false}};</script>
-<script src="https://static.projects.iq.harvard.edu/files/js/js_LiusrpwJT3Sg0H0ZmGojUVryUYFnHLCv1UjzLbWcgsw.js?m=1675397537"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_CHTML"></script>
-<script src="https://static.projects.iq.harvard.edu/files/js/js_Gn6CPUOXDTurT1_dttEf_0ILEDturfDpbAqZFd3d6g4.js?m=1675397512"></script>
-<script>(function ($) { angular.module('openscholar', ['SiteCreationForm']); })();</script>
-<script src="https://static.projects.iq.harvard.edu/files/js/js_TF0j_xSQPq-6QP1Il7NFw8ppuW60PTAxM0BwHtQXBsA.js?m=1675397525"></script>
-<script src="https://static.projects.iq.harvard.edu/files/js/js_qluyoBMkmyevXrrhnKB_2ie6cLJ7DL5g_0nHm6hyXwA.js?m=1675397503"></script>
+</div>
 
 </body>
-
 </html>

--- a/gca2.html
+++ b/gca2.html
@@ -1,9 +1,4 @@
 <!DOCTYPE html>
-<!--[if IEMobile 7]><html class="iem7"  lang="en" dir="ltr"><![endif]-->
-<!--[if lte IE 6]><html class="lt-ie9 lt-ie8 lt-ie7"  lang="en" dir="ltr"><![endif]-->
-<!--[if (IE 7)&(!IEMobile)]><html class="lt-ie9 lt-ie8"  lang="en" dir="ltr"><![endif]-->
-<!--[if IE 8]><html class="lt-ie9"  lang="en" dir="ltr"><![endif]-->
-<!--[if (gte IE 9)|(gt IEMobile 7)]><!--><html  lang="en" dir="ltr"><!--<![endif]-->
 <head>
 <meta charset="utf-8" />
 <!--<base href="/gca2" />-->
@@ -18,23 +13,12 @@
 <title>The 2nd Regional GEOS-Chem Asia Meeting</title>
 <meta http-equiv="x-ua-compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<link type="text/css" rel="stylesheet" href="css/css_xE-rWrJf-fncB6ztZfd2huxqgxu4WO-qwma6Xer30m4%EF%B9%96m=1675397288.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_1kR8T1_c-l5pBT6ZwbDT7BFda-4fyqW9Jjum29_2IY8%EF%B9%96m=1675397312.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_YnlUIvHP13qgpYEqubzE8JyDwlSxUnVibfnVkSoSDb0%EF%B9%96m=1675397273.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_Ku-3OcT9qU9h7dnGig5e23q6EVryY8orK4wzVDxsweE%EF%B9%96m=1675397367.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_vprtFTrWyg23GbY50_zJZHWGYMNfS8vsrRS26i4-ISk%EF%B9%96m=1675397406.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_dW-aNNrctRhQNc-KECjtQd0PxuW-h19IEum-TX2MeEk%EF%B9%96m=1675397301.css" media="print" />
-<link type="text/css" rel="stylesheet" href="css/css_SH2Lx3Qprh0GZo_9xRp85U9NsWfkSXn_Bi-rJoMY1sw%EF%B9%96m=1675397273.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_uaIDKcYMUK5osSQXuirpr3ZleXtnnpBN-eiECm7N0M0%EF%B9%96m=1675397395.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/responsive.blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/geos-chem.css" media="all"/>
 <script type="text/javascript" src="dropdown-menu.js"></script>
-<!--[if lte IE 8]>
-<script type="text/javascript">
-  var os_c = document.createElement;os_c('header');os_c('nav');os_c('section');os_c('article');os_c('aside');os_c('footer');os_c('hgroup');os_c('figure');
-</script>
-<![endif]-->
 </head>
 
 <body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-1585687 node-type-page og-context og-context-node og-context-node-1585652 navbar-on">
@@ -45,7 +29,7 @@
 <div id="page_wrap" class="page_wrap">
 <div id="page" class="container page header-main content-top footer-none">
 <div id="page-wrapper">
-		
+
 <!--header regions beg-->
 <header id="header" class="clearfix" role="banner">
 <div id="header-container">
@@ -53,15 +37,12 @@
 <div class="region region-header-second">
 <div class="region-inner clearfix">
 <div id="block-boxes-1617807424" class="block block-boxes block-boxes-os_boxes_html no-title"  module="boxes" delta="1617807424">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <div class="block-content content" ng-non-bindable="">
 <div id='boxes-box-1617807424' class='boxes-box'>
 <div class="boxes-box-content">
-
-<h2 class="css-brand--css-geos-meetings-header-h2-xxxlarge">
 <a href="https://geoschem.github.io/"><img height="600" width="1034" style="float: right; width: 350px; height: 203px;" class="media-element file-default file-os-files-xxlarge" src="img/gca2_nuist.png" alt="" title="" /></a>
-The 2nd GEOS-Chem Asia Meeting (GCA2)<br>May 19-21, 2025
-</h2>
+<h2 class="css-brand--css-geos-meetings-header-h2-xxxlarge">The 2nd GEOS-Chem Asia Meeting (GCA2)<br>May 19-21, 2025</h2>
 
 </div>
 </div>
@@ -78,15 +59,16 @@ The 2nd GEOS-Chem Asia Meeting (GCA2)<br>May 19-21, 2025
 
 <!--main menu region beg-->
 <div id="menu-bar" class="nav region-menu-bar clearfix">
-<nav id="block-os-gac2-menu" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="gac2_menu">  
-<ul class="nice-menu nice-menu-down nice-menu-gac2_menu" id="nice-menu-gac2_menu">
-  <li class="menu-854289 menu-path-node-1585795  first   odd   active-trail"><a href="gca2.html"  class="active active">Home</a></li>
-  <li class="menu-854305 menu-path-node-1585800   even  "><a href="gca2-presentations.html" >Presentations</a></li>
+<nav id="block-os-gac2-menu" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="gac2_menu">
+<ul class="nice-menu nice-menu-down">
+  <li><a href="gca2.html" class="active">GCA2 Home</a></li>
+  <li><a href="gca2-presentations.html">Presentations and Posters</a></li>
+  <li><a href="index.html">GEOS-Chem Home</a></li>
 </ul>
 </nav>
 </div>
 <!--main menu region end-->
-		
+
 <div id="columns" class="clearfix">
 <div class="hg-container">
 <div id="content-column" role="main">
@@ -95,13 +77,13 @@ The 2nd GEOS-Chem Asia Meeting (GCA2)<br>May 19-21, 2025
 <header id="main-content-header">
 <a name="main-content"></a>
 </header>
-														
+
 <!--front panel regions beg-->
 <div id="content-panels" class="at-panel gpanel panel-display content clearfix">
 <div class="region region-content-top">
 <div class="region-inner clearfix">
 <div id="block-os-pages-main-content" class="block block-os-pages no-title"  module="os_pages" delta="main_content">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <div class="block-content content" ng-non-bindable="">
 <article id="node-1585687" class="node node-page article clearfix" role="article">
 <div class="node-content" ng-non-bindable="">
@@ -110,33 +92,29 @@ The 2nd GEOS-Chem Asia Meeting (GCA2)<br>May 19-21, 2025
 <div class="field-item even">
 
 <p style="text-align:center">
-	<a href="img/gca2_group_photo_20250519.jpg"><img height="800" width="2000" alt="Group photo" class="media-element file-default file-os-files-xxlarge" src="img/gca2_group_photo.png" title="" /></a>
+  <a href="img/gca2_group_photo_20250519.jpg"><img height="800" width="2000" alt="Group photo" class="media-element file-default file-os-files-xxlarge" src="img/gca2_group_photo.png" title="" /></a>
 </p>
 
-<p>
-	The 2nd GEOS-Chem Asia meeting (GCA2) was held at Nanjing University of Information Science & Technology (NUIST) on <b>May 19-21, 2025</b> with 263 participants from 55 institutions and 8 countries. 
-</p>
+<p>The 2nd GEOS-Chem Asia meeting (GCA2) was held at Nanjing University of Information Science & Technology (NUIST) on <b>May 19-21, 2025</b> with 263 participants from 55 institutions and 8 countries.</p>
 
 <ul>
-    <li>
-		<a href="gca2-presentations.html">Oral and poster presentations from the meeting</a>;
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/12A74lTYxisFGl3_uLVEzFz79GpFQZH_H/view?usp=sharing" target="_blank">GCA2 participants list and contact information</a>.
-	</li>
+  <li>
+    <a href="gca2-presentations.html">Oral and poster presentations from the meeting</a>;
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/12A74lTYxisFGl3_uLVEzFz79GpFQZH_H/view?usp=sharing" target="_blank">GCA2 participants list and contact information</a>.
+  </li>
 </ul>
 
-<p>
-The meeting was organized by:
+<p>The meeting was organized by:</p>
+
 <ul>
-	<li>Harvard University</li>
-	<li>Nanjing University of Information Science and Technology (NUIST)</li>
-	<li><a href="https://projects.iq.harvard.edu/acmg-jlaqc" target="_blank">Harvard-NUIST Joint Laboratory for Air Quality and Climate (JLAQC)</a></li>
+  <li>Harvard University</li>
+  <li>Nanjing University of Information Science and Technology (NUIST)</li>
+  <li><a href="https://projects.iq.harvard.edu/acmg-jlaqc" target="_blank">Harvard-NUIST Joint Laboratory for Air Quality and Climate (JLAQC)</a></li>
 </ul>
 
-<p>
-	We look forward to seeing you in at GCA3 in 2027 and before that at the 12th International GEOS-Chem Meeting (IGC12) in 2026!
-</p>
+<p>We look forward to seeing you in at GCA3 in 2027 and before that at the 12th International GEOS-Chem Meeting (IGC12) in 2026!</p>
 
 </div>
 </div>
@@ -156,64 +134,16 @@ The meeting was organized by:
 </div>
 </div>
 
-<!--footer region beg-->
+<!--footer-->
 <footer id="footer" class="clearfix" role="contentinfo">
-
-<!-- Three column 3x33 Gpanel -->
-<div class="at-panel gpanel panel-display footer clearfix">
-<div class="region region-footer">
-<div class="region-inner clearfix">
-<div id="block-boxes-1617037690" class="block block-boxes block-boxes-os_boxes_html no-title"  module="boxes" delta="1617037690">
-<div class="block-inner clearfix">  
-<div class="block-content content" ng-non-bindable="">  
-<div id='boxes-box-1617037690' class='boxes-box'>  
 <div class="boxes-box-content">
   <p style="text-align:center">
-    Copyright © 2025 by the International GEOS-Chem Community. All rights reserved.
+    Copyright © 2026 by the International GEOS-Chem Community. All rights reserved.
   </p>
 </div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-<div class="region region-footer-bottom">  
-<div class="region-inner clearfix">  
-<div id="block-boxes-1616879798" class="block block-boxes block-boxes-os_boxes_media no-title"  module="boxes" delta="1616879798">  
-<div class="block-inner clearfix">  
-<div class="block-content content"> 
-<div id='boxes-box-1616879798' class='boxes-box'> 
-<div class="boxes-box-content"> 
-<div id="file-3900146" class="file file-html file-html-embed">
-<h2 class="element-invisible"><a href="">css-brand</a></h2>
-<div class="content">
-<div class="file-info">
-</div>
-<div class="field field-name-field-html-code field-type-text-long field-label-hidden view-mode-full">
-<div class="field-items">
-<div class="field-item even">
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-
-<!--footer region end-->
 </footer>
-</div>
-</div>
 
-<!--page area ends-->
-<div id="extradiv"></div>
+</div>
 </div>
 
 </body>

--- a/gce1-agenda.html
+++ b/gce1-agenda.html
@@ -1,9 +1,4 @@
 <!DOCTYPE html>
-<!--[if IEMobile 7]><html class="iem7"  lang="en" dir="ltr"><![endif]-->
-<!--[if lte IE 6]><html class="lt-ie9 lt-ie8 lt-ie7"  lang="en" dir="ltr"><![endif]-->
-<!--[if (IE 7)&(!IEMobile)]><html class="lt-ie9 lt-ie8"  lang="en" dir="ltr"><![endif]-->
-<!--[if IE 8]><html class="lt-ie9"  lang="en" dir="ltr"><![endif]-->
-<!--[if (gte IE 9)|(gt IEMobile 7)]><!--><html  lang="en" dir="ltr"><!--<![endif]-->
 <head>
 <meta charset="utf-8" />
 <!--<base href="/gce1-agenda" />-->
@@ -18,23 +13,12 @@
 <title>The 1st Regional GEOS-Chem Europe Meeting</title>
 <meta http-equiv="x-ua-compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<link type="text/css" rel="stylesheet" href="css/css_xE-rWrJf-fncB6ztZfd2huxqgxu4WO-qwma6Xer30m4%EF%B9%96m=1675397288.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_1kR8T1_c-l5pBT6ZwbDT7BFda-4fyqW9Jjum29_2IY8%EF%B9%96m=1675397312.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_YnlUIvHP13qgpYEqubzE8JyDwlSxUnVibfnVkSoSDb0%EF%B9%96m=1675397273.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_Ku-3OcT9qU9h7dnGig5e23q6EVryY8orK4wzVDxsweE%EF%B9%96m=1675397367.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_vprtFTrWyg23GbY50_zJZHWGYMNfS8vsrRS26i4-ISk%EF%B9%96m=1675397406.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_dW-aNNrctRhQNc-KECjtQd0PxuW-h19IEum-TX2MeEk%EF%B9%96m=1675397301.css" media="print" />
-<link type="text/css" rel="stylesheet" href="css/css_SH2Lx3Qprh0GZo_9xRp85U9NsWfkSXn_Bi-rJoMY1sw%EF%B9%96m=1675397273.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_uaIDKcYMUK5osSQXuirpr3ZleXtnnpBN-eiECm7N0M0%EF%B9%96m=1675397395.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/responsive.blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/geos-chem.css" media="all"/>
 <script type="text/javascript" src="dropdown-menu.js"></script>
-<!--[if lte IE 8]>
-<script type="text/javascript">
-  var os_c = document.createElement;os_c('header');os_c('nav');os_c('section');os_c('article');os_c('aside');os_c('footer');os_c('hgroup');os_c('figure');
-</script>
-<![endif]-->
 </head>
 
 <body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-1585687 node-type-page og-context og-context-node og-context-node-1585652 navbar-on">
@@ -45,7 +29,7 @@
 <div id="page_wrap" class="page_wrap">
 <div id="page" class="container page header-main content-top footer-none">
 <div id="page-wrapper">
-		
+
 <!--header regions beg-->
 <header id="header" class="clearfix" role="banner">
 <div id="header-container">
@@ -53,14 +37,12 @@
 <div class="region region-header-second">
 <div class="region-inner clearfix">
 <div id="block-boxes-1617807424" class="block block-boxes block-boxes-os_boxes_html no-title"  module="boxes" delta="1617807424">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <div class="block-content content" ng-non-bindable="">
 <div id='boxes-box-1617807424' class='boxes-box'>
 <div class="boxes-box-content">
-<h2 class="css-brand--css-geos-meetings-header-h2-xxxlarge">
 <a href="https://geoschem.github.io/"><img style="float: right; width: 350px; height: 249px;" class="media-element file-default file-os-files-large" src="img/img-logo-gce1.png" width="579" height="412" alt="" title="" /></a>
-The 1st (virtual) GEOS-Chem Europe Meeting (GCE1)<br>1-2 Sep, 2020
-</h2>
+<h2 class="css-brand--css-geos-meetings-header-h2-xxxlarge">The 1st (virtual) GEOS-Chem Europe Meeting (GCE1), 1-2 Sep, 2020</h2>
 </div>
 </div>
 </div>
@@ -76,16 +58,17 @@ The 1st (virtual) GEOS-Chem Europe Meeting (GCE1)<br>1-2 Sep, 2020
 
 <!--main menu region beg-->
 <div id="menu-bar" class="nav region-menu-bar clearfix">
-<nav id="block-os-gce1" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="gce1">  
-<ul class="nice-menu nice-menu-down nice-menu-gce1" id="nice-menu-gce1">
-  <li class="menu-857182 menu-path-node-1586483  first   odd  "><a href="gce1.html"  class="active">Home</a></li>
-  <li class="menu-857184 menu-path-node-1586484   even  "><a href="gce1-agenda.html" >Agenda</a></li>
-  <li class="menu-857186 menu-path-node-1586485   odd   last "><a href="gce1-webcast-archive.html" >Webcast Archive</a></li>
+<nav id="block-os-gce1" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="gce1">
+<ul class="nice-menu nice-menu-down">
+  <li><a href="gce1.html" class="active">GCE1 Home</a></li>
+  <li><a href="gce1-agenda.html">Agenda</a></li>
+  <li><a href="gce1-webcast-archive.html">Webcast Archive</a></li>
+  <li><a href="index.html">GEOS-Chem Home</a></li>
 </ul>
 </nav>
 </div>
 <!--main menu region end-->
-		
+
 <div id="columns" class="clearfix">
 <div class="hg-container">
 <div id="content-column" role="main">
@@ -95,26 +78,24 @@ The 1st (virtual) GEOS-Chem Europe Meeting (GCE1)<br>1-2 Sep, 2020
 <a name="main-content"></a>
 <h1 id="page-title" ng-non-bindable="">Agenda</h1>
 </header>
-														
+
 <!--front panel regions beg-->
 <div id="content-panels" class="at-panel gpanel panel-display content clearfix">
 <div class="region region-content-top">
 <div class="region-inner clearfix">
 <div id="block-os-pages-main-content" class="block block-os-pages no-title"  module="os_pages" delta="main_content">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <div class="block-content content" ng-non-bindable="">
 <article id="node-1585687" class="node node-page article clearfix" role="article">
 <div class="node-content" ng-non-bindable="">
 <div class="field field-name-body field-type-text-with-summary field-label-hidden view-mode-full">
 <div class="field-items">
 <div class="field-item even">
-  
-<p>
-	GCE1 was held virtually via Zoom on 1-2 September 2020 and featured keynote presentations by <a href="http://sites.exeter.ac.uk/atmos-chem/" target="_blank">Prof. Nadine Unger</a> at University of Exeter, <a href="https://www.ch.cam.ac.uk/person/as2737" target="_blank">Dr Anja Schmidt</a> at University of Cambridge, and <a href="https://kfolkertboersma.wordpress.com/over/" target="_blank">Dr Folkert Boersma</a> at KNMI/Wageningen University.
+
+<p>GCE1 was held virtually via Zoom on 1-2 September 2020 and featured keynote presentations by <a href="http://sites.exeter.ac.uk/atmos-chem/" target="_blank">Prof. Nadine Unger</a> at University of Exeter, <a href="https://www.ch.cam.ac.uk/person/as2737" target="_blank">Dr Anja Schmidt</a> at University of Cambridge, and <a href="https://kfolkertboersma.wordpress.com/over/" target="_blank">Dr Folkert Boersma</a> at KNMI/Wageningen University.
 </p>
 
-<p>
-	Recordings of the meeting can be viewed here: <a href="https://geos-chem.seas.harvard.edu/geos-meetings-2020-gce-webcast-archive">GCE1 Webcast Archive</a>
+<p>Recordings of the meeting can be viewed here: <a href="https://geos-chem.seas.harvard.edu/geos-meetings-2020-gce-webcast-archive">GCE1 Webcast Archive</a>
 </p>
 
 </div>
@@ -135,64 +116,16 @@ The 1st (virtual) GEOS-Chem Europe Meeting (GCE1)<br>1-2 Sep, 2020
 </div>
 </div>
 
-<!--footer region beg-->
+<!--footer-->
 <footer id="footer" class="clearfix" role="contentinfo">
-
-<!-- Three column 3x33 Gpanel -->
-<div class="at-panel gpanel panel-display footer clearfix">
-<div class="region region-footer">
-<div class="region-inner clearfix">
-<div id="block-boxes-1617037690" class="block block-boxes block-boxes-os_boxes_html no-title"  module="boxes" delta="1617037690">
-<div class="block-inner clearfix">  
-<div class="block-content content" ng-non-bindable="">  
-<div id='boxes-box-1617037690' class='boxes-box'>  
 <div class="boxes-box-content">
   <p style="text-align:center">
-    Copyright © 2023 by the International GEOS-Chem Community. All rights reserved.
+    Copyright © 2026 by the International GEOS-Chem Community. All rights reserved.
   </p>
 </div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-<div class="region region-footer-bottom">  
-<div class="region-inner clearfix">  
-<div id="block-boxes-1616879798" class="block block-boxes block-boxes-os_boxes_media no-title"  module="boxes" delta="1616879798">  
-<div class="block-inner clearfix">  
-<div class="block-content content"> 
-<div id='boxes-box-1616879798' class='boxes-box'> 
-<div class="boxes-box-content"> 
-<div id="file-3900146" class="file file-html file-html-embed">
-<h2 class="element-invisible"><a href="">css-brand</a></h2>
-<div class="content">
-<div class="file-info">
-</div>
-<div class="field field-name-field-html-code field-type-text-long field-label-hidden view-mode-full">
-<div class="field-items">
-<div class="field-item even">
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-
-<!--footer region end-->
 </footer>
-</div>
-</div>
 
-<!--page area ends-->
-<div id="extradiv"></div>
+</div>
 </div>
 
 </body>

--- a/gce1-webcast-archive.html
+++ b/gce1-webcast-archive.html
@@ -1,9 +1,4 @@
 <!DOCTYPE html>
-<!--[if IEMobile 7]><html class="iem7"  lang="en" dir="ltr"><![endif]-->
-<!--[if lte IE 6]><html class="lt-ie9 lt-ie8 lt-ie7"  lang="en" dir="ltr"><![endif]-->
-<!--[if (IE 7)&(!IEMobile)]><html class="lt-ie9 lt-ie8"  lang="en" dir="ltr"><![endif]-->
-<!--[if IE 8]><html class="lt-ie9"  lang="en" dir="ltr"><![endif]-->
-<!--[if (gte IE 9)|(gt IEMobile 7)]><!--><html  lang="en" dir="ltr"><!--<![endif]-->
 <head>
 <meta charset="utf-8" />
 <!--<base href="/gce1-webcast" />-->
@@ -18,23 +13,12 @@
 <title>The 1st Regional GEOS-Chem Europe Meeting</title>
 <meta http-equiv="x-ua-compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<link type="text/css" rel="stylesheet" href="css/css_xE-rWrJf-fncB6ztZfd2huxqgxu4WO-qwma6Xer30m4%EF%B9%96m=1675397288.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_1kR8T1_c-l5pBT6ZwbDT7BFda-4fyqW9Jjum29_2IY8%EF%B9%96m=1675397312.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_YnlUIvHP13qgpYEqubzE8JyDwlSxUnVibfnVkSoSDb0%EF%B9%96m=1675397273.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_Ku-3OcT9qU9h7dnGig5e23q6EVryY8orK4wzVDxsweE%EF%B9%96m=1675397367.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_vprtFTrWyg23GbY50_zJZHWGYMNfS8vsrRS26i4-ISk%EF%B9%96m=1675397406.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_dW-aNNrctRhQNc-KECjtQd0PxuW-h19IEum-TX2MeEk%EF%B9%96m=1675397301.css" media="print" />
-<link type="text/css" rel="stylesheet" href="css/css_SH2Lx3Qprh0GZo_9xRp85U9NsWfkSXn_Bi-rJoMY1sw%EF%B9%96m=1675397273.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_uaIDKcYMUK5osSQXuirpr3ZleXtnnpBN-eiECm7N0M0%EF%B9%96m=1675397395.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/responsive.blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/geos-chem.css" media="all"/>
 <script type="text/javascript" src="dropdown-menu.js"></script>
-<!--[if lte IE 8]>
-<script type="text/javascript">
-  var os_c = document.createElement;os_c('header');os_c('nav');os_c('section');os_c('article');os_c('aside');os_c('footer');os_c('hgroup');os_c('figure');
-</script>
-<![endif]-->
 </head>
 
 <body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-1585687 node-type-page og-context og-context-node og-context-node-1585652 navbar-on">
@@ -45,7 +29,7 @@
 <div id="page_wrap" class="page_wrap">
 <div id="page" class="container page header-main content-top footer-none">
 <div id="page-wrapper">
-		
+
 <!--header regions beg-->
 <header id="header" class="clearfix" role="banner">
 <div id="header-container">
@@ -53,14 +37,12 @@
 <div class="region region-header-second">
 <div class="region-inner clearfix">
 <div id="block-boxes-1617807424" class="block block-boxes block-boxes-os_boxes_html no-title"  module="boxes" delta="1617807424">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <div class="block-content content" ng-non-bindable="">
 <div id='boxes-box-1617807424' class='boxes-box'>
 <div class="boxes-box-content">
-<h2 class="css-brand--css-geos-meetings-header-h2-xxxlarge">
 <a href="https://geoschem.github.io/"><img style="float: right; width: 350px; height: 249px;" class="media-element file-default file-os-files-large" src="img/img-logo-gce1.png" width="579" height="412" alt="" title="" /></a>
-The 1st (virtual) GEOS-Chem Europe Meeting (GCE1)<br>1-2 Sep, 2020
-</h2>
+<h2 class="css-brand--css-geos-meetings-header-h2-xxxlarge">The 1st (virtual) GEOS-Chem Europe Meeting (GCE1), 1-2 Sep, 2020</h2>
 </div>
 </div>
 </div>
@@ -76,16 +58,17 @@ The 1st (virtual) GEOS-Chem Europe Meeting (GCE1)<br>1-2 Sep, 2020
 
 <!--main menu region beg-->
 <div id="menu-bar" class="nav region-menu-bar clearfix">
-<nav id="block-os-gce1" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="gce1">  
-<ul class="nice-menu nice-menu-down nice-menu-gce1" id="nice-menu-gce1">
-  <li class="menu-857182 menu-path-node-1586483  first   odd  "><a href="gce1.html"  class="active">Home</a></li>
-  <li class="menu-857184 menu-path-node-1586484   even  "><a href="gce1-agenda.html" >Agenda</a></li>
-  <li class="menu-857186 menu-path-node-1586485   odd   last "><a href="gce1-webcast-archive.html" >Webcast Archive</a></li>
+<nav id="block-os-gce1" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="gce1">
+<ul class="nice-menu nice-menu-down">
+  <li><a href="gce1.html" class="active">GCE1 Home</a></li>
+  <li><a href="gce1-agenda.html">Agenda</a></li>
+  <li><a href="gce1-agenda.html">Webcast Archive</a></li>
+  <li><a href="index.html">GEOS-Chem Home</a></li>
 </ul>
 </nav>
 </div>
 <!--main menu region end-->
-		
+
 <div id="columns" class="clearfix">
 <div class="hg-container">
 <div id="content-column" role="main">
@@ -95,40 +78,39 @@ The 1st (virtual) GEOS-Chem Europe Meeting (GCE1)<br>1-2 Sep, 2020
 <a name="main-content"></a>
 <h1 id="page-title" ng-non-bindable="">Webcast Archive</h1>
 </header>
-														
+
 <!--front panel regions beg-->
 <div id="content-panels" class="at-panel gpanel panel-display content clearfix">
 <div class="region region-content-top">
 <div class="region-inner clearfix">
 <div id="block-os-pages-main-content" class="block block-os-pages no-title"  module="os_pages" delta="main_content">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <div class="block-content content" ng-non-bindable="">
 <article id="node-1585687" class="node node-page article clearfix" role="article">
 <div class="node-content" ng-non-bindable="">
 <div class="field field-name-body field-type-text-with-summary field-label-hidden view-mode-full">
 <div class="field-items">
 <div class="field-item even">
-  
-<h2>
-	Tuesday, 1 September
-</h2>
 
-<ul><li>
-		<b><a href="https://youtu.be/v3qWD_gRBPc" target="_blank">Day 1 Morning Session</a></b>: Air Quality
-	</li>
-	<li>
-		<b><a href="https://youtu.be/3-PSq1TKyRY" target="_blank">Day 1 Afternoon Session</a></b>: Model Overview, Greenhouse Gases
-	</li>
-</ul><h2>
-	Wednesday, 2 September
-</h2>
+<h2>Tuesday, 1 September</h2>
 
-<ul><li>
-		<b><a href="https://youtu.be/YTbXeWiUuTU" target="_blank">Day 2 Morning Session</a></b>: Interface of Models and Satellites
-	</li>
-	<li>
-		<b><a href="https://youtu.be/OUyBOJiZD74" target="_blank">Day 2 Afternoon Session</a></b>: Aerosols
-	</li>
+<ul>
+  <li>
+    <b><a href="https://youtu.be/v3qWD_gRBPc" target="_blank">Day 1 Morning Session</a></b>: Air Quality
+  </li>
+  <li>
+    <b><a href="https://youtu.be/3-PSq1TKyRY" target="_blank">Day 1 Afternoon Session</a></b>: Model Overview, Greenhouse Gases
+  </li>
+
+</ul><h2>Wednesday, 2 September</h2>
+
+<ul>
+  <li>
+    <b><a href="https://youtu.be/YTbXeWiUuTU" target="_blank">Day 2 Morning Session</a></b>: Interface of Models and Satellites
+  </li>
+  <li>
+    <b><a href="https://youtu.be/OUyBOJiZD74" target="_blank">Day 2 Afternoon Session</a></b>: Aerosols
+  </li>
 </ul>
 
 </div>
@@ -149,64 +131,16 @@ The 1st (virtual) GEOS-Chem Europe Meeting (GCE1)<br>1-2 Sep, 2020
 </div>
 </div>
 
-<!--footer region beg-->
+<!--footer-->
 <footer id="footer" class="clearfix" role="contentinfo">
-
-<!-- Three column 3x33 Gpanel -->
-<div class="at-panel gpanel panel-display footer clearfix">
-<div class="region region-footer">
-<div class="region-inner clearfix">
-<div id="block-boxes-1617037690" class="block block-boxes block-boxes-os_boxes_html no-title"  module="boxes" delta="1617037690">
-<div class="block-inner clearfix">  
-<div class="block-content content" ng-non-bindable="">  
-<div id='boxes-box-1617037690' class='boxes-box'>  
 <div class="boxes-box-content">
   <p style="text-align:center">
-    Copyright © 2023 by the International GEOS-Chem Community. All rights reserved.
+    Copyright © 2026 by the International GEOS-Chem Community. All rights reserved.
   </p>
 </div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-<div class="region region-footer-bottom">  
-<div class="region-inner clearfix">  
-<div id="block-boxes-1616879798" class="block block-boxes block-boxes-os_boxes_media no-title"  module="boxes" delta="1616879798">  
-<div class="block-inner clearfix">  
-<div class="block-content content"> 
-<div id='boxes-box-1616879798' class='boxes-box'> 
-<div class="boxes-box-content"> 
-<div id="file-3900146" class="file file-html file-html-embed">
-<h2 class="element-invisible"><a href="">css-brand</a></h2>
-<div class="content">
-<div class="file-info">
-</div>
-<div class="field field-name-field-html-code field-type-text-long field-label-hidden view-mode-full">
-<div class="field-items">
-<div class="field-item even">
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-
-<!--footer region end-->
 </footer>
-</div>
-</div>
 
-<!--page area ends-->
-<div id="extradiv"></div>
+</div>
 </div>
 
 </body>

--- a/gce1.html
+++ b/gce1.html
@@ -1,9 +1,4 @@
 <!DOCTYPE html>
-<!--[if IEMobile 7]><html class="iem7"  lang="en" dir="ltr"><![endif]-->
-<!--[if lte IE 6]><html class="lt-ie9 lt-ie8 lt-ie7"  lang="en" dir="ltr"><![endif]-->
-<!--[if (IE 7)&(!IEMobile)]><html class="lt-ie9 lt-ie8"  lang="en" dir="ltr"><![endif]-->
-<!--[if IE 8]><html class="lt-ie9"  lang="en" dir="ltr"><![endif]-->
-<!--[if (gte IE 9)|(gt IEMobile 7)]><!--><html  lang="en" dir="ltr"><!--<![endif]-->
 <head>
 <meta charset="utf-8" />
 <!--<base href="/gce1" />-->
@@ -18,23 +13,12 @@
 <title>The 1st Regional GEOS-Chem Europe Meeting</title>
 <meta http-equiv="x-ua-compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<link type="text/css" rel="stylesheet" href="css/css_xE-rWrJf-fncB6ztZfd2huxqgxu4WO-qwma6Xer30m4%EF%B9%96m=1675397288.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_1kR8T1_c-l5pBT6ZwbDT7BFda-4fyqW9Jjum29_2IY8%EF%B9%96m=1675397312.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_YnlUIvHP13qgpYEqubzE8JyDwlSxUnVibfnVkSoSDb0%EF%B9%96m=1675397273.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_Ku-3OcT9qU9h7dnGig5e23q6EVryY8orK4wzVDxsweE%EF%B9%96m=1675397367.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_vprtFTrWyg23GbY50_zJZHWGYMNfS8vsrRS26i4-ISk%EF%B9%96m=1675397406.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_dW-aNNrctRhQNc-KECjtQd0PxuW-h19IEum-TX2MeEk%EF%B9%96m=1675397301.css" media="print" />
-<link type="text/css" rel="stylesheet" href="css/css_SH2Lx3Qprh0GZo_9xRp85U9NsWfkSXn_Bi-rJoMY1sw%EF%B9%96m=1675397273.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_uaIDKcYMUK5osSQXuirpr3ZleXtnnpBN-eiECm7N0M0%EF%B9%96m=1675397395.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/responsive.blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/geos-chem.css" media="all"/>
 <script type="text/javascript" src="dropdown-menu.js"></script>
-<!--[if lte IE 8]>
-<script type="text/javascript">
-  var os_c = document.createElement;os_c('header');os_c('nav');os_c('section');os_c('article');os_c('aside');os_c('footer');os_c('hgroup');os_c('figure');
-</script>
-<![endif]-->
 </head>
 
 <body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-1585687 node-type-page og-context og-context-node og-context-node-1585652 navbar-on">
@@ -45,7 +29,7 @@
 <div id="page_wrap" class="page_wrap">
 <div id="page" class="container page header-main content-top footer-none">
 <div id="page-wrapper">
-		
+
 <!--header regions beg-->
 <header id="header" class="clearfix" role="banner">
 <div id="header-container">
@@ -53,14 +37,12 @@
 <div class="region region-header-second">
 <div class="region-inner clearfix">
 <div id="block-boxes-1617807424" class="block block-boxes block-boxes-os_boxes_html no-title"  module="boxes" delta="1617807424">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <div class="block-content content" ng-non-bindable="">
 <div id='boxes-box-1617807424' class='boxes-box'>
 <div class="boxes-box-content">
-<h2 class="css-brand--css-geos-meetings-header-h2-xxxlarge">
 <a href="https://geoschem.github.io/"><img style="float: right; width: 350px; height: 249px;" class="media-element file-default file-os-files-large" src="img/img-logo-gce1.png" width="579" height="412" alt="" title="" /></a>
-The 1st (virtual) GEOS-Chem Europe Meeting (GCE1)<br>1-2 Sep, 2020
-</h2>
+<h2 class="css-brand--css-geos-meetings-header-h2-xxxlarge">The 1st (virtual) GEOS-Chem Europe Meeting (GCE1), 1-2 Sep, 2020</h2>
 </div>
 </div>
 </div>
@@ -76,16 +58,17 @@ The 1st (virtual) GEOS-Chem Europe Meeting (GCE1)<br>1-2 Sep, 2020
 
 <!--main menu region beg-->
 <div id="menu-bar" class="nav region-menu-bar clearfix">
-<nav id="block-os-gce1" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="gce1">  
-<ul class="nice-menu nice-menu-down nice-menu-gce1" id="nice-menu-gce1">
-  <li class="menu-857182 menu-path-node-1586483  first   odd  "><a href="gce1.html"  class="active">Home</a></li>
-  <li class="menu-857184 menu-path-node-1586484   even  "><a href="gce1-agenda.html" >Agenda</a></li>
-  <li class="menu-857186 menu-path-node-1586485   odd   last "><a href="gce1-webcast-archive.html" >Webcast Archive</a></li>
+<nav id="block-os-gce1" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="gce1">
+<ul class="nice-menu nice-menu-down">
+  <li><a href="gce1.html" class="active">GCE1 Home</a></li>
+  <li><a href="gce1-agenda.html">Agenda</a></li>
+  <li><a href="gce1-webcast-archive.html">Webcast Archive</a></li>
+  <li><a href="index.html">GEOS-Chem Home</a></li>
 </ul>
 </nav>
 </div>
 <!--main menu region end-->
-		
+
 <div id="columns" class="clearfix">
 <div class="hg-container">
 <div id="content-column" role="main">
@@ -95,27 +78,23 @@ The 1st (virtual) GEOS-Chem Europe Meeting (GCE1)<br>1-2 Sep, 2020
 <a name="main-content"></a>
 <h1 id="page-title" ng-non-bindable="">Overview</h1>
 </header>
-														
+
 <!--front panel regions beg-->
 <div id="content-panels" class="at-panel gpanel panel-display content clearfix">
 <div class="region region-content-top">
 <div class="region-inner clearfix">
 <div id="block-os-pages-main-content" class="block block-os-pages no-title"  module="os_pages" delta="main_content">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <div class="block-content content" ng-non-bindable="">
 <article id="node-1585687" class="node node-page article clearfix" role="article">
 <div class="node-content" ng-non-bindable="">
 <div class="field field-name-body field-type-text-with-summary field-label-hidden view-mode-full">
 <div class="field-items">
 <div class="field-item even">
-  
-<p>
-	The 1st GEOS-Chem Europe meeting (GCE1) was held virtually via Zoom on 1-2 September 2020. The meeting was organized by Mathew Evans (York), Eloise Marais (UCL), and Paul Palmer (Edinburgh).
-</p>
 
-<p>
-	We look forward to seeing you at the next GEOS-Chem Europe Meeting!
-</p>
+<p>The 1st GEOS-Chem Europe meeting (GCE1) was held virtually via Zoom on 1-2 September 2020. The meeting was organized by Mathew Evans (York), Eloise Marais (UCL), and Paul Palmer (Edinburgh).</p>
+
+<p>We look forward to seeing you at the next GEOS-Chem Europe Meeting!</p>
 
 </div>
 </div>
@@ -135,64 +114,16 @@ The 1st (virtual) GEOS-Chem Europe Meeting (GCE1)<br>1-2 Sep, 2020
 </div>
 </div>
 
-<!--footer region beg-->
+<!--footer-->
 <footer id="footer" class="clearfix" role="contentinfo">
-
-<!-- Three column 3x33 Gpanel -->
-<div class="at-panel gpanel panel-display footer clearfix">
-<div class="region region-footer">
-<div class="region-inner clearfix">
-<div id="block-boxes-1617037690" class="block block-boxes block-boxes-os_boxes_html no-title"  module="boxes" delta="1617037690">
-<div class="block-inner clearfix">  
-<div class="block-content content" ng-non-bindable="">  
-<div id='boxes-box-1617037690' class='boxes-box'>  
 <div class="boxes-box-content">
   <p style="text-align:center">
-    Copyright © 2023 by the International GEOS-Chem Community. All rights reserved.
+    Copyright © 2026 by the International GEOS-Chem Community. All rights reserved.
   </p>
 </div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-<div class="region region-footer-bottom">  
-<div class="region-inner clearfix">  
-<div id="block-boxes-1616879798" class="block block-boxes block-boxes-os_boxes_media no-title"  module="boxes" delta="1616879798">  
-<div class="block-inner clearfix">  
-<div class="block-content content"> 
-<div id='boxes-box-1616879798' class='boxes-box'> 
-<div class="boxes-box-content"> 
-<div id="file-3900146" class="file file-html file-html-embed">
-<h2 class="element-invisible"><a href="">css-brand</a></h2>
-<div class="content">
-<div class="file-info">
-</div>
-<div class="field field-name-field-html-code field-type-text-long field-label-hidden view-mode-full">
-<div class="field-items">
-<div class="field-item even">
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-
-<!--footer region end-->
 </footer>
-</div>
-</div>
 
-<!--page area ends-->
-<div id="extradiv"></div>
+</div>
 </div>
 
 </body>

--- a/gce2-presentations.html
+++ b/gce2-presentations.html
@@ -1,9 +1,4 @@
 <!DOCTYPE html>
-<!--[if IEMobile 7]><html class="iem7"  lang="en" dir="ltr"><![endif]-->
-<!--[if lte IE 6]><html class="lt-ie9 lt-ie8 lt-ie7"  lang="en" dir="ltr"><![endif]-->
-<!--[if (IE 7)&(!IEMobile)]><html class="lt-ie9 lt-ie8"  lang="en" dir="ltr"><![endif]-->
-<!--[if IE 8]><html class="lt-ie9"  lang="en" dir="ltr"><![endif]-->
-<!--[if (gte IE 9)|(gt IEMobile 7)]><!--><html  lang="en" dir="ltr"><!--<![endif]-->
 <head>
 <meta charset="utf-8" />
 <!--<base href="/gce2" />-->
@@ -18,23 +13,12 @@
 <title>The 2nd Regional GEOS-Chem Europe Meeting</title>
 <meta http-equiv="x-ua-compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<link type="text/css" rel="stylesheet" href="css/css_xE-rWrJf-fncB6ztZfd2huxqgxu4WO-qwma6Xer30m4%EF%B9%96m=1675397288.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_1kR8T1_c-l5pBT6ZwbDT7BFda-4fyqW9Jjum29_2IY8%EF%B9%96m=1675397312.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_YnlUIvHP13qgpYEqubzE8JyDwlSxUnVibfnVkSoSDb0%EF%B9%96m=1675397273.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_Ku-3OcT9qU9h7dnGig5e23q6EVryY8orK4wzVDxsweE%EF%B9%96m=1675397367.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_vprtFTrWyg23GbY50_zJZHWGYMNfS8vsrRS26i4-ISk%EF%B9%96m=1675397406.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_dW-aNNrctRhQNc-KECjtQd0PxuW-h19IEum-TX2MeEk%EF%B9%96m=1675397301.css" media="print" />
-<link type="text/css" rel="stylesheet" href="css/css_SH2Lx3Qprh0GZo_9xRp85U9NsWfkSXn_Bi-rJoMY1sw%EF%B9%96m=1675397273.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_uaIDKcYMUK5osSQXuirpr3ZleXtnnpBN-eiECm7N0M0%EF%B9%96m=1675397395.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/responsive.blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/geos-chem.css" media="all"/>
 <script type="text/javascript" src="dropdown-menu.js"></script>
-<!--[if lte IE 8]>
-<script type="text/javascript">
-  var os_c = document.createElement;os_c('header');os_c('nav');os_c('section');os_c('article');os_c('aside');os_c('footer');os_c('hgroup');os_c('figure');
-</script>
-<![endif]-->
 </head>
 
 <body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-1585687 node-type-page og-context og-context-node og-context-node-1585652 navbar-on">
@@ -45,7 +29,7 @@
 <div id="page_wrap" class="page_wrap">
 <div id="page" class="container page header-main content-top footer-none">
 <div id="page-wrapper">
-		
+    
 <!--header regions beg-->
 <header id="header" class="clearfix" role="banner">
 <div id="header-container">
@@ -57,10 +41,8 @@
 <div class="block-content content" ng-non-bindable="">
 <div id='boxes-box-1617807424' class='boxes-box'>
 <div class="boxes-box-content">
-<h2 class="css-brand--css-geos-meetings-header-h2-xxxlarge">
 <a href="https://geoschem.github.io/"><img style="float: right; width: 300px; height: 249px;" class="media-element file-default file-os-files-large"  src="img/gce2_ucl_portico_london.png" width="579" height="412" alt="" title="" /></a>
-The 2nd GEOS-Chem Europe Meeting (GCE2)<br>14-16 Aug, 2023
-</h2>
+<h2 class="css-brand--css-geos-meetings-header-h2-xxxlarge">The 2nd GEOS-Chem Europe Meeting (GCE2), 14-16 Aug, 2023</h2>
 </div>
 </div>
 </div>
@@ -76,17 +58,16 @@ The 2nd GEOS-Chem Europe Meeting (GCE2)<br>14-16 Aug, 2023
 
 <!--main menu region beg-->
 <div id="menu-bar" class="nav region-menu-bar clearfix">
-<!--<nav id="block-os-primary-menu" class="block block-os no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="primary-menu">
-<script>inlineDropDownMenu();</script>
-</nav>-->
-<nav id="block-os-gce1" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="gce1">  
-  <ul class="nice-menu nice-menu-down nice-menu-gce1" id="nice-menu-gce1">
-  <li class="menu-857182 menu-path-node-1586483  first   odd  "><a href="gce2.html"  >Home</a></li>
-  <li class="menu-857182 menu-path-node-1586483   even  "><a href="gce2-presentations.html"  title="">Presentations and posters</a></li>
+<nav id="block-os-gce2" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="gce2">
+<ul class="nice-menu nice-menu-down">
+  <li><a href="gce2.html" class="active">GCE2 Home</a></li>
+  <li><a href="gce2-presentations.html">Presentations and posters</a></li>
+  <li><a href="index.html">GEOS-Chem Home</a></li>
+</ul>
 </nav>
 </div>
 <!--main menu region end-->
-		
+    
 <div id="columns" class="clearfix">
 <div class="hg-container">
 <div id="content-column" role="main">
@@ -96,7 +77,7 @@ The 2nd GEOS-Chem Europe Meeting (GCE2)<br>14-16 Aug, 2023
 <a name="main-content"></a>
 <h1 id="page-title" ng-non-bindable="">Tentative agenda</h1>
 </header>
-														
+                            
 <!--front panel regions beg-->
 <div id="content-panels" class="at-panel gpanel panel-display content clearfix">
 <div class="region region-content-top">
@@ -111,183 +92,178 @@ The 2nd GEOS-Chem Europe Meeting (GCE2)<br>14-16 Aug, 2023
 <div class="field-item even">
 
 <p align="justify">
-	<strong>
-	Monday, 14 August: <a href="#overview">Meeting and Model Overview</a> | <a href="#emissions">Emissions</a>
-	<br class="clearfix" />
-	Tuesday, 15 August: <a href="#models">Models to Motivate Action</a> | <a href="#particles">Particles Great and Small</a> | <a href="#policy">Modelling to Inform Environmental Policy</a> | <a href="#posters">Posters</a>
-	<br class="clearfix" />
-	Wednesday, 16 August: <a href="#composition1">Tropospheric composition, part 1</a> | <a href="#composition2">Tropospheric Composition, part 2</a>
-	</strong>
+  <strong>
+  Monday, 14 August: <a href="#overview">Meeting and Model Overview</a> | <a href="#emissions">Emissions</a>
+  <br class="clearfix" />
+  Tuesday, 15 August: <a href="#models">Models to Motivate Action</a> | <a href="#particles">Particles Great and Small</a> | <a href="#policy">Modelling to Inform Environmental Policy</a> | <a href="#posters">Posters</a>
+  <br class="clearfix" />
+  Wednesday, 16 August: <a href="#composition1">Tropospheric composition, part 1</a> | <a href="#composition2">Tropospheric Composition, part 2</a>
+  </strong>
 </p>
 
-<div>
-	<h2>
-		Monday 14 August
-	</h2>
-	
-	<a name="overview" id="overview"></a><strong>Meeting and Model Overview (Chair: Karn Vohra, UCL)</strong>
-	<ul>
-		<li>
-			<a href="https://drive.google.com/file/d/1b5Z4h1griW5qXgfsZX2ou8eXQpgzXdj6/view?usp=drive_link">Welcome and meeting overview</a> (Eloise Marais, UCL)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/17DaIsPAUfUGbrlXebvS2lfelmDs-A1Ae/view?usp=drive_link">GEOS-Chem Model Overview</a> (Randall Martin, WUSTL)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1tvetjMeCKpne0BzY_9OR7QqStBF5di8N/view?usp=drive_link">GEOS-Chem Technical Overview</a> (Melissa Sulprizio, Harvard)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/16xiIGExM6D9qTD8yPro845-1w4On4UV-/view?usp=drive_link">GCHP Demonstration</a> (Killian Murphy, York)
-		</li>
-	</ul>
-	
-	<a name="emissions" id="emissions"></a><strong> Emissions (Chair: Matthew Rowlinson, York)</strong>
-	<ul>
-		<li>
-			<a href="https://drive.google.com/file/d/12K6vMd-8ZNEKGknQT49M9S14ADGG0t7n/view?usp=drive_link">European Emissions for GEOS-Chem</a> (Mat Evans, York)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1KJ6NiwTBM9qlbR8WSxtCI1Df9New6WIV/view?usp=drive_link">Assessing HTAP NOx Emissions in Cities in South and Southeast Asia using TROPOMI</a> (Gongda Lu, UCL)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1rlsAgSAGSU9lrfdh2DDQuNtQkABgYbgb/view?usp=drive_link">Implementing an improved parameterisation for inorganic iodine emissions in GEOS-Chem</a> (Ryan Pound, York)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1vrpKeZmzh2efZ_CJF7xHD1Y1emnFy5ZX/view?usp=drive_link">An inverse modelling framework to estimate the GHG emissions for the UK</a> (Alex Kurganskiy, Edinburgh)
-		</li>
-	</ul>
-</div>
+<h2>Monday 14 August</h2>
 
-<div>
-	<h2>
-		Tuesday 15 August
-	</h2>
-	
-	<a name="models" id="models"></a><strong>Models to Motivate Action (Chair: Alex Kurganskiy, Edinburgh)</strong>
-	<ul>
-		<li>
-			<a href="https://drive.google.com/file/d/1ajcNeng-9cIBYsx8AN9kfJ7UAqetSp-n/view?usp=drive_link">KEYNOTE: The use of atmospheric chemistry models in air pollution activism</a> (Jamie Kelly, Centre for Research on Energy and Clean Air (CREA))
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1aDxWRVNNXoK6roKQlPXbmmxIj5jd5WD_/view?usp=drive_link">Investigating climate co-benefits using GEOS-Chem adjoint sensitivities</a> (Omar Nawaz, GWU)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1vYLKBSg2E9FJURfMt1iX-1qMEh7UpvBX/view?usp=drive_link">Early deaths, asthma exacerbation and cancer risks linked to air pollution from each major oil and gas lifecycle stage in the US</a> (Karn Vohra, UCL)
+<a name="overview" id="overview"></a><strong>Meeting and Model Overview (Chair: Karn Vohra, UCL)</strong>
 
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1Bg1qsnRHLCd04KF-ZHgsyAEfgGTpH51K/view?usp=drive_link">Evaluation of the atmospheric impact of supersonic emissions from the SCENIC project on a 2050 atmosphere</a> (Jurriaan van 't Hoff, TU Delft)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1avlYU7Cv-7VaxCqzRs8Mv9MkSPRGwTV5/view?usp=drive_link">Impacts of megaconstellation satellite launches and end-of-life satellite disposal on stratospheric ozone and climate</a> (Connor Barker, UCL)
-		</li>
-	</ul>
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1b5Z4h1griW5qXgfsZX2ou8eXQpgzXdj6/view?usp=drive_link">Welcome and meeting overview</a> (Eloise Marais, UCL)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/17DaIsPAUfUGbrlXebvS2lfelmDs-A1Ae/view?usp=drive_link">GEOS-Chem Model Overview</a> (Randall Martin, WUSTL)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1tvetjMeCKpne0BzY_9OR7QqStBF5di8N/view?usp=drive_link">GEOS-Chem Technical Overview</a> (Melissa Sulprizio, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/16xiIGExM6D9qTD8yPro845-1w4On4UV-/view?usp=drive_link">GCHP Demonstration</a> (Killian Murphy, York)
+  </li>
+</ul>
 
-	<a name="particles" id="particles"></a><strong>Particles Great and Small (Chair: Hansen Cao, York)</strong>
-	<ul>
-		<li>
-			<a href="https://drive.google.com/file/d/1Ixj0dUh84DWEiguvLcPqRqKAAs9XgsID/view?usp=drive_link">KEYNOTE: Plastic aerosols - what do we know?</a> (Stephanie Wright, Imperial College London)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1v__8DVMsvusYhMcODYekFsIImHp-Jcxc/view?usp=drive_link">Advances in Simulating the Global Spatial Heterogeneity of Air Quality using GCHP and Its Implications for the Relation of AOD with PM2.5</a> (Dandan Zhang, WUSTL)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/14yPcqCxd_bbQctXyBiN_Yj9SgHmJiN8K/view?usp=drive_link">Porting GEOS-Chem Chemistry to External Models</a> (Lizzie Lundgren, Harvard)
-		</li>
-	</ul>
+<a name="emissions" id="emissions"></a><strong> Emissions (Chair: Matthew Rowlinson, York)</strong>
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/12K6vMd-8ZNEKGknQT49M9S14ADGG0t7n/view?usp=drive_link">European Emissions for GEOS-Chem</a> (Mat Evans, York)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1KJ6NiwTBM9qlbR8WSxtCI1Df9New6WIV/view?usp=drive_link">Assessing HTAP NOx Emissions in Cities in South and Southeast Asia using TROPOMI</a> (Gongda Lu, UCL)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1rlsAgSAGSU9lrfdh2DDQuNtQkABgYbgb/view?usp=drive_link">Implementing an improved parameterisation for inorganic iodine emissions in GEOS-Chem</a> (Ryan Pound, York)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1vrpKeZmzh2efZ_CJF7xHD1Y1emnFy5ZX/view?usp=drive_link">An inverse modelling framework to estimate the GHG emissions for the UK</a> (Alex Kurganskiy, Edinburgh)
+  </li>
+</ul>
 
+<h2>Tuesday 15 August</h2>
 
-	<a name="posters" id="posters"></a><strong>Posters</strong>
-	<ul>
-		<li>
-			Modeling biomass burning impacts on air quality in Canada</a> (Samaneh Ashraf, UdeMP)
-		</li>
-		<li>
-			Spatio-temporal variability of atmospheric mercury over India by using ground-based observations and GEOS-Chem model simulations (M.Chakradhar Reddy, IIT-Madras)
-		</li>
-		<li>
-			Using GEOS-Chem for retrieval of vertical profiles of atmospheric composition over Central London (Eleanor Gershenson-Smith, UCL)
-		</li>
-		<li>
-			Exploring the impact of biogenic and pyrogenic emissions in South America with GEOS-Chem and satellite data (Susie Shihan Sun, Edinburgh)
-		</li>
-		<li>
-			Exploring marine boundary layer halogen chemistry using GEOS-Chem (Amy Lees, York)
-		</li>
-		<li>
-			Global simulation of tropospheric halogen multiphase chemistry (Hansen Cao, York)
-		</li>
-		<li>
-			Development of versatile Python software to retrieve tropospheric vertical profiles of NO2 and ozone from satellite observations (Gongda Lu, UCL)
-		</li>
-		<li>
-			The impact of diurnal variation in African wildfires on atmospheric chemistry (Haolin Wang, Sun Yat-sen U.)
-		</li>
-		<li>
-			Climate effect of biomass burning aerosol from key biomass burning regions (Shuaiyi Shi, Edinburgh)
-		</li>
-	</ul>
+<a name="models" id="models"></a><strong>Models to Motivate Action (Chair: Alex Kurganskiy, Edinburgh)</strong>
 
-	<a name="policy" id="policy"></a><strong>Modelling to Inform Environmental Policy (Chair: Connor Barker, UCL)</strong>
-	<ul>
-		<li>
-			<a href="https://drive.google.com/file/d/1cfvKtmTzAacY2sifxc1jqdekR3yVIAQO/view?usp=drive_link">KEYNOTE: How the UK Department for the Environment, Food and Rural Affairs (DEFRA) uses air quality models to inform policy</a> (Alison Davies, DEFRA)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1HXnJyOP8B0mH7fFh--63SrCVgfOWObK9/view?usp=drive_link">Emerging capabilities for GEOS-Chem Meteorological datasets</a> (Saptarshi Sinha, WUSTL)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1ecErLc1Cj_yFv2f51mn1r6vk9dw-vcYd/view?usp=drive_link">Sensitivity of Air Quality (AQ) in Eastern Canada to Transboundary Pollution and Meteorology: Understanding Potential Climate-AQ Feedbacks</a> (Robin Stevens, UdeM.)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1IbR0OmmTiW3-H1a5LoC8LINvjQjPzstJ/view?usp=drive_link">Present-day and next mid-century estimates of global aviation impacts on air quality</a> (Flávio Quadros, TU Delft)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1B2lPHB6Qt5A8Fhf8G8aprIKlcxfX9F5t/view?usp=drive_link">Effects of model resolution on simulated air quality impacts from aviation</a> (Seb Eastham, MIT)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/16ABPy00zdXeNPJ3xkTs_ZeVNWbNZL7RC/view?usp=drive_link">UK public health and ecosystem benefits from adopting technically feasible emissions controls throughout Europe</a> (Eloise Marais, UCL)
-		</li>
-	</ul>
-</div>
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1ajcNeng-9cIBYsx8AN9kfJ7UAqetSp-n/view?usp=drive_link">KEYNOTE: The use of atmospheric chemistry models in air pollution activism</a> (Jamie Kelly, Centre for Research on Energy and Clean Air (CREA))
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1aDxWRVNNXoK6roKQlPXbmmxIj5jd5WD_/view?usp=drive_link">Investigating climate co-benefits using GEOS-Chem adjoint sensitivities</a> (Omar Nawaz, GWU)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1vYLKBSg2E9FJURfMt1iX-1qMEh7UpvBX/view?usp=drive_link">Early deaths, asthma exacerbation and cancer risks linked to air pollution from each major oil and gas lifecycle stage in the US</a> (Karn Vohra, UCL)
 
-<div>
-	<h2>
-		Wednesday 16 August
-	</h2>
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Bg1qsnRHLCd04KF-ZHgsyAEfgGTpH51K/view?usp=drive_link">Evaluation of the atmospheric impact of supersonic emissions from the SCENIC project on a 2050 atmosphere</a> (Jurriaan van 't Hoff, TU Delft)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1avlYU7Cv-7VaxCqzRs8Mv9MkSPRGwTV5/view?usp=drive_link">Impacts of megaconstellation satellite launches and end-of-life satellite disposal on stratospheric ozone and climate</a> (Connor Barker, UCL)
+  </li>
+</ul>
 
-	<a name="composition1" id="composition1"></a><strong>Tropospheric composition (mostly ozone) part 1 (Chair: Susie Shihan Sun, Edinburgh)</strong>
-	<ul>
-		<li>
-			<a href="https://drive.google.com/file/d/1addXrQKxyOnpX-BgwIjZVnLG6ZZ2v3Q7/view?usp=drive_link">KEYNOTE: The role of atmospheric non-linearities in understanding aviation emissions‘ impacts </a> (Irene Dedoussi, TU Delft)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1DGN1HnNrMdHsy-mGAHe7P5yzGR7cRjkl/view?usp=drive_link">Why is tropospheric ozone around 40 ppbv?</a> (Mat Evans, York)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1xvFLqj4HQR3S_xWq0Yb0Jxw6-VXk5_WK/view?usp=drive_link">Why is background ozone over East Asia so high?</a> (Nadia Kathryn Colombi, Harvard)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/13ACwsDesD7YRgYUvHt6NKqUaPJpTpsTn/view?usp=drive_link">Evaluation of GEOS-Chem vertical profiles of nitrogen dioxide (NO2) and ozone (O3) using cloudsliced TROPOMI columns</a> (Bex Horner, UCL)
-		</li>
-	</ul>
+<a name="particles" id="particles"></a><strong>Particles Great and Small (Chair: Hansen Cao, York)</strong>
 
-	<a name="composition2" id="composition2"></a><strong>Tropospheric composition (mostly ozone) part 2 (Gongda Lu, UCL)</strong>
-	<ul>
-		<li>
-			The rise and rise of atmospheric methane: an unfolding story about hotspots and wet spots (Paul Palmer, Edinburgh)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1_ry9MR6BA5XKRSb7fMxQQHd-JFASWOXr/view?usp=drive_link">Implementation of an observationally-constrained nitrate photolysis parameterisation and the impact on tropospheric ozone</a> (Mathew Rowlinson, York)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/14WINcSbKDbmSnJLYT3WQTBmAL5rw3T65/view?usp=drive_link">Reactive nitrogen and ozone in the global upper troposphere: Insights from historic DC8 aircraft campaigns and GEOS-Chem</a> (Nana Wei, UCL)
-		</li>
-		<li>
-			Closing Remarks (Eloise Marais, UCL)
-		</li>
-	</ul>
-</div>
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1Ixj0dUh84DWEiguvLcPqRqKAAs9XgsID/view?usp=drive_link">KEYNOTE: Plastic aerosols - what do we know?</a> (Stephanie Wright, Imperial College London)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1v__8DVMsvusYhMcODYekFsIImHp-Jcxc/view?usp=drive_link">Advances in Simulating the Global Spatial Heterogeneity of Air Quality using GCHP and Its Implications for the Relation of AOD with PM2.5</a> (Dandan Zhang, WUSTL)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/14yPcqCxd_bbQctXyBiN_Yj9SgHmJiN8K/view?usp=drive_link">Porting GEOS-Chem Chemistry to External Models</a> (Lizzie Lundgren, Harvard)
+  </li>
+</ul>
+
+<a name="posters" id="posters"></a><strong>Posters</strong>
+
+<ul>
+  <li>
+    Modeling biomass burning impacts on air quality in Canada</a> (Samaneh Ashraf, UdeMP)
+  </li>
+  <li>
+    Spatio-temporal variability of atmospheric mercury over India by using ground-based observations and GEOS-Chem model simulations (M.Chakradhar Reddy, IIT-Madras)
+  </li>
+  <li>
+    Using GEOS-Chem for retrieval of vertical profiles of atmospheric composition over Central London (Eleanor Gershenson-Smith, UCL)
+  </li>
+  <li>
+    Exploring the impact of biogenic and pyrogenic emissions in South America with GEOS-Chem and satellite data (Susie Shihan Sun, Edinburgh)
+  </li>
+  <li>
+    Exploring marine boundary layer halogen chemistry using GEOS-Chem (Amy Lees, York)
+  </li>
+  <li>
+    Global simulation of tropospheric halogen multiphase chemistry (Hansen Cao, York)
+  </li>
+  <li>
+    Development of versatile Python software to retrieve tropospheric vertical profiles of NO2 and ozone from satellite observations (Gongda Lu, UCL)
+  </li>
+  <li>
+    The impact of diurnal variation in African wildfires on atmospheric chemistry (Haolin Wang, Sun Yat-sen U.)
+  </li>
+  <li>
+    Climate effect of biomass burning aerosol from key biomass burning regions (Shuaiyi Shi, Edinburgh)
+  </li>
+</ul>
+
+<a name="policy" id="policy"></a><strong>Modelling to Inform Environmental Policy (Chair: Connor Barker, UCL)</strong>
+
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1cfvKtmTzAacY2sifxc1jqdekR3yVIAQO/view?usp=drive_link">KEYNOTE: How the UK Department for the Environment, Food and Rural Affairs (DEFRA) uses air quality models to inform policy</a> (Alison Davies, DEFRA)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1HXnJyOP8B0mH7fFh--63SrCVgfOWObK9/view?usp=drive_link">Emerging capabilities for GEOS-Chem Meteorological datasets</a> (Saptarshi Sinha, WUSTL)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1ecErLc1Cj_yFv2f51mn1r6vk9dw-vcYd/view?usp=drive_link">Sensitivity of Air Quality (AQ) in Eastern Canada to Transboundary Pollution and Meteorology: Understanding Potential Climate-AQ Feedbacks</a> (Robin Stevens, UdeM.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1IbR0OmmTiW3-H1a5LoC8LINvjQjPzstJ/view?usp=drive_link">Present-day and next mid-century estimates of global aviation impacts on air quality</a> (Flávio Quadros, TU Delft)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1B2lPHB6Qt5A8Fhf8G8aprIKlcxfX9F5t/view?usp=drive_link">Effects of model resolution on simulated air quality impacts from aviation</a> (Seb Eastham, MIT)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/16ABPy00zdXeNPJ3xkTs_ZeVNWbNZL7RC/view?usp=drive_link">UK public health and ecosystem benefits from adopting technically feasible emissions controls throughout Europe</a> (Eloise Marais, UCL)
+  </li>
+</ul>
+
+<h2>Wednesday 16 August</h2>
+
+<a name="composition1" id="composition1"></a><strong>Tropospheric composition (mostly ozone) part 1 (Chair: Susie Shihan Sun, Edinburgh)</strong>
+
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1addXrQKxyOnpX-BgwIjZVnLG6ZZ2v3Q7/view?usp=drive_link">KEYNOTE: The role of atmospheric non-linearities in understanding aviation emissions‘ impacts </a> (Irene Dedoussi, TU Delft)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1DGN1HnNrMdHsy-mGAHe7P5yzGR7cRjkl/view?usp=drive_link">Why is tropospheric ozone around 40 ppbv?</a> (Mat Evans, York)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1xvFLqj4HQR3S_xWq0Yb0Jxw6-VXk5_WK/view?usp=drive_link">Why is background ozone over East Asia so high?</a> (Nadia Kathryn Colombi, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/13ACwsDesD7YRgYUvHt6NKqUaPJpTpsTn/view?usp=drive_link">Evaluation of GEOS-Chem vertical profiles of nitrogen dioxide (NO2) and ozone (O3) using cloudsliced TROPOMI columns</a> (Bex Horner, UCL)
+  </li>
+</ul>
+
+<a name="composition2" id="composition2"></a><strong>Tropospheric composition (mostly ozone) part 2 (Gongda Lu, UCL)</strong>
+
+<ul>
+  <li>
+    The rise and rise of atmospheric methane: an unfolding story about hotspots and wet spots (Paul Palmer, Edinburgh)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1_ry9MR6BA5XKRSb7fMxQQHd-JFASWOXr/view?usp=drive_link">Implementation of an observationally-constrained nitrate photolysis parameterisation and the impact on tropospheric ozone</a> (Mathew Rowlinson, York)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/14WINcSbKDbmSnJLYT3WQTBmAL5rw3T65/view?usp=drive_link">Reactive nitrogen and ozone in the global upper troposphere: Insights from historic DC8 aircraft campaigns and GEOS-Chem</a> (Nana Wei, UCL)
+  </li>
+  <li>
+    Closing Remarks (Eloise Marais, UCL)
+  </li>
+</ul>
+
 </div>
 </div>
 </div>
@@ -305,64 +281,16 @@ The 2nd GEOS-Chem Europe Meeting (GCE2)<br>14-16 Aug, 2023
 </div>
 </div>
 
-<!--footer region beg-->
+<!--footer-->
 <footer id="footer" class="clearfix" role="contentinfo">
-
-<!-- Three column 3x33 Gpanel -->
-<div class="at-panel gpanel panel-display footer clearfix">
-<div class="region region-footer">
-<div class="region-inner clearfix">
-<div id="block-boxes-1617037690" class="block block-boxes block-boxes-os_boxes_html no-title"  module="boxes" delta="1617037690">
-<div class="block-inner clearfix">  
-<div class="block-content content" ng-non-bindable="">  
-<div id='boxes-box-1617037690' class='boxes-box'>  
 <div class="boxes-box-content">
   <p style="text-align:center">
-    Copyright © 2023 by the International GEOS-Chem Community. All rights reserved.
+    Copyright © 2026 by the International GEOS-Chem Community. All rights reserved.
   </p>
 </div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-<div class="region region-footer-bottom">  
-<div class="region-inner clearfix">  
-<div id="block-boxes-1616879798" class="block block-boxes block-boxes-os_boxes_media no-title"  module="boxes" delta="1616879798">  
-<div class="block-inner clearfix">  
-<div class="block-content content"> 
-<div id='boxes-box-1616879798' class='boxes-box'> 
-<div class="boxes-box-content"> 
-<div id="file-3900146" class="file file-html file-html-embed">
-<h2 class="element-invisible"><a href="">css-brand</a></h2>
-<div class="content">
-<div class="file-info">
-</div>
-<div class="field field-name-field-html-code field-type-text-long field-label-hidden view-mode-full">
-<div class="field-items">
-<div class="field-item even">
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-
-<!--footer region end-->
 </footer>
-</div>
-</div>
 
-<!--page area ends-->
-<div id="extradiv"></div>
+</div>
 </div>
 
 </body>

--- a/gce2-presentations.html
+++ b/gce2-presentations.html
@@ -42,7 +42,7 @@
 <div id='boxes-box-1617807424' class='boxes-box'>
 <div class="boxes-box-content">
 <a href="https://geoschem.github.io/"><img style="float: right; width: 300px; height: 249px;" class="media-element file-default file-os-files-large"  src="img/gce2_ucl_portico_london.png" width="579" height="412" alt="" title="" /></a>
-<h2 class="css-brand--css-geos-meetings-header-h2-xxxlarge">The 2nd GEOS-Chem Europe Meeting (GCE2), 14-16 Aug, 2023</h2>
+<h2 class="css-brand--css-geos-meetings-header-h2-xxxlarge">The 2nd GEOS-Chem<br />Europe Meeting (GCE2)<br />14-16 Aug, 2023</h2>
 </div>
 </div>
 </div>
@@ -75,7 +75,7 @@
 <a name="main-content"></a>
 <header id="main-content-header">
 <a name="main-content"></a>
-<h1 id="page-title" ng-non-bindable="">Tentative agenda</h1>
+<h1 id="page-title" ng-non-bindable="">Agenda</h1>
 </header>
                             
 <!--front panel regions beg-->

--- a/gce2.html
+++ b/gce2.html
@@ -42,7 +42,7 @@
 <div id='boxes-box-1617807424' class='boxes-box'>
 <div class="boxes-box-content">
 <a href="https://geoschem.github.io/"><img style="float: right; width: 300px; height: 249px;" class="media-element file-default file-os-files-large"  src="img/gce2_ucl_portico_london.png" width="579" height="412" alt="" title="" /></a>
-<h2 class="css-brand--css-geos-meetings-header-h2-xxxlarge">The 2nd GEOS-Chem Europe Meeting (GCE2), 14-16 Aug, 2023</h2>
+<h2 class="css-brand--css-geos-meetings-header-h2-xxxlarge">The 2nd GEOS-Chem<br />Europe Meeting (GCE2)<br />14-16 Aug, 2023</h2>
 </div>
 </div>
 </div>

--- a/gce2.html
+++ b/gce2.html
@@ -1,9 +1,4 @@
 <!DOCTYPE html>
-<!--[if IEMobile 7]><html class="iem7"  lang="en" dir="ltr"><![endif]-->
-<!--[if lte IE 6]><html class="lt-ie9 lt-ie8 lt-ie7"  lang="en" dir="ltr"><![endif]-->
-<!--[if (IE 7)&(!IEMobile)]><html class="lt-ie9 lt-ie8"  lang="en" dir="ltr"><![endif]-->
-<!--[if IE 8]><html class="lt-ie9"  lang="en" dir="ltr"><![endif]-->
-<!--[if (gte IE 9)|(gt IEMobile 7)]><!--><html  lang="en" dir="ltr"><!--<![endif]-->
 <head>
 <meta charset="utf-8" />
 <!--<base href="/gce2" />-->
@@ -18,23 +13,12 @@
 <title>The 2nd Regional GEOS-Chem Europe Meeting</title>
 <meta http-equiv="x-ua-compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<link type="text/css" rel="stylesheet" href="css/css_xE-rWrJf-fncB6ztZfd2huxqgxu4WO-qwma6Xer30m4%EF%B9%96m=1675397288.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_1kR8T1_c-l5pBT6ZwbDT7BFda-4fyqW9Jjum29_2IY8%EF%B9%96m=1675397312.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_YnlUIvHP13qgpYEqubzE8JyDwlSxUnVibfnVkSoSDb0%EF%B9%96m=1675397273.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_Ku-3OcT9qU9h7dnGig5e23q6EVryY8orK4wzVDxsweE%EF%B9%96m=1675397367.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_vprtFTrWyg23GbY50_zJZHWGYMNfS8vsrRS26i4-ISk%EF%B9%96m=1675397406.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_dW-aNNrctRhQNc-KECjtQd0PxuW-h19IEum-TX2MeEk%EF%B9%96m=1675397301.css" media="print" />
-<link type="text/css" rel="stylesheet" href="css/css_SH2Lx3Qprh0GZo_9xRp85U9NsWfkSXn_Bi-rJoMY1sw%EF%B9%96m=1675397273.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_uaIDKcYMUK5osSQXuirpr3ZleXtnnpBN-eiECm7N0M0%EF%B9%96m=1675397395.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/responsive.blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/geos-chem.css" media="all"/>
 <script type="text/javascript" src="dropdown-menu.js"></script>
-<!--[if lte IE 8]>
-<script type="text/javascript">
-  var os_c = document.createElement;os_c('header');os_c('nav');os_c('section');os_c('article');os_c('aside');os_c('footer');os_c('hgroup');os_c('figure');
-</script>
-<![endif]-->
 </head>
 
 <body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-1585687 node-type-page og-context og-context-node og-context-node-1585652 navbar-on">
@@ -45,7 +29,7 @@
 <div id="page_wrap" class="page_wrap">
 <div id="page" class="container page header-main content-top footer-none">
 <div id="page-wrapper">
-		
+
 <!--header regions beg-->
 <header id="header" class="clearfix" role="banner">
 <div id="header-container">
@@ -53,14 +37,12 @@
 <div class="region region-header-second">
 <div class="region-inner clearfix">
 <div id="block-boxes-1617807424" class="block block-boxes block-boxes-os_boxes_html no-title"  module="boxes" delta="1617807424">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <div class="block-content content" ng-non-bindable="">
 <div id='boxes-box-1617807424' class='boxes-box'>
 <div class="boxes-box-content">
-<h2 class="css-brand--css-geos-meetings-header-h2-xxxlarge">
 <a href="https://geoschem.github.io/"><img style="float: right; width: 300px; height: 249px;" class="media-element file-default file-os-files-large"  src="img/gce2_ucl_portico_london.png" width="579" height="412" alt="" title="" /></a>
-The 2nd GEOS-Chem Europe Meeting (GCE2)<br>14-16 Aug, 2023
-</h2>
+<h2 class="css-brand--css-geos-meetings-header-h2-xxxlarge">The 2nd GEOS-Chem Europe Meeting (GCE2), 14-16 Aug, 2023</h2>
 </div>
 </div>
 </div>
@@ -76,17 +58,16 @@ The 2nd GEOS-Chem Europe Meeting (GCE2)<br>14-16 Aug, 2023
 
 <!--main menu region beg-->
 <div id="menu-bar" class="nav region-menu-bar clearfix">
-<!-- <nav id="block-os-primary-menu" class="block block-os no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="primary-menu">
-<script>inlineDropDownMenu();</script>
-</nav> -->
-<nav id="block-os-gce1" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="gce1">  
-  <ul class="nice-menu nice-menu-down nice-menu-gce1" id="nice-menu-gce1">
-  <li class="menu-857182 menu-path-node-1586483  first   odd  "><a href="gce2.html"  class="active">Home</a></li>
-  <li class="menu-857182 menu-path-node-1586483   even  "><a href="gce2-presentations.html"  title="">Presentations and posters</a></li>
+<nav id="block-os-gce2" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="gce2">
+<ul class="nice-menu nice-menu-down">
+  <li><a href="gce2.html" class="active">GCE2 Home</a></li>
+  <li><a href="gce2-presentations.html">Presentations and posters</a></li>
+  <li><a href="index.html">GEOS-Chem Home</a></li>
+</ul>
 </nav>
 </div>
 <!--main menu region end-->
-		
+
 <div id="columns" class="clearfix">
 <div class="hg-container">
 <div id="content-column" role="main">
@@ -96,13 +77,13 @@ The 2nd GEOS-Chem Europe Meeting (GCE2)<br>14-16 Aug, 2023
 <a name="main-content"></a>
 <h1 id="page-title" ng-non-bindable="">Overview</h1>
 </header>
-														
+
 <!--front panel regions beg-->
 <div id="content-panels" class="at-panel gpanel panel-display content clearfix">
 <div class="region region-content-top">
 <div class="region-inner clearfix">
 <div id="block-os-pages-main-content" class="block block-os-pages no-title"  module="os_pages" delta="main_content">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <div class="block-content content" ng-non-bindable="">
 <article id="node-1585687" class="node node-page article clearfix" role="article">
 <div class="node-content" ng-non-bindable="">
@@ -111,15 +92,11 @@ The 2nd GEOS-Chem Europe Meeting (GCE2)<br>14-16 Aug, 2023
 <div class="field-item even">
 
 <p style="text-align:center">
-	<img height="942" width="628" alt="GCE2 group photo" class="media-element file-default file-os-files-xxlarge" src="img/gce2-photo.jpg"/></p>
+  <img height="942" width="628" alt="GCE2 group photo" class="media-element file-default file-os-files-xxlarge" src="img/gce2-photo.jpg"/></p>
 
-<p align="justify">
-	The 2nd GEOS-Chem Europe meeting (GCE2) was held at the University College London (UCL) Bloomsbury campus in Central London on 14-16 August 2023. We invite you to view the <a href="gce2-presentations.html">oral and poster presentations from the meeting</a>.
-</p>
+<p>The 2nd GEOS-Chem Europe meeting (GCE2) was held at the University College London (UCL) Bloomsbury campus in Central London on 14-16 August 2023. We invite you to view the <a href="gce2-presentations.html">oral and poster presentations from the meeting</a>.</p>
 
-<p>
-	We look forward to seeing you at the 3rd GEOS-Chem Europe Meeting!
-</p>
+<p>We look forward to seeing you at the 3rd GEOS-Chem Europe Meeting!</p>
 
 </div>
 </div>
@@ -139,64 +116,16 @@ The 2nd GEOS-Chem Europe Meeting (GCE2)<br>14-16 Aug, 2023
 </div>
 </div>
 
-<!--footer region beg-->
+<!--footer-->
 <footer id="footer" class="clearfix" role="contentinfo">
-
-<!-- Three column 3x33 Gpanel -->
-<div class="at-panel gpanel panel-display footer clearfix">
-<div class="region region-footer">
-<div class="region-inner clearfix">
-<div id="block-boxes-1617037690" class="block block-boxes block-boxes-os_boxes_html no-title"  module="boxes" delta="1617037690">
-<div class="block-inner clearfix">  
-<div class="block-content content" ng-non-bindable="">  
-<div id='boxes-box-1617037690' class='boxes-box'>  
 <div class="boxes-box-content">
   <p style="text-align:center">
-    Copyright © 2023 by the International GEOS-Chem Community. All rights reserved.
+    Copyright © 2026 by the International GEOS-Chem Community. All rights reserved.
   </p>
 </div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-<div class="region region-footer-bottom">  
-<div class="region-inner clearfix">  
-<div id="block-boxes-1616879798" class="block block-boxes block-boxes-os_boxes_media no-title"  module="boxes" delta="1616879798">  
-<div class="block-inner clearfix">  
-<div class="block-content content"> 
-<div id='boxes-box-1616879798' class='boxes-box'> 
-<div class="boxes-box-content"> 
-<div id="file-3900146" class="file file-html file-html-embed">
-<h2 class="element-invisible"><a href="">css-brand</a></h2>
-<div class="content">
-<div class="file-info">
-</div>
-<div class="field field-name-field-html-code field-type-text-long field-label-hidden view-mode-full">
-<div class="field-items">
-<div class="field-item even">
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-
-<!--footer region end-->
 </footer>
-</div>
-</div>
 
-<!--page area ends-->
-<div id="extradiv"></div>
+</div>
 </div>
 
 </body>

--- a/gce3-keynotes.html
+++ b/gce3-keynotes.html
@@ -1,12 +1,7 @@
 <!DOCTYPE html>
-<!--[if IEMobile 7]><html class="iem7"  lang="en" dir="ltr"><![endif]-->
-<!--[if lte IE 6]><html class="lt-ie9 lt-ie8 lt-ie7"  lang="en" dir="ltr"><![endif]-->
-<!--[if (IE 7)&(!IEMobile)]><html class="lt-ie9 lt-ie8"  lang="en" dir="ltr"><![endif]-->
-<!--[if IE 8]><html class="lt-ie9"  lang="en" dir="ltr"><![endif]-->
-<!--[if (gte IE 9)|(gt IEMobile 7)]><!--><html  lang="en" dir="ltr"><!--<![endif]-->
 <head>
 <meta charset="utf-8" />
-<!--<base href="/gce2" />-->
+<!--<base href="/gce3" />-->
 <link rel="shortcut icon" href="img/geos-chem-logo-favicon.png" />
 <link rel="canonical" href="gce2.html" />
 <link rel="shortlink" href="gce2.html" />
@@ -18,23 +13,12 @@
 <title>The 3rd Regional GEOS-Chem Europe Meeting</title>
 <meta http-equiv="x-ua-compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<link type="text/css" rel="stylesheet" href="css/css_xE-rWrJf-fncB6ztZfd2huxqgxu4WO-qwma6Xer30m4%EF%B9%96m=1675397288.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_1kR8T1_c-l5pBT6ZwbDT7BFda-4fyqW9Jjum29_2IY8%EF%B9%96m=1675397312.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_YnlUIvHP13qgpYEqubzE8JyDwlSxUnVibfnVkSoSDb0%EF%B9%96m=1675397273.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_Ku-3OcT9qU9h7dnGig5e23q6EVryY8orK4wzVDxsweE%EF%B9%96m=1675397367.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_vprtFTrWyg23GbY50_zJZHWGYMNfS8vsrRS26i4-ISk%EF%B9%96m=1675397406.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_dW-aNNrctRhQNc-KECjtQd0PxuW-h19IEum-TX2MeEk%EF%B9%96m=1675397301.css" media="print" />
-<link type="text/css" rel="stylesheet" href="css/css_SH2Lx3Qprh0GZo_9xRp85U9NsWfkSXn_Bi-rJoMY1sw%EF%B9%96m=1675397273.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_uaIDKcYMUK5osSQXuirpr3ZleXtnnpBN-eiECm7N0M0%EF%B9%96m=1675397395.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/responsive.blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/geos-chem.css" media="all"/>
 <script type="text/javascript" src="dropdown-menu.js"></script>
-<!--[if lte IE 8]>
-<script type="text/javascript">
-  var os_c = document.createElement;os_c('header');os_c('nav');os_c('section');os_c('article');os_c('aside');os_c('footer');os_c('hgroup');os_c('figure');
-</script>
-<![endif]-->
 </head>
 
 <body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-1585687 node-type-page og-context og-context-node og-context-node-1585652 navbar-on">
@@ -57,9 +41,8 @@
 <div class="block-content content" ng-non-bindable="">
 <div id='boxes-box-1617807424' class='boxes-box'>
 <div class="boxes-box-content">
-<h2 class="css-brand--css-geos-meetings-header-h2-xxxlarge">
-<img style="float: right; width: 300px; height: 249px;" class="media-element file-default file-os-files-large"  src="img/gce2_ucl_portico_london.png" width="579" height="412" alt="" title="" />The 3rd GEOS-Chem Europe Meeting (GCE3)<br>18-20 August 2025
-</h2>
+<a href="https://geoschem.github.io/"><img style="float: right; width: 300px; height: 249px;" class="media-element file-default file-os-files-large"  src="img/gce2_ucl_portico_london.png" width="579" height="412" alt="" title="" /></a>
+<h2 class="css-brand--css-geos-meetings-header-h2-xxxlarge">The 3rd GEOS-Chem <br />Europe Meeting (GCE3)<br />18-20 August 2025</h2>
 </div>
 </div>
 </div>
@@ -75,15 +58,13 @@
 
 <!--main menu region beg-->
 <div id="menu-bar" class="nav region-menu-bar clearfix">
-<!--<nav id="block-os-primary-menu" class="block block-os no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="primary-menu">
-<script>inlineDropDownMenu();</script>
-</nav>-->
-<nav id="block-os-gce1" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="gce1">  
-  <ul class="nice-menu nice-menu-down nice-menu-gce1" id="nice-menu-gce1">
-    <li class="menu-857182 menu-path-node-1586483  first   odd  "><a href="gce3.html"  >Home</a></li>
-    <li class="menu-857184 menu-path-node-1586484   even  "><a href="gce3-presentations.html" >Presentations and posters</a></li>
-    <li class="menu-857184 menu-path-node-1586484   even  "><a href="gce3-keynotes.html" class="active">Keynotes</a></li>
-  </ul>
+<nav id="block-os-gce3" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="gce3">
+<ul class="nice-menu nice-menu-down">
+  <li><a href="gce3.html" class="active">GCE3 Home</a></li>
+  <li><a href="gce3-presentations.html">Presentations and posters</a></li>
+  <li><a href="gce3-keynotes.html">Keynotes</a></li>
+  <li><a href="index.html">GEOS-Chem Home</a></li>
+</ul>
 </nav>
 </div>
 <!--main menu region end-->
@@ -111,9 +92,7 @@
 <div class="field-items">
 <div class="field-item even">
   
-<p>
-GCE3 featured keynote talks by researchers representing modelling communities such as NAME, AQUM, WRF-Chem, EMEP4UK and UKCA. Speakers included <a href="https://www.metoffice.gov.uk/research/people/lucy-neal" target="_blank" rel="noopener noreferrer">Lucy Neal</a> from the UK MetOffice, <a href="https://www.ch.cam.ac.uk/person/ata27" target="_blank" rel="noopener noreferrer">Alex Archibald</a> from University of Cambridge, <a href="https://www.ceh.ac.uk/staff/massimo-vieno" target="_blank" rel="noopener noreferrer">Massimo Vieno</a> from the UK Centre for Ecology and Hydrology and <a href="https://profiles.ucl.ac.uk/77627-clare-heaviside/" target="_blank" rel="noopener noreferrer">Clare Heaviside</a> from University College London.
-</p>
+<p>GCE3 featured keynote talks by researchers representing modelling communities such as NAME, AQUM, WRF-Chem, EMEP4UK and UKCA. Speakers included <a href="https://www.metoffice.gov.uk/research/people/lucy-neal" target="_blank" rel="noopener noreferrer">Lucy Neal</a> from the UK MetOffice, <a href="https://www.ch.cam.ac.uk/person/ata27" target="_blank" rel="noopener noreferrer">Alex Archibald</a> from University of Cambridge, <a href="https://www.ceh.ac.uk/staff/massimo-vieno" target="_blank" rel="noopener noreferrer">Massimo Vieno</a> from the UK Centre for Ecology and Hydrology and <a href="https://profiles.ucl.ac.uk/77627-clare-heaviside/" target="_blank" rel="noopener noreferrer">Clare Heaviside</a> from University College London.</p>
 
 <img src="img/gce3-keynote-speakers-fig1.png" alt="image of keynotes Lucy and Alex" height="90%" width="90%">
 </br>
@@ -139,64 +118,16 @@ GCE3 featured keynote talks by researchers representing modelling communities su
 </div>
 </div>
 
-<!--footer region beg-->
+<!--footer-->
 <footer id="footer" class="clearfix" role="contentinfo">
-
-<!-- Three column 3x33 Gpanel -->
-<div class="at-panel gpanel panel-display footer clearfix">
-<div class="region region-footer">
-<div class="region-inner clearfix">
-<div id="block-boxes-1617037690" class="block block-boxes block-boxes-os_boxes_html no-title"  module="boxes" delta="1617037690">
-<div class="block-inner clearfix">  
-<div class="block-content content" ng-non-bindable="">  
-<div id='boxes-box-1617037690' class='boxes-box'>  
 <div class="boxes-box-content">
   <p style="text-align:center">
-    Copyright © 2025 by the International GEOS-Chem Community. All rights reserved.
+    Copyright © 2026 by the International GEOS-Chem Community. All rights reserved.
   </p>
 </div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-<div class="region region-footer-bottom">  
-<div class="region-inner clearfix">  
-<div id="block-boxes-1616879798" class="block block-boxes block-boxes-os_boxes_media no-title"  module="boxes" delta="1616879798">  
-<div class="block-inner clearfix">  
-<div class="block-content content"> 
-<div id='boxes-box-1616879798' class='boxes-box'> 
-<div class="boxes-box-content"> 
-<div id="file-3900146" class="file file-html file-html-embed">
-<h2 class="element-invisible"><a href="">css-brand</a></h2>
-<div class="content">
-<div class="file-info">
-</div>
-<div class="field field-name-field-html-code field-type-text-long field-label-hidden view-mode-full">
-<div class="field-items">
-<div class="field-item even">
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-
-<!--footer region end-->
 </footer>
-</div>
-</div>
 
-<!--page area ends-->
-<div id="extradiv"></div>
+</div>
 </div>
 
 </body>

--- a/gce3-presentations.html
+++ b/gce3-presentations.html
@@ -1,9 +1,4 @@
 <!DOCTYPE html>
-<!--[if IEMobile 7]><html class="iem7"  lang="en" dir="ltr"><![endif]-->
-<!--[if lte IE 6]><html class="lt-ie9 lt-ie8 lt-ie7"  lang="en" dir="ltr"><![endif]-->
-<!--[if (IE 7)&(!IEMobile)]><html class="lt-ie9 lt-ie8"  lang="en" dir="ltr"><![endif]-->
-<!--[if IE 8]><html class="lt-ie9"  lang="en" dir="ltr"><![endif]-->
-<!--[if (gte IE 9)|(gt IEMobile 7)]><!--><html  lang="en" dir="ltr"><!--<![endif]-->
 <head>
 <meta charset="utf-8" />
 <!--<base href="/gce2" />-->
@@ -18,23 +13,12 @@
 <title>The 3rd Regional GEOS-Chem Europe Meeting</title>
 <meta http-equiv="x-ua-compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<link type="text/css" rel="stylesheet" href="css/css_xE-rWrJf-fncB6ztZfd2huxqgxu4WO-qwma6Xer30m4%EF%B9%96m=1675397288.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_1kR8T1_c-l5pBT6ZwbDT7BFda-4fyqW9Jjum29_2IY8%EF%B9%96m=1675397312.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_YnlUIvHP13qgpYEqubzE8JyDwlSxUnVibfnVkSoSDb0%EF%B9%96m=1675397273.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_Ku-3OcT9qU9h7dnGig5e23q6EVryY8orK4wzVDxsweE%EF%B9%96m=1675397367.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_vprtFTrWyg23GbY50_zJZHWGYMNfS8vsrRS26i4-ISk%EF%B9%96m=1675397406.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_dW-aNNrctRhQNc-KECjtQd0PxuW-h19IEum-TX2MeEk%EF%B9%96m=1675397301.css" media="print" />
-<link type="text/css" rel="stylesheet" href="css/css_SH2Lx3Qprh0GZo_9xRp85U9NsWfkSXn_Bi-rJoMY1sw%EF%B9%96m=1675397273.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_uaIDKcYMUK5osSQXuirpr3ZleXtnnpBN-eiECm7N0M0%EF%B9%96m=1675397395.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/responsive.blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/geos-chem.css" media="all"/>
 <script type="text/javascript" src="dropdown-menu.js"></script>
-<!--[if lte IE 8]>
-<script type="text/javascript">
-  var os_c = document.createElement;os_c('header');os_c('nav');os_c('section');os_c('article');os_c('aside');os_c('footer');os_c('hgroup');os_c('figure');
-</script>
-<![endif]-->
 </head>
 
 <body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-1585687 node-type-page og-context og-context-node og-context-node-1585652 navbar-on">
@@ -45,7 +29,7 @@
 <div id="page_wrap" class="page_wrap">
 <div id="page" class="container page header-main content-top footer-none">
 <div id="page-wrapper">
-		
+
 <!--header regions beg-->
 <header id="header" class="clearfix" role="banner">
 <div id="header-container">
@@ -53,12 +37,12 @@
 <div class="region region-header-second">
 <div class="region-inner clearfix">
 <div id="block-boxes-1617807424" class="block block-boxes block-boxes-os_boxes_html no-title"  module="boxes" delta="1617807424">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <div class="block-content content" ng-non-bindable="">
 <div id='boxes-box-1617807424' class='boxes-box'>
 <div class="boxes-box-content">
-<h2 class="css-brand--css-geos-meetings-header-h2-xxxlarge">
-<img style="float: right; width: 300px; height: 249px;" class="media-element file-default file-os-files-large"  src="img/gce2_ucl_portico_london.png" width="579" height="412" alt="" title="" />The 3rd GEOS-Chem Europe Meeting (GCE3)<br>18-20 August 2025
+<a href="https://geoschem.github.io/"><img style="float: right; width: 300px; height: 249px;" class="media-element file-default file-os-files-large"  src="img/gce2_ucl_portico_london.png" width="579" height="412" alt="" title="" /></a>
+<h2 class="css-brand--css-geos-meetings-header-h2-xxxlarge">The 3rd GEOS-Chem <br />Europe Meeting (GCE3)<br />18-20 August 2025</h2>
 </h2>
 </div>
 </div>
@@ -75,19 +59,17 @@
 
 <!--main menu region beg-->
 <div id="menu-bar" class="nav region-menu-bar clearfix">
-<!--<nav id="block-os-primary-menu" class="block block-os no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="primary-menu">
-<script>inlineDropDownMenu();</script>
-</nav>-->
-<nav id="block-os-gce1" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="gce1">  
-  <ul class="nice-menu nice-menu-down nice-menu-gce1" id="nice-menu-gce1">
-    <li class="menu-857182 menu-path-node-1586483  first   odd  "><a href="gce3.html"  >Home</a></li>
-    <li class="menu-857184 menu-path-node-1586484   even  "><a href="gce3-presentations.html" class="active">Presentations and posters</a></li>
-    <li class="menu-857184 menu-path-node-1586484   even  "><a href="gce3-keynotes.html" >Keynotes</a></li>
-  </ul>
+<nav id="block-os-gce3" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="gce3">
+<ul class="nice-menu nice-menu-down">
+  <li><a href="gce3.html" class="active">GCE3 Home</a></li>
+  <li><a href="gce3-presentations.html">Presentations and posters</a></li>
+  <li><a href="gce3-keynotes.html">Keynotes</a></li>
+  <li><a href="index.html">GEOS-Chem Home</a></li>
+</ul>
 </nav>
 </div>
 <!--main menu region end-->
-		
+
 <div id="columns" class="clearfix">
 <div class="hg-container">
 <div id="content-column" role="main">
@@ -97,119 +79,100 @@
 <a name="main-content"></a>
 <h1 id="page-title" ng-non-bindable="">Agenda</h1>
 </header>
-														
+
 <!--front panel regions beg-->
 <div id="content-panels" class="at-panel gpanel panel-display content clearfix">
 <div class="region region-content-top">
 <div class="region-inner clearfix">
 <div id="block-os-pages-main-content" class="block block-os-pages no-title"  module="os_pages" delta="main_content">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <div class="block-content content" ng-non-bindable="">
 <article id="node-1585687" class="node node-page article clearfix" role="article">
 <div class="node-content" ng-non-bindable="">
 <div class="field field-name-body field-type-text-with-summary field-label-hidden view-mode-full">
 <div class="field-items">
 <div class="field-item even">
-  
+
 <p align="justify">
-	<strong>Tue, Aug 19: <a href="#TueA">Overview</a> | <a href="#TueB">Air quality</a> | <a href="#TueC">Gas-phase chemistry</a> | <a href="#TueD">Posters</a></strong><br class="clearfix" />
-	<strong>Wed, Aug 20: <a href="#WedA">Biosphere-atmosphere interactions</a> | <a href="#WedB">Persistent pollutants</a> | <a href="#WedC">Multiphase chemistry</a></strong>
+  <strong>Tue, Aug 19: <a href="#TueA">Overview</a> | <a href="#TueB">Air quality</a> | <a href="#TueC">Gas-phase chemistry</a> | <a href="#TueD">Posters</a></strong><br class="clearfix" />
+  <strong>Wed, Aug 20: <a href="#WedA">Biosphere-atmosphere interactions</a> | <a href="#WedB">Persistent pollutants</a> | <a href="#WedC">Multiphase chemistry</a></strong>
 </p>
 
-<h2>
-	Tuesday, 19 August
-</h2>
-  
-<h4>
-	<a name="TueA" id="TueA"></a><strong>Model Overview and Opening Talks</strong>
-</h4>
+<h2>Tuesday, 19 August</h2>
+
+<h4><a name="TueA" id="TueA"></a><strong>Model Overview and Opening Talks</strong></h4>
 
 <ul>
-	<li>Welcome. Meeting and GEOS-Chem Model Overview (Eloise Marais, UCL)</li>
-	<li><a href="https://drive.google.com/file/d/1tsdzanoAeiqM7cEy1OTSPglbdycsrKAf/view?usp=drive_link">Broadening Scope of GEOS-Chem</a> (Seb Eastham, Imperial)</li>
-	<li><a href="https://drive.google.com/file/d/1iIpBYYR2RY0T2MbM5hFWWAQXqS5s5ZX4/view?usp=drive_link">GEOS-Chem Software Engineers / Support Team update</a> (Bob Yantosca, Harvard)</li>
-	<li><a href="https://drive.google.com/file/d/1vNZaxCjXTgfqdmm_hFCCkfbBa6qOoGwc/view?usp=drive_link">Chemical uncertainties in chemistry transport modelling</a> (Mat Evans, U. York)</li>
-	<li>Investigating increasing levels of carbon monoxide across southern extratropical latitudes (Clara Nussbaumer, ETH Zurich)</li>
+  <li>Welcome. Meeting and GEOS-Chem Model Overview (Eloise Marais, UCL)</li>
+  <li><a href="https://drive.google.com/file/d/1tsdzanoAeiqM7cEy1OTSPglbdycsrKAf/view?usp=drive_link">Broadening Scope of GEOS-Chem</a> (Seb Eastham, Imperial)</li>
+  <li><a href="https://drive.google.com/file/d/1iIpBYYR2RY0T2MbM5hFWWAQXqS5s5ZX4/view?usp=drive_link">GEOS-Chem Software Engineers / Support Team update</a> (Bob Yantosca, Harvard)</li>
+  <li><a href="https://drive.google.com/file/d/1vNZaxCjXTgfqdmm_hFCCkfbBa6qOoGwc/view?usp=drive_link">Chemical uncertainties in chemistry transport modelling</a> (Mat Evans, U. York)</li>
+  <li>Investigating increasing levels of carbon monoxide across southern extratropical latitudes (Clara Nussbaumer, ETH Zurich)</li>
+</ul>
+
+<h4><a name="TueB" id="TueB"></a><strong>Air quality and atmospheric composition</strong></h4>
+
+<ul>
+  <li><a href="https://drive.google.com/file/d/1d13CcevxusKEq087z_Tup0feoGOqnpUJ/view?usp=drive_link">KEYNOTE: Using global and regional climate models to estimate the impacts of climate change and urbanisation on health</a> (Clare Heaviside, UCL)</li>
+  <li><a href="https://drive.google.com/file/d/1XeQWFSdCh9GvLghzHvIwdPU2nztiza_j/view?usp=drive_link">Multiphase HONO formation pathways in Central London</a> (Eleanor Gershenson-Smith, UCL)</li>
+  <li><a href="https://drive.google.com/file/d/18cAQd8Gr6LqShztRxRGQ0vvHPkkXKmbp/view?usp=drive_link">Improved surface NO2 estimates over India using satellite retrievals and modelling</a> (Ardra Divakaran, IIT Delhi)</li>
 </ul>
 
 
-<h4>
-	<a name="TueB" id="TueB"></a><strong>Air quality and atmospheric composition</strong>
-</h4>
+<h4><a name="TueC" id="TueC"></a><strong>ECMWF / GEOS-Chem gas-phase chemistry (mostly halogens!)</strong></h4>
 
 <ul>
-	<li><a href="https://drive.google.com/file/d/1d13CcevxusKEq087z_Tup0feoGOqnpUJ/view?usp=drive_link">KEYNOTE: Using global and regional climate models to estimate the impacts of climate change and urbanisation on health</a> (Clare Heaviside, UCL)</li>
-	<li><a href="https://drive.google.com/file/d/1XeQWFSdCh9GvLghzHvIwdPU2nztiza_j/view?usp=drive_link">Multiphase HONO formation pathways in Central London</a> (Eleanor Gershenson-Smith, UCL)</li>
-	<li><a href="https://drive.google.com/file/d/18cAQd8Gr6LqShztRxRGQ0vvHPkkXKmbp/view?usp=drive_link">Improved surface NO2 estimates over India using satellite retrievals and modelling</a> (Ardra Divakaran, IIT Delhi)</li>
+  <li><a href="https://drive.google.com/file/d/1YnUMQIN5KBtz9QrQig-F1R2Rm1DrYMRV/view?usp=drive_link">KEYNOTE: ECMWF products and activities of appeal to the GEOS-Chem community</a> (Vincent-Henri Peuch, ECMWF)</li>
+  <li><a href="https://drive.google.com/file/d/1ggcAkSHKImm2KzJmxvSphK_jZA_NZqVm/view?usp=drive_link">Understanding chlorine chemistry in GEOS-Chem</a> (Amy Lees, U. York)</li>
+  <li><a href="https://drive.google.com/file/d/1pULJuWMGMs4drGOdcTj0DByPN53jA5b6/view?usp=drive_link">The role of iodine chemistry in a changing climate</a> (Ryan Pound, U. York)</li>
+  <li><a href="https://drive.google.com/file/d/1SIoUOyaxj1_2NDuPPxvDx4mwBlUf-umK/view?usp=drive_link">The importance of speciated iodine aerosol in gas-phase reactive iodine abundance</a> (Alli Moon, U. Washington)</li>
+  <li><a href="https://drive.google.com/file/d/1swoP9IqzH9yI0eSiIgRp_9-Kl1fOP2J-/view?usp=drive_link">Impacts of aromatic peroxy radical chemistry on atmospheric ozone</a> (Stephen MacFarlane, U. Wollongong)</li>
 </ul>
 
-
-<h4>
-	<a name="TueC" id="TueC"></a><strong>ECMWF / GEOS-Chem gas-phase chemistry (mostly halogens!)</strong>
-</h4>
-	
-<ul>
-	<li><a href="https://drive.google.com/file/d/1YnUMQIN5KBtz9QrQig-F1R2Rm1DrYMRV/view?usp=drive_link">KEYNOTE: ECMWF products and activities of appeal to the GEOS-Chem community</a> (Vincent-Henri Peuch, ECMWF)</li>
-	<li><a href="https://drive.google.com/file/d/1ggcAkSHKImm2KzJmxvSphK_jZA_NZqVm/view?usp=drive_link">Understanding chlorine chemistry in GEOS-Chem</a> (Amy Lees, U. York)</li>
-	<li><a href="https://drive.google.com/file/d/1pULJuWMGMs4drGOdcTj0DByPN53jA5b6/view?usp=drive_link">The role of iodine chemistry in a changing climate</a> (Ryan Pound, U. York)</li>
-	<li><a href="https://drive.google.com/file/d/1SIoUOyaxj1_2NDuPPxvDx4mwBlUf-umK/view?usp=drive_link">The importance of speciated iodine aerosol in gas-phase reactive iodine abundance</a> (Alli Moon, U. Washington)</li>
-	<li><a href="https://drive.google.com/file/d/1swoP9IqzH9yI0eSiIgRp_9-Kl1fOP2J-/view?usp=drive_link">Impacts of aromatic peroxy radical chemistry on atmospheric ozone</a> (Stephen MacFarlane, U. Wollongong)</li>
-</ul>
-
-<h4>
-	<a name="TueD" id="TueD"></a><strong>Posters</strong>
-</h4>
-
-<ul>	
-	<li>Inverse modeling of satellite and ¹³C observations highlights the role of wet tropics in driving the 2020–2022 methane surge (Zhen Qu, North Carolina State University)</li>
-	<li>Climate impact of atmospheric methane removal strategies (Qimin Sun, U. Edinburgh)</li>
-	<li><a href="https://drive.google.com/file/d/1Ytj6ETcyc_ce5rwt8TPteQq3pJfsOdB6/view?usp=drive_link">Implementation of the Global Forest Fire Emissions Prediction System in GEOS-Chem</a> (Timothé Payette, Montréal University)</li>
-	<li><a href="https://drive.google.com/file/d/1PWmWlrP80Rc4kj2xWfl_HOM--IW77lHF/view?usp=drive_link">Characterizing the air quality and health impacts from oil and gas emissions in Mexico using GCHP</a> (Omar Nawaz, Cardiff University)</li>
-	<li><a href="https://drive.google.com/file/d/1KKEo38rgP14Sto25DlWoN-61oq_HxqMy/view?usp=drive_link">Future projection of global air pollution in 2060</a> (Hiroo Hata, AIST)</li>
-	<li><a href="https://drive.google.com/file/d/1GWynVCRkVc0t-jZ9c-g8Slg28WgLylPo/view?usp=drive_link">Modelling southern Africa air pollution</a> (Mbavhi Maliage, U. York)</li>
-	<li><a href="https://drive.google.com/file/d/15Vd4Bl4Qy0ZzXDurQd7itccTIPZaBY-Y/view?usp=drive_link">Assessing the need for heterogeneous production of small acids in GEOS-Chem using DC8 aircraft observations</a> (Huilin Zhan, UCL)</li>
-	<li><a href="https://drive.google.com/file/d/1-bMq51WtWv-4OGDAyouA7gVtJp__8KMA/view?usp=drive_link">Present day impacts of road transport on atmospheric chemistry and public health in India using GEOS-Chem</a> (Karn Vohra, U. Birmingham)</li>
-	<li><a href="https://drive.google.com/file/d/1fTrB0tzmsSqhb-bAJB1CGEqeGebOoKTe/view?usp=drive_link">Impacts of the GAINS LRTAP MTFR emission scenario in Europe for 2040</a> (Coralina Hernández Trujillo, CIEMAT)</li>
-	<li><a href="https://drive.google.com/file/d/1aJILxDCm-ZtyoZzRpGZY5_GeSL5YE2BY/view?usp=drive_link">Spatial and diurnally varying lightning NOx production rates for use in GEOS-Chem</a> (Bex Horner, UCL)</li>
-	<li><a href="https://drive.google.com/file/d/1LQWophRw3y9UcIfxgX7wPeLmMCmbItk8/view?usp=drive_link">A GPU-Accelerated ALE Solver for Low-Diffusion Plume Transport</a> (Oliver Marx, Imperial)</li>
-</ul>
-
-<h2>
-	Day 2, Wednesday 20 August
-</h2>
-
-<h4>
-	<a name="WedA" id="WedA"></a><strong>Biosphere-Atmosphere Interactions</strong>
-</h4>
+<h4><a name="TueD" id="TueD"></a><strong>Posters</strong></h4>
 
 <ul>
-	<li><a href="https://drive.google.com/file/d/1cAzDVYhWmkOOMWODBcqFRGuWUzXzrTdD/view?usp=drive_link">KEYNOTE: Modelling atmospheric compositions with the EMEP atmospheric chemistry transport model</a> (Massimo Vieno, UKCEH)</li>
-	<li><a href="https://drive.google.com/file/d/1khi9WeFuhNP2wTrG6p25r6Qog2WBu3jT/view?usp=drive_link">Integration of atmospheric chemistry and terrestrial biogeochemistry to advance the understanding of global nitrogen cycle</a> (Cheng Gong, Max Planck Institute for Biogeochemistry)</li>
-	<li><a href="https://drive.google.com/file/d/1I53U3Bo9_rjbBFG3HJZq5anmZHQWTDm_/view?usp=drive_link">Evaluating the effects of variability in biomass burning emission inventories on modeled smoke concentrations: Insights from the 2019 and 2021 Canadian wildfire seasons</a> (Samaneh Ashraf, Montréal University)</li>
-	<li><a href="https://drive.google.com/file/d/1Rnzod3bnH-he8BCsLsO0ko3Pt_lfs9x1/view?usp=drive_link">Influence of humidity-dependent stomatal conductance of VOCs on ozone and secondary organic aerosols (SOA)</a> (Connor Barker, UCL)</li>
+  <li>Inverse modeling of satellite and ¹³C observations highlights the role of wet tropics in driving the 2020–2022 methane surge (Zhen Qu, North Carolina State University)</li>
+  <li>Climate impact of atmospheric methane removal strategies (Qimin Sun, U. Edinburgh)</li>
+  <li><a href="https://drive.google.com/file/d/1Ytj6ETcyc_ce5rwt8TPteQq3pJfsOdB6/view?usp=drive_link">Implementation of the Global Forest Fire Emissions Prediction System in GEOS-Chem</a> (Timothé Payette, Montréal University)</li>
+  <li><a href="https://drive.google.com/file/d/1PWmWlrP80Rc4kj2xWfl_HOM--IW77lHF/view?usp=drive_link">Characterizing the air quality and health impacts from oil and gas emissions in Mexico using GCHP</a> (Omar Nawaz, Cardiff University)</li>
+  <li><a href="https://drive.google.com/file/d/1KKEo38rgP14Sto25DlWoN-61oq_HxqMy/view?usp=drive_link">Future projection of global air pollution in 2060</a> (Hiroo Hata, AIST)</li>
+  <li><a href="https://drive.google.com/file/d/1GWynVCRkVc0t-jZ9c-g8Slg28WgLylPo/view?usp=drive_link">Modelling southern Africa air pollution</a> (Mbavhi Maliage, U. York)</li>
+  <li><a href="https://drive.google.com/file/d/15Vd4Bl4Qy0ZzXDurQd7itccTIPZaBY-Y/view?usp=drive_link">Assessing the need for heterogeneous production of small acids in GEOS-Chem using DC8 aircraft observations</a> (Huilin Zhan, UCL)</li>
+  <li><a href="https://drive.google.com/file/d/1-bMq51WtWv-4OGDAyouA7gVtJp__8KMA/view?usp=drive_link">Present day impacts of road transport on atmospheric chemistry and public health in India using GEOS-Chem</a> (Karn Vohra, U. Birmingham)</li>
+  <li><a href="https://drive.google.com/file/d/1fTrB0tzmsSqhb-bAJB1CGEqeGebOoKTe/view?usp=drive_link">Impacts of the GAINS LRTAP MTFR emission scenario in Europe for 2040</a> (Coralina Hernández Trujillo, CIEMAT)</li>
+  <li><a href="https://drive.google.com/file/d/1aJILxDCm-ZtyoZzRpGZY5_GeSL5YE2BY/view?usp=drive_link">Spatial and diurnally varying lightning NOx production rates for use in GEOS-Chem</a> (Bex Horner, UCL)</li>
+  <li><a href="https://drive.google.com/file/d/1LQWophRw3y9UcIfxgX7wPeLmMCmbItk8/view?usp=drive_link">A GPU-Accelerated ALE Solver for Low-Diffusion Plume Transport</a> (Oliver Marx, Imperial)</li>
 </ul>
 
-<h4>
-	<a name="WedB" id="WedB"></a><strong>Persistent Pollutants</strong>
-</h4>
+<h2>Day 2, Wednesday 20 August</h2>
+
+<h4><a name="WedA" id="WedA"></a><strong>Biosphere-Atmosphere Interactions</strong></h4>
 
 <ul>
-	<li><a href="https://drive.google.com/file/d/1CqaH8WpQfobTtZKGmb5NAPqkmz-hs2Li/view?usp=drive_link">KEYNOTE: Met Office dispersion modelling tools for pollen and air quality</a> (Lucy Neal, UK Met Office)</li>
-	<li><a href="https://drive.google.com/file/d/16UAHuAwqvvWF160CPpdJP-zr9TNhI3gc/view?usp=drive_link">PFAS species in the Arctic</a> (Freja F. Oesterstroem, Aarhus University)</li>
-	<li><a href="https://drive.google.com/file/d/12DQQ8BgoBEVq9DpQTVc927BMAquPgqHV/view?usp=drive_link">Development and applications of the AWS-based Integrated Methane Inversion (IMI) tool for quantifying methane emissions with satellite observations</a> (Daniel Varon, MIT)</li>
-	<li><a href="https://drive.google.com/file/d/1LrdiZ2EvJKd00y4KfDB1HaiBj08f7fo5/view?usp=drive_link">Modelling the atmospheric degradation of HFO-1234ze</a> (Beth Killen, UNSW Sydney)</li>
-	<li>Sectoral top-down emission estimates using TEMPO and LEO satellite observations (Zhen Qu, North Carolina State University)</li>
+  <li><a href="https://drive.google.com/file/d/1cAzDVYhWmkOOMWODBcqFRGuWUzXzrTdD/view?usp=drive_link">KEYNOTE: Modelling atmospheric compositions with the EMEP atmospheric chemistry transport model</a> (Massimo Vieno, UKCEH)</li>
+  <li><a href="https://drive.google.com/file/d/1khi9WeFuhNP2wTrG6p25r6Qog2WBu3jT/view?usp=drive_link">Integration of atmospheric chemistry and terrestrial biogeochemistry to advance the understanding of global nitrogen cycle</a> (Cheng Gong, Max Planck Institute for Biogeochemistry)</li>
+  <li><a href="https://drive.google.com/file/d/1I53U3Bo9_rjbBFG3HJZq5anmZHQWTDm_/view?usp=drive_link">Evaluating the effects of variability in biomass burning emission inventories on modeled smoke concentrations: Insights from the 2019 and 2021 Canadian wildfire seasons</a> (Samaneh Ashraf, Montréal University)</li>
+  <li><a href="https://drive.google.com/file/d/1Rnzod3bnH-he8BCsLsO0ko3Pt_lfs9x1/view?usp=drive_link">Influence of humidity-dependent stomatal conductance of VOCs on ozone and secondary organic aerosols (SOA)</a> (Connor Barker, UCL)</li>
 </ul>
 
-<h4>
-	<a name="WedC" id="WedC"></a><strong>Multiphase Chemistry</strong>
-</h4>
+<h4><a name="WedB" id="WedB"></a><strong>Persistent Pollutants</strong></h4>
 
 <ul>
-	<li>KEYNOTE: Modelling the sources and fate of reduced sulfur compounds in the marine atmosphere (Alex Archibald, UK NCAS and U. Cambridge)</li>
-	<li>Global impacts of organic aerosol phase state (Yumin Li, ETH Zurich)</li>
-	<li>Updates on wet scavenging and its impacts on horizontal and vertical aerosol distributions (Gan Luo, SUNY-Albany)</li>
-	<li><a href="https://drive.google.com/file/d/18CvWIC37yoz9dzmY1pZxqDHT_5U1oRtf/view?usp=drive_link">Closing Remarks</a> (Seb + Eloise)</li>
+  <li><a href="https://drive.google.com/file/d/1CqaH8WpQfobTtZKGmb5NAPqkmz-hs2Li/view?usp=drive_link">KEYNOTE: Met Office dispersion modelling tools for pollen and air quality</a> (Lucy Neal, UK Met Office)</li>
+  <li><a href="https://drive.google.com/file/d/16UAHuAwqvvWF160CPpdJP-zr9TNhI3gc/view?usp=drive_link">PFAS species in the Arctic</a> (Freja F. Oesterstroem, Aarhus University)</li>
+  <li><a href="https://drive.google.com/file/d/12DQQ8BgoBEVq9DpQTVc927BMAquPgqHV/view?usp=drive_link">Development and applications of the AWS-based Integrated Methane Inversion (IMI) tool for quantifying methane emissions with satellite observations</a> (Daniel Varon, MIT)</li>
+  <li><a href="https://drive.google.com/file/d/1LrdiZ2EvJKd00y4KfDB1HaiBj08f7fo5/view?usp=drive_link">Modelling the atmospheric degradation of HFO-1234ze</a> (Beth Killen, UNSW Sydney)</li>
+  <li>Sectoral top-down emission estimates using TEMPO and LEO satellite observations (Zhen Qu, North Carolina State University)</li>
+</ul>
+
+<h4><a name="WedC" id="WedC"></a><strong>Multiphase Chemistry</strong></h4>
+
+<ul>
+  <li>KEYNOTE: Modelling the sources and fate of reduced sulfur compounds in the marine atmosphere (Alex Archibald, UK NCAS and U. Cambridge)</li>
+  <li>Global impacts of organic aerosol phase state (Yumin Li, ETH Zurich)</li>
+  <li>Updates on wet scavenging and its impacts on horizontal and vertical aerosol distributions (Gan Luo, SUNY-Albany)</li>
+  <li><a href="https://drive.google.com/file/d/18CvWIC37yoz9dzmY1pZxqDHT_5U1oRtf/view?usp=drive_link">Closing Remarks</a> (Seb + Eloise)</li>
 </lul>
 
 </div>
@@ -230,64 +193,15 @@
 </div>
 </div>
 
-<!--footer region beg-->
+<!--footer-->
 <footer id="footer" class="clearfix" role="contentinfo">
-
-<!-- Three column 3x33 Gpanel -->
-<div class="at-panel gpanel panel-display footer clearfix">
-<div class="region region-footer">
-<div class="region-inner clearfix">
-<div id="block-boxes-1617037690" class="block block-boxes block-boxes-os_boxes_html no-title"  module="boxes" delta="1617037690">
-<div class="block-inner clearfix">  
-<div class="block-content content" ng-non-bindable="">  
-<div id='boxes-box-1617037690' class='boxes-box'>  
 <div class="boxes-box-content">
   <p style="text-align:center">
-    Copyright © 2025 by the International GEOS-Chem Community. All rights reserved.
+    Copyright © 2026 by the International GEOS-Chem Community. All rights reserved.
   </p>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-<div class="region region-footer-bottom">  
-<div class="region-inner clearfix">  
-<div id="block-boxes-1616879798" class="block block-boxes block-boxes-os_boxes_media no-title"  module="boxes" delta="1616879798">  
-<div class="block-inner clearfix">  
-<div class="block-content content"> 
-<div id='boxes-box-1616879798' class='boxes-box'> 
-<div class="boxes-box-content"> 
-<div id="file-3900146" class="file file-html file-html-embed">
-<h2 class="element-invisible"><a href="">css-brand</a></h2>
-<div class="content">
-<div class="file-info">
-</div>
-<div class="field field-name-field-html-code field-type-text-long field-label-hidden view-mode-full">
-<div class="field-items">
-<div class="field-item even">
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
 
-<!--footer region end-->
-</footer>
 </div>
 </div>
-
-<!--page area ends-->
-<div id="extradiv"></div>
 </div>
 
 </body>

--- a/gce3.html
+++ b/gce3.html
@@ -1,9 +1,4 @@
 <!DOCTYPE html>
-<!--[if IEMobile 7]><html class="iem7"  lang="en" dir="ltr"><![endif]-->
-<!--[if lte IE 6]><html class="lt-ie9 lt-ie8 lt-ie7"  lang="en" dir="ltr"><![endif]-->
-<!--[if (IE 7)&(!IEMobile)]><html class="lt-ie9 lt-ie8"  lang="en" dir="ltr"><![endif]-->
-<!--[if IE 8]><html class="lt-ie9"  lang="en" dir="ltr"><![endif]-->
-<!--[if (gte IE 9)|(gt IEMobile 7)]><!--><html  lang="en" dir="ltr"><!--<![endif]-->
 <head>
 <meta charset="utf-8" />
 <!--<base href="/gce3" />-->
@@ -18,23 +13,12 @@
 <title>The 3rd Regional GEOS-Chem Europe Meeting</title>
 <meta http-equiv="x-ua-compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<link type="text/css" rel="stylesheet" href="css/css_xE-rWrJf-fncB6ztZfd2huxqgxu4WO-qwma6Xer30m4%EF%B9%96m=1675397288.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_1kR8T1_c-l5pBT6ZwbDT7BFda-4fyqW9Jjum29_2IY8%EF%B9%96m=1675397312.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_YnlUIvHP13qgpYEqubzE8JyDwlSxUnVibfnVkSoSDb0%EF%B9%96m=1675397273.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_Ku-3OcT9qU9h7dnGig5e23q6EVryY8orK4wzVDxsweE%EF%B9%96m=1675397367.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_vprtFTrWyg23GbY50_zJZHWGYMNfS8vsrRS26i4-ISk%EF%B9%96m=1675397406.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_dW-aNNrctRhQNc-KECjtQd0PxuW-h19IEum-TX2MeEk%EF%B9%96m=1675397301.css" media="print" />
-<link type="text/css" rel="stylesheet" href="css/css_SH2Lx3Qprh0GZo_9xRp85U9NsWfkSXn_Bi-rJoMY1sw%EF%B9%96m=1675397273.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_uaIDKcYMUK5osSQXuirpr3ZleXtnnpBN-eiECm7N0M0%EF%B9%96m=1675397395.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/responsive.blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/geos-chem.css" media="all"/>
 <script type="text/javascript" src="dropdown-menu.js"></script>
-<!--[if lte IE 8]>
-<script type="text/javascript">
-  var os_c = document.createElement;os_c('header');os_c('nav');os_c('section');os_c('article');os_c('aside');os_c('footer');os_c('hgroup');os_c('figure');
-</script>
-<![endif]-->
 </head>
 
 <body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-1585687 node-type-page og-context og-context-node og-context-node-1585652 navbar-on">
@@ -45,7 +29,7 @@
 <div id="page_wrap" class="page_wrap">
 <div id="page" class="container page header-main content-top footer-none">
 <div id="page-wrapper">
-		
+    
 <!--header regions beg-->
 <header id="header" class="clearfix" role="banner">
 <div id="header-container">
@@ -57,10 +41,8 @@
 <div class="block-content content" ng-non-bindable="">
 <div id='boxes-box-1617807424' class='boxes-box'>
 <div class="boxes-box-content">
-<h2 class="css-brand--css-geos-meetings-header-h2-xxxlarge">
 <a href="https://geoschem.github.io/"><img style="float: right; width: 300px; height: 249px;" class="media-element file-default file-os-files-large"  src="img/gce2_ucl_portico_london.png" width="579" height="412" alt="" title="" /></a>
-The 3rd GEOS-Chem Europe Meeting (GCE3)<br>18-20 August 2025
-</h2>
+<h2 class="css-brand--css-geos-meetings-header-h2-xxxlarge">The 3rd GEOS-Chem <br />Europe Meeting (GCE3)<br />18-20 August 2025</h2>
 </div>
 </div>
 </div>
@@ -76,19 +58,17 @@ The 3rd GEOS-Chem Europe Meeting (GCE3)<br>18-20 August 2025
 
 <!--main menu region beg-->
 <div id="menu-bar" class="nav region-menu-bar clearfix">
-<!-- <nav id="block-os-primary-menu" class="block block-os no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="primary-menu">
-<script>inlineDropDownMenu();</script>
-</nav> -->
-<nav id="block-os-gce1" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="gce1">  
-  <ul class="nice-menu nice-menu-down nice-menu-gce1" id="nice-menu-gce1">
-    <li class="menu-857182 menu-path-node-1586483  first   odd  "><a href="gce3.html"  class="active">Home</a></li>
-    <li class="menu-857184 menu-path-node-1586484   even  "><a href="gce3-presentations.html" >Presentations and posters</a></li>
-    <li class="menu-857184 menu-path-node-1586484   even  "><a href="gce3-keynotes.html" >Keynotes</a></li>
-  </ul>
+<nav id="block-os-gce3" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="gce3">  
+<ul class="nice-menu nice-menu-down">
+  <li><a href="gce3.html" class="active">GCE3 Home</a></li>
+  <li><a href="gce3-presentations.html">Presentations and posters</a></li>
+  <li><a href="gce3-keynotes.html">Keynotes</a></li>
+  <li><a href="index.html">GEOS-Chem Home</a></li>
+</ul>
 </nav>
 </div>
 <!--main menu region end-->
-		
+    
 <div id="columns" class="clearfix">
 <div class="hg-container">
 <div id="content-column" role="main">
@@ -98,7 +78,7 @@ The 3rd GEOS-Chem Europe Meeting (GCE3)<br>18-20 August 2025
 <a name="main-content"></a>
 <h1 id="page-title" ng-non-bindable="">Overview</h1>
 </header>
-														
+                            
 <!--front panel regions beg-->
 <div id="content-panels" class="at-panel gpanel panel-display content clearfix">
 <div class="region region-content-top">
@@ -113,16 +93,12 @@ The 3rd GEOS-Chem Europe Meeting (GCE3)<br>18-20 August 2025
 <div class="field-item even">
 
 <p align="center">
-	<img style="width: 75%;" alt="GCE3 group photo" class="media-element file-default file-os-files-xxlarge" src="img/gce3-ucl-aug-2025.jpg"/>
+  <img style="width: 75%;" alt="GCE3 group photo" class="media-element file-default file-os-files-xxlarge" src="img/gce3-ucl-aug-2025.jpg"/>
 </p>
 
-<p align="justify">
-	The 3rd GEOS-Chem Europe meeting (GCE3) was held in London on the Unversity College London campus in Bloomsbury on 18-20 August 2025 with 45 attendees from 27 institutions and 10 countries. We invite you to view the <a href="gce3-presentations.html">oral and poster presentations from the meeting</a>.
-</p>
+<p>The 3rd GEOS-Chem Europe meeting (GCE3) was held in London on the Unversity College London campus in Bloomsbury on 18-20 August 2025 with 45 attendees from 27 institutions and 10 countries. We invite you to view the <a href="gce3-presentations.html">oral and poster presentations from the meeting</a>.</p>
 
-<p>
-	We look forward to seeing you at the 4th GEOS-Chem Europe Meeting!
-</p>
+<p>We look forward to seeing you at the 4th GEOS-Chem Europe Meeting!</p>
 
 </div>
 </div>
@@ -142,64 +118,16 @@ The 3rd GEOS-Chem Europe Meeting (GCE3)<br>18-20 August 2025
 </div>
 </div>
 
-<!--footer region beg-->
+<!--footer-->
 <footer id="footer" class="clearfix" role="contentinfo">
-
-<!-- Three column 3x33 Gpanel -->
-<div class="at-panel gpanel panel-display footer clearfix">
-<div class="region region-footer">
-<div class="region-inner clearfix">
-<div id="block-boxes-1617037690" class="block block-boxes block-boxes-os_boxes_html no-title"  module="boxes" delta="1617037690">
-<div class="block-inner clearfix">  
-<div class="block-content content" ng-non-bindable="">  
-<div id='boxes-box-1617037690' class='boxes-box'>  
 <div class="boxes-box-content">
   <p style="text-align:center">
-    Copyright © 2025 by the International GEOS-Chem Community. All rights reserved.
+    Copyright © 2026 by the International GEOS-Chem Community. All rights reserved.
   </p>
 </div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-<div class="region region-footer-bottom">  
-<div class="region-inner clearfix">  
-<div id="block-boxes-1616879798" class="block block-boxes block-boxes-os_boxes_media no-title"  module="boxes" delta="1616879798">  
-<div class="block-inner clearfix">  
-<div class="block-content content"> 
-<div id='boxes-box-1616879798' class='boxes-box'> 
-<div class="boxes-box-content"> 
-<div id="file-3900146" class="file file-html file-html-embed">
-<h2 class="element-invisible"><a href="">css-brand</a></h2>
-<div class="content">
-<div class="file-info">
-</div>
-<div class="field field-name-field-html-code field-type-text-long field-label-hidden view-mode-full">
-<div class="field-items">
-<div class="field-item even">
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-
-<!--footer region end-->
 </footer>
-</div>
-</div>
 
-<!--page area ends-->
-<div id="extradiv"></div>
+</div>
 </div>
 
 </body>

--- a/igc1-presentations.html
+++ b/igc1-presentations.html
@@ -1,9 +1,4 @@
 <!DOCTYPE html>
-<!--[if IEMobile 7]><html class="iem7"  lang="en" dir="ltr"><![endif]-->
-<!--[if lte IE 6]><html class="lt-ie9 lt-ie8 lt-ie7"  lang="en" dir="ltr"><![endif]-->
-<!--[if (IE 7)&(!IEMobile)]><html class="lt-ie9 lt-ie8"  lang="en" dir="ltr"><![endif]-->
-<!--[if IE 8]><html class="lt-ie9"  lang="en" dir="ltr"><![endif]-->
-<!--[if (gte IE 9)|(gt IEMobile 7)]><!--><html  lang="en" dir="ltr"><!--<![endif]-->
 <head>
 <meta charset="utf-8" />
 <!--<base href="/igc1-presentations" />-->
@@ -18,23 +13,12 @@
 <title>The 1st GEOS-Chem Meeting</title>
 <meta http-equiv="x-ua-compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<link type="text/css" rel="stylesheet" href="css/css_xE-rWrJf-fncB6ztZfd2huxqgxu4WO-qwma6Xer30m4%EF%B9%96m=1675397288.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_1kR8T1_c-l5pBT6ZwbDT7BFda-4fyqW9Jjum29_2IY8%EF%B9%96m=1675397312.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_YnlUIvHP13qgpYEqubzE8JyDwlSxUnVibfnVkSoSDb0%EF%B9%96m=1675397273.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_Ku-3OcT9qU9h7dnGig5e23q6EVryY8orK4wzVDxsweE%EF%B9%96m=1675397367.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_vprtFTrWyg23GbY50_zJZHWGYMNfS8vsrRS26i4-ISk%EF%B9%96m=1675397406.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_dW-aNNrctRhQNc-KECjtQd0PxuW-h19IEum-TX2MeEk%EF%B9%96m=1675397301.css" media="print" />
-<link type="text/css" rel="stylesheet" href="css/css_SH2Lx3Qprh0GZo_9xRp85U9NsWfkSXn_Bi-rJoMY1sw%EF%B9%96m=1675397273.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_uaIDKcYMUK5osSQXuirpr3ZleXtnnpBN-eiECm7N0M0%EF%B9%96m=1675397395.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/responsive.blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/geos-chem.css" media="all"/>
 <script type="text/javascript" src="dropdown-menu.js"></script>
-<!--[if lte IE 8]>
-<script type="text/javascript">
-  var os_c = document.createElement;os_c('header');os_c('nav');os_c('section');os_c('article');os_c('aside');os_c('footer');os_c('hgroup');os_c('figure');
-</script>
-<![endif]-->
 </head>
 
 <body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-1585687 node-type-page og-context og-context-node og-context-node-1585652 navbar-on">
@@ -45,7 +29,7 @@
 <div id="page_wrap" class="page_wrap">
 <div id="page" class="container page header-main content-top footer-none">
 <div id="page-wrapper">
-		
+  
 <!--header regions beg-->
 <header id="header" class="clearfix" role="banner">
 <div id="header-container">
@@ -76,15 +60,16 @@
 
 <!--main menu region beg-->
 <div id="menu-bar" class="nav region-menu-bar clearfix">
-<nav id="block-os-igc1-menu" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="igc1_menu">  
-<ul class="nice-menu nice-menu-down nice-menu-igc1_menu" id="nice-menu-igc1_menu">
-  <li class="menu-861303 menu-path-node-1587366  first   odd  "><a href="igc1.html" >Home</a></li>
-  <li class="menu-861308 menu-path-node-1587367   even  "><a href="igc1-presentations.html"  class="active">Presentations</a></li>
-  <li class="menu-861316 menu-path-node-1587368   odd   last "><a href="igc1-attendees.html" >Attendees</a></li>
+<nav id="block-os-igc1-menu" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="igc1_menu">
+<ul class="nice-menu nice-menu-down">
+  <li><a href="igc1.html" class="active">IGC1 Home</a></li>
+  <li><a href="igc1-presentations.html">Presentations and Posters</a></li>
+  <li><a href="index.html">GEOS-Chem Home</a></li>
 </ul>
 </nav>
 </div>
-<!--main menu region end-->	
+<!--main menu region end-->
+
 
 <div id="columns" class="clearfix">
 <div class="hg-container">
@@ -121,97 +106,97 @@
 
 <ul class="disc">
     <li>
-		<a href="https://docs.google.com/presentation/d/10YAPWpvaYlAoiUSe7NRvrXbrRxxtr5ht/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">GEOS-Chem overview, </a>Daniel Jacob
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/13RW_LpOGgLW1Gy4AGYsrVFHO9a3hSC2L/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">GEOS-Chem structure, documentation, platforms, and parallelization</a>, Bob Yantosca
-	</li>
-	<li>
-		Porting of GEOS-Chem to NCCS, Tom Clune
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1on5mYinee49NJbCLtfXpTT7M2EQvTONl/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true"" target="_blank">GEOS meteorological products: Evolution, status, and plans</a>, Steven Pawson
-	</li>
+  <a href="https://docs.google.com/presentation/d/10YAPWpvaYlAoiUSe7NRvrXbrRxxtr5ht/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">GEOS-Chem overview, </a>Daniel Jacob
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/13RW_LpOGgLW1Gy4AGYsrVFHO9a3hSC2L/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">GEOS-Chem structure, documentation, platforms, and parallelization</a>, Bob Yantosca
+ </li>
+ <li>
+  Porting of GEOS-Chem to NCCS, Tom Clune
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1on5mYinee49NJbCLtfXpTT7M2EQvTONl/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">GEOS meteorological products: Evolution, status, and plans</a>, Steven Pawson
+ </li>
 </ul>
 
 <h2>
-	<a name="ug" id="ug"></a>GEOS-Chem User Group Presentations
+ <a name="ug" id="ug"></a>GEOS-Chem User Group Presentations
 </h2>
 
 <ul class="disc">
-	<li>
-		<a href="https://docs.google.com/presentation/d/10W-PrAuingmfzJQ08TXLUysv_-NogMuk/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Ongoing GEOS-Chem activities in the Jacob Group</a>, Daniel Jacob
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/19avRnKl9WxwiAuXugPgDqRmRDoQgTFnu/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Applications of the GEOS-Chem model to investigate trends, budgets, and interannual variability in O3, CO, CH4, and OH; and development and application of a nested grid in GEOS-Chem over Asia</a>, Jennifer Logan
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/15BY3vXp_B2ophHN_3PAZkgh6AhXq-Pi-/view?usp=drive_link" target="_blank">Harvard University (Martin Group) research update</a>, Scot Martin
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/16xcMVoDFWgxy7aczjXPP6KVWnoyX1GFX/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Research activities at EPFL with the GEOS-Chem model</a>, Isabelle Bey
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1X6BylwAhAAB8MJFWFEqnUVfcRBeqKPUR/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Use of GEOS-Chem by SAO and Dalhousie University</a>, Randall Martin
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1DHk7-gvsP8lj1tvIPZoqEyNNxIqCQaLW/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Tropospheric CO modeling using assimilated meteorology</a>, Prasad Kasibhatla
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1NeKCwFb-IHQe5i2TSoc4K4O6SEM6ESOD/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">University of Washington research update</a>, Lyatt Jaegle
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1vJp1iHUlo-qp4e7TkOy9AE5wBq6dWJxL/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Global simulation of CH3Cl with GEOS-Chem</a>, Yuhang Wang
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1vVCjOipPCsciGJK6kbeYV--oTBXsy8n6/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Linking CMAQ with GEOS-Chem</a>, Daewon Byun
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1v_bx2zZHnbdnLY5ehDrUlgkREnKJ4E9e/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">EPA: planned GEOS-Chem / CMAQ interface</a>, Alice Gilliland &amp; Carey Jang
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1ikJd_d_U3IP4bX2sX-WD7Fu0NglfVuP3/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Stratospheric chemistry and SMVGEAR II in GEOS-Chem</a>, Gabriele Curci
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1EBQFIGvrEvEOa2snZn-adAYJVEJ90WmB/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">GEOS-Chem activities at National Institute of Aerospace</a>, Hongyu Liu
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1N9NujJ7fK2K-5to4rRInyj9kpVZQ2jyA/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Extending GEOS-Chem to the stratosphere</a>, Tom Zhao
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1RjEPfPuTVt3EEQKt9a-saHXURKY8q_jb/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Aerosol Microphysics: Plans for GEOS-Chem</a>, Peter Adams
-	</li>
-	<li>
-		CACTUS, Hong Liao
-	</li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/10W-PrAuingmfzJQ08TXLUysv_-NogMuk/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Ongoing GEOS-Chem activities in the Jacob Group</a>, Daniel Jacob
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/19avRnKl9WxwiAuXugPgDqRmRDoQgTFnu/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Applications of the GEOS-Chem model to investigate trends, budgets, and interannual variability in O3, CO, CH4, and OH; and development and application of a nested grid in GEOS-Chem over Asia</a>, Jennifer Logan
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/15BY3vXp_B2ophHN_3PAZkgh6AhXq-Pi-/view?usp=drive_link" target="_blank">Harvard University (Martin Group) research update</a>, Scot Martin
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/16xcMVoDFWgxy7aczjXPP6KVWnoyX1GFX/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Research activities at EPFL with the GEOS-Chem model</a>, Isabelle Bey
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1X6BylwAhAAB8MJFWFEqnUVfcRBeqKPUR/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Use of GEOS-Chem by SAO and Dalhousie University</a>, Randall Martin
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1DHk7-gvsP8lj1tvIPZoqEyNNxIqCQaLW/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Tropospheric CO modeling using assimilated meteorology</a>, Prasad Kasibhatla
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1NeKCwFb-IHQe5i2TSoc4K4O6SEM6ESOD/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">University of Washington research update</a>, Lyatt Jaegle
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1vJp1iHUlo-qp4e7TkOy9AE5wBq6dWJxL/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Global simulation of CH3Cl with GEOS-Chem</a>, Yuhang Wang
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1vVCjOipPCsciGJK6kbeYV--oTBXsy8n6/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Linking CMAQ with GEOS-Chem</a>, Daewon Byun
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1v_bx2zZHnbdnLY5ehDrUlgkREnKJ4E9e/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">EPA: planned GEOS-Chem / CMAQ interface</a>, Alice Gilliland &amp; Carey Jang
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1ikJd_d_U3IP4bX2sX-WD7Fu0NglfVuP3/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Stratospheric chemistry and SMVGEAR II in GEOS-Chem</a>, Gabriele Curci
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1EBQFIGvrEvEOa2snZn-adAYJVEJ90WmB/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">GEOS-Chem activities at National Institute of Aerospace</a>, Hongyu Liu
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1N9NujJ7fK2K-5to4rRInyj9kpVZQ2jyA/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Extending GEOS-Chem to the stratosphere</a>, Tom Zhao
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1RjEPfPuTVt3EEQKt9a-saHXURKY8q_jb/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Aerosol Microphysics: Plans for GEOS-Chem</a>, Peter Adams
+ </li>
+ <li>
+  CACTUS, Hong Liao
+ </li>
 </ul><h2>
-	<a name="comp" id="comp"></a>Companion Activities
+ <a name="comp" id="comp"></a>Companion Activities
 </h2>
 
 <ul class="disc"><li>
-		The View from NASA / HQ, Don Anderson
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1KjkpHtiQtAO-8Nq-hf_VJFyeufDk_6zy/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">The Global Modeling Initiative (GMI): Past, current, and future activities</a>, Jose Rodriguez &amp; Susan Strahan
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1on5mYinee49NJbCLtfXpTT7M2EQvTONl/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Constituent assimilation at GMAO</a>, Steven Pawson
-	</li>
-	<li>
-		The GOCART model, Mian Chin
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1ft0XlcDS0vR57YwKpC5Mu2REDdyI0Akv/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Assessment of CO outflow during TRACE-P with the University of Maryland CTM and mid-Atlantic air quality modeling efforts at the University of Maryland</a>, Dale Allen
-	</li>
-	<li>
-		The MOZART model, Denise Mauzerall
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1ZfPtw4rZJTF8lFw8fV9JjR-Pz-RpFivi/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">The other Harvard 3-D model: , CACTUS Chemistry, aerosols, climate: tropospheric unified simulation</a>, Loretta Mickley
-	</li>
-	<li>
-		The RAQMS system, Duncan Fairlie
-	</li>
+  The View from NASA / HQ, Don Anderson
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1KjkpHtiQtAO-8Nq-hf_VJFyeufDk_6zy/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">The Global Modeling Initiative (GMI): Past, current, and future activities</a>, Jose Rodriguez &amp; Susan Strahan
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1on5mYinee49NJbCLtfXpTT7M2EQvTONl/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Constituent assimilation at GMAO</a>, Steven Pawson
+ </li>
+ <li>
+  The GOCART model, Mian Chin
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1ft0XlcDS0vR57YwKpC5Mu2REDdyI0Akv/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Assessment of CO outflow during TRACE-P with the University of Maryland CTM and mid-Atlantic air quality modeling efforts at the University of Maryland</a>, Dale Allen
+ </li>
+ <li>
+  The MOZART model, Denise Mauzerall
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1ZfPtw4rZJTF8lFw8fV9JjR-Pz-RpFivi/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">The other Harvard 3-D model: , CACTUS Chemistry, aerosols, climate: tropospheric unified simulation</a>, Loretta Mickley
+ </li>
+ <li>
+  The RAQMS system, Duncan Fairlie
+ </li>
 </ul>
 
 </div>
@@ -232,64 +217,16 @@
 </div>
 </div>
 
-<!--footer region beg-->
+<!--footer-->
 <footer id="footer" class="clearfix" role="contentinfo">
-
-<!-- Three column 3x33 Gpanel -->
-<div class="at-panel gpanel panel-display footer clearfix">
-<div class="region region-footer">
-<div class="region-inner clearfix">
-<div id="block-boxes-1617037690" class="block block-boxes block-boxes-os_boxes_html no-title"  module="boxes" delta="1617037690">
-<div class="block-inner clearfix">  
-<div class="block-content content" ng-non-bindable="">  
-<div id='boxes-box-1617037690' class='boxes-box'>  
 <div class="boxes-box-content">
   <p style="text-align:center">
-    Copyright © 2023 by the International GEOS-Chem Community. All rights reserved.
+    Copyright © 2026 by the International GEOS-Chem Community. All rights reserved.
   </p>
 </div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-<div class="region region-footer-bottom">  
-<div class="region-inner clearfix">  
-<div id="block-boxes-1616879798" class="block block-boxes block-boxes-os_boxes_media no-title"  module="boxes" delta="1616879798">  
-<div class="block-inner clearfix">  
-<div class="block-content content"> 
-<div id='boxes-box-1616879798' class='boxes-box'> 
-<div class="boxes-box-content"> 
-<div id="file-3900146" class="file file-html file-html-embed">
-<h2 class="element-invisible"><a href="">css-brand</a></h2>
-<div class="content">
-<div class="file-info">
-</div>
-<div class="field field-name-field-html-code field-type-text-long field-label-hidden view-mode-full">
-<div class="field-items">
-<div class="field-item even">
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-
-<!--footer region end-->
 </footer>
-</div>
-</div>
 
-<!--page area ends-->
-<div id="extradiv"></div>
+</div>
 </div>
 
 </body>

--- a/igc1-presentations.html
+++ b/igc1-presentations.html
@@ -29,22 +29,20 @@
 <div id="page_wrap" class="page_wrap">
 <div id="page" class="container page header-main content-top footer-none">
 <div id="page-wrapper">
-  
+
 <!--header regions beg-->
 <header id="header" class="clearfix" role="banner">
 <div id="header-container">
 <div id="header-panels" class="at-panel gpanel panel-display three-col clearfix">
 <div class="region region-header-second"><div class="region-inner clearfix">
 <section id="block-boxes-1630413211" class="block block-boxes block-boxes-os_boxes_html"  module="boxes" delta="1630413211">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <h2 class="block-title" ng-non-bindable="">Site-Logo</h2>
 <div class="block-content content" ng-non-bindable="">
 <div id='boxes-box-1630413211' class='boxes-box'>
 <div class="boxes-box-content">
-<img height="551" width="1101" style="float: right; width: 350px; height: 175px; margin-bottom: 1.5em;" alt="gca2 logo" class="media-element file-default file-os-files-xxlarge" src="img/igc-early-logo.png" title="" />
-<h2 class="css-brand--css-geos-meetings-header-h2-xxxlarge">
-  The 1st GEOS-Chem Scientific and Users' Meeting (IGC1)<br />June 2-3 2003
-</h2>
+<a href="https://geoschem.github.io/"><img height="600" width="1034" style="float: right; width: 350px; height: 203px;" class="media-element file-default file-os-files-xxlarge" src="img/GEOS-Chem_Logo_Square_Light_Background_Orig.png" alt="" title="" /></a>
+<h2 class="css-brand--css-geos-meetings-header-h2-xxxlarge">The 1st GEOS-Chem Scientific and Users' Meeting (IGC1)<br />June 2-3 2003</h2>
 </div>
 </div>
 </div>
@@ -86,7 +84,7 @@
 <div class="region region-content-top">
 <div class="region-inner clearfix">
 <div id="block-os-pages-main-content" class="block block-os-pages no-title"  module="os_pages" delta="main_content">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <div class="block-content content" ng-non-bindable="">
 <article id="node-1585687" class="node node-page article clearfix" role="article">
 <div class="node-content" ng-non-bindable="">
@@ -105,97 +103,93 @@
 </h2>
 
 <ul class="disc">
-    <li>
-  <a href="https://docs.google.com/presentation/d/10YAPWpvaYlAoiUSe7NRvrXbrRxxtr5ht/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">GEOS-Chem overview, </a>Daniel Jacob
+  <li>
+    <a href="https://docs.google.com/presentation/d/10YAPWpvaYlAoiUSe7NRvrXbrRxxtr5ht/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">GEOS-Chem overview, </a>Daniel Jacob
  </li>
  <li>
-  <a href="https://docs.google.com/presentation/d/13RW_LpOGgLW1Gy4AGYsrVFHO9a3hSC2L/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">GEOS-Chem structure, documentation, platforms, and parallelization</a>, Bob Yantosca
+   <a href="https://docs.google.com/presentation/d/13RW_LpOGgLW1Gy4AGYsrVFHO9a3hSC2L/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">GEOS-Chem structure, documentation, platforms, and parallelization</a>, Bob Yantosca
  </li>
  <li>
-  Porting of GEOS-Chem to NCCS, Tom Clune
+   Porting of GEOS-Chem to NCCS, Tom Clune
  </li>
  <li>
-  <a href="https://docs.google.com/presentation/d/1on5mYinee49NJbCLtfXpTT7M2EQvTONl/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">GEOS meteorological products: Evolution, status, and plans</a>, Steven Pawson
+   <a href="https://docs.google.com/presentation/d/1on5mYinee49NJbCLtfXpTT7M2EQvTONl/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">GEOS meteorological products: Evolution, status, and plans</a>, Steven Pawson
  </li>
 </ul>
 
-<h2>
- <a name="ug" id="ug"></a>GEOS-Chem User Group Presentations
-</h2>
+<h2><a name="ug" id="ug"></a>GEOS-Chem User Group Presentations</h2>
 
 <ul class="disc">
  <li>
-  <a href="https://docs.google.com/presentation/d/10W-PrAuingmfzJQ08TXLUysv_-NogMuk/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Ongoing GEOS-Chem activities in the Jacob Group</a>, Daniel Jacob
+   <a href="https://docs.google.com/presentation/d/10W-PrAuingmfzJQ08TXLUysv_-NogMuk/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Ongoing GEOS-Chem activities in the Jacob Group</a>, Daniel Jacob
  </li>
  <li>
-  <a href="https://docs.google.com/presentation/d/19avRnKl9WxwiAuXugPgDqRmRDoQgTFnu/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Applications of the GEOS-Chem model to investigate trends, budgets, and interannual variability in O3, CO, CH4, and OH; and development and application of a nested grid in GEOS-Chem over Asia</a>, Jennifer Logan
+   <a href="https://docs.google.com/presentation/d/19avRnKl9WxwiAuXugPgDqRmRDoQgTFnu/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Applications of the GEOS-Chem model to investigate trends, budgets, and interannual variability in O3, CO, CH4, and OH; and development and application of a nested grid in GEOS-Chem over Asia</a>, Jennifer Logan
  </li>
  <li>
-  <a href="https://drive.google.com/file/d/15BY3vXp_B2ophHN_3PAZkgh6AhXq-Pi-/view?usp=drive_link" target="_blank">Harvard University (Martin Group) research update</a>, Scot Martin
+   <a href="https://drive.google.com/file/d/15BY3vXp_B2ophHN_3PAZkgh6AhXq-Pi-/view?usp=drive_link" target="_blank">Harvard University (Martin Group) research update</a>, Scot Martin
  </li>
  <li>
-  <a href="https://docs.google.com/presentation/d/16xcMVoDFWgxy7aczjXPP6KVWnoyX1GFX/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Research activities at EPFL with the GEOS-Chem model</a>, Isabelle Bey
+   <a href="https://docs.google.com/presentation/d/16xcMVoDFWgxy7aczjXPP6KVWnoyX1GFX/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Research activities at EPFL with the GEOS-Chem model</a>, Isabelle Bey
  </li>
  <li>
-  <a href="https://docs.google.com/presentation/d/1X6BylwAhAAB8MJFWFEqnUVfcRBeqKPUR/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Use of GEOS-Chem by SAO and Dalhousie University</a>, Randall Martin
+   <a href="https://docs.google.com/presentation/d/1X6BylwAhAAB8MJFWFEqnUVfcRBeqKPUR/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Use of GEOS-Chem by SAO and Dalhousie University</a>, Randall Martin
  </li>
  <li>
-  <a href="https://docs.google.com/presentation/d/1DHk7-gvsP8lj1tvIPZoqEyNNxIqCQaLW/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Tropospheric CO modeling using assimilated meteorology</a>, Prasad Kasibhatla
+   <a href="https://docs.google.com/presentation/d/1DHk7-gvsP8lj1tvIPZoqEyNNxIqCQaLW/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Tropospheric CO modeling using assimilated meteorology</a>, Prasad Kasibhatla
  </li>
  <li>
-  <a href="https://docs.google.com/presentation/d/1NeKCwFb-IHQe5i2TSoc4K4O6SEM6ESOD/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">University of Washington research update</a>, Lyatt Jaegle
+   <a href="https://docs.google.com/presentation/d/1NeKCwFb-IHQe5i2TSoc4K4O6SEM6ESOD/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">University of Washington research update</a>, Lyatt Jaegle
  </li>
  <li>
-  <a href="https://docs.google.com/presentation/d/1vJp1iHUlo-qp4e7TkOy9AE5wBq6dWJxL/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Global simulation of CH3Cl with GEOS-Chem</a>, Yuhang Wang
+   <a href="https://docs.google.com/presentation/d/1vJp1iHUlo-qp4e7TkOy9AE5wBq6dWJxL/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Global simulation of CH3Cl with GEOS-Chem</a>, Yuhang Wang
  </li>
  <li>
-  <a href="https://docs.google.com/presentation/d/1vVCjOipPCsciGJK6kbeYV--oTBXsy8n6/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Linking CMAQ with GEOS-Chem</a>, Daewon Byun
+   <a href="https://docs.google.com/presentation/d/1vVCjOipPCsciGJK6kbeYV--oTBXsy8n6/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Linking CMAQ with GEOS-Chem</a>, Daewon Byun
  </li>
  <li>
-  <a href="https://docs.google.com/presentation/d/1v_bx2zZHnbdnLY5ehDrUlgkREnKJ4E9e/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">EPA: planned GEOS-Chem / CMAQ interface</a>, Alice Gilliland &amp; Carey Jang
+   <a href="https://docs.google.com/presentation/d/1v_bx2zZHnbdnLY5ehDrUlgkREnKJ4E9e/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">EPA: planned GEOS-Chem / CMAQ interface</a>, Alice Gilliland &amp; Carey Jang
  </li>
  <li>
-  <a href="https://docs.google.com/presentation/d/1ikJd_d_U3IP4bX2sX-WD7Fu0NglfVuP3/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Stratospheric chemistry and SMVGEAR II in GEOS-Chem</a>, Gabriele Curci
+   <a href="https://docs.google.com/presentation/d/1ikJd_d_U3IP4bX2sX-WD7Fu0NglfVuP3/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Stratospheric chemistry and SMVGEAR II in GEOS-Chem</a>, Gabriele Curci
  </li>
  <li>
-  <a href="https://docs.google.com/presentation/d/1EBQFIGvrEvEOa2snZn-adAYJVEJ90WmB/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">GEOS-Chem activities at National Institute of Aerospace</a>, Hongyu Liu
+   <a href="https://docs.google.com/presentation/d/1EBQFIGvrEvEOa2snZn-adAYJVEJ90WmB/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">GEOS-Chem activities at National Institute of Aerospace</a>, Hongyu Liu
  </li>
  <li>
-  <a href="https://docs.google.com/presentation/d/1N9NujJ7fK2K-5to4rRInyj9kpVZQ2jyA/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Extending GEOS-Chem to the stratosphere</a>, Tom Zhao
+   <a href="https://docs.google.com/presentation/d/1N9NujJ7fK2K-5to4rRInyj9kpVZQ2jyA/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Extending GEOS-Chem to the stratosphere</a>, Tom Zhao
  </li>
  <li>
-  <a href="https://docs.google.com/presentation/d/1RjEPfPuTVt3EEQKt9a-saHXURKY8q_jb/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Aerosol Microphysics: Plans for GEOS-Chem</a>, Peter Adams
+   <a href="https://docs.google.com/presentation/d/1RjEPfPuTVt3EEQKt9a-saHXURKY8q_jb/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Aerosol Microphysics: Plans for GEOS-Chem</a>, Peter Adams
  </li>
  <li>
-  CACTUS, Hong Liao
+   CACTUS, Hong Liao
  </li>
 </ul><h2>
  <a name="comp" id="comp"></a>Companion Activities
 </h2>
 
-<ul class="disc"><li>
-  The View from NASA / HQ, Don Anderson
+<ul class="disc"><li>The View from NASA / HQ, Don Anderson </li>
+ <li>
+   <a href="https://docs.google.com/presentation/d/1KjkpHtiQtAO-8Nq-hf_VJFyeufDk_6zy/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">The Global Modeling Initiative (GMI): Past, current, and future activities</a>, Jose Rodriguez &amp; Susan Strahan
  </li>
  <li>
-  <a href="https://docs.google.com/presentation/d/1KjkpHtiQtAO-8Nq-hf_VJFyeufDk_6zy/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">The Global Modeling Initiative (GMI): Past, current, and future activities</a>, Jose Rodriguez &amp; Susan Strahan
+   <a href="https://docs.google.com/presentation/d/1on5mYinee49NJbCLtfXpTT7M2EQvTONl/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Constituent assimilation at GMAO</a>, Steven Pawson
  </li>
  <li>
-  <a href="https://docs.google.com/presentation/d/1on5mYinee49NJbCLtfXpTT7M2EQvTONl/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Constituent assimilation at GMAO</a>, Steven Pawson
+   The GOCART model, Mian Chin
  </li>
  <li>
-  The GOCART model, Mian Chin
+   <a href="https://docs.google.com/presentation/d/1ft0XlcDS0vR57YwKpC5Mu2REDdyI0Akv/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Assessment of CO outflow during TRACE-P with the University of Maryland CTM and mid-Atlantic air quality modeling efforts at the University of Maryland</a>, Dale Allen
  </li>
  <li>
-  <a href="https://docs.google.com/presentation/d/1ft0XlcDS0vR57YwKpC5Mu2REDdyI0Akv/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Assessment of CO outflow during TRACE-P with the University of Maryland CTM and mid-Atlantic air quality modeling efforts at the University of Maryland</a>, Dale Allen
+   The MOZART model, Denise Mauzerall
  </li>
  <li>
-  The MOZART model, Denise Mauzerall
+   <a href="https://docs.google.com/presentation/d/1ZfPtw4rZJTF8lFw8fV9JjR-Pz-RpFivi/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">The other Harvard 3-D model: , CACTUS Chemistry, aerosols, climate: tropospheric unified simulation</a>, Loretta Mickley
  </li>
  <li>
-  <a href="https://docs.google.com/presentation/d/1ZfPtw4rZJTF8lFw8fV9JjR-Pz-RpFivi/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">The other Harvard 3-D model: , CACTUS Chemistry, aerosols, climate: tropospheric unified simulation</a>, Loretta Mickley
- </li>
- <li>
-  The RAQMS system, Duncan Fairlie
+   The RAQMS system, Duncan Fairlie
  </li>
 </ul>
 
@@ -231,3 +225,4 @@
 
 </body>
 </html>
+

--- a/igc1.html
+++ b/igc1.html
@@ -29,22 +29,20 @@
 <div id="page_wrap" class="page_wrap">
 <div id="page" class="container page header-main content-top footer-none">
 <div id="page-wrapper">
-		
+
 <!--header regions beg-->
 <header id="header" class="clearfix" role="banner">
 <div id="header-container">
 <div id="header-panels" class="at-panel gpanel panel-display three-col clearfix">
 <div class="region region-header-second"><div class="region-inner clearfix">
 <section id="block-boxes-1630413211" class="block block-boxes block-boxes-os_boxes_html"  module="boxes" delta="1630413211">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <h2 class="block-title" ng-non-bindable="">Site-Logo</h2>
 <div class="block-content content" ng-non-bindable="">
 <div id='boxes-box-1630413211' class='boxes-box'>
 <div class="boxes-box-content">
-<img height="551" width="1101" style="float: right; width: 350px; height: 175px; margin-bottom: 1.5em;" alt="gca2 logo" class="media-element file-default file-os-files-xxlarge" src="img/igc-early-logo.png" title="" />
-<h2 class="css-brand--css-geos-meetings-header-h2-xxxlarge">
-  The 1st GEOS-Chem Scientific and Users' Meeting (IGC1)<br />June 2-3 2003
-</h2>
+<a href="https://geoschem.github.io/"><img height="600" width="1034" style="float: right; width: 350px; height: 203px;" class="media-element file-default file-os-files-xxlarge" src="img/GEOS-Chem_Logo_Square_Light_Background_Orig.png" alt="" title="" /></a>
+<h2 class="css-brand--css-geos-meetings-header-h2-xxxlarge">The 1st GEOS-Chem Scientific and Users' Meeting (IGC1)<br />June 2-3 2003</h2>
 </div>
 </div>
 </div>
@@ -86,7 +84,7 @@
 <div class="region region-content-top">
 <div class="region-inner clearfix">
 <div id="block-os-pages-main-content" class="block block-os-pages no-title"  module="os_pages" delta="main_content">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <div class="block-content content" ng-non-bindable="">
 <article id="node-1585687" class="node node-page article clearfix" role="article">
 <div class="node-content" ng-non-bindable="">

--- a/igc1.html
+++ b/igc1.html
@@ -1,9 +1,4 @@
 <!DOCTYPE html>
-<!--[if IEMobile 7]><html class="iem7"  lang="en" dir="ltr"><![endif]-->
-<!--[if lte IE 6]><html class="lt-ie9 lt-ie8 lt-ie7"  lang="en" dir="ltr"><![endif]-->
-<!--[if (IE 7)&(!IEMobile)]><html class="lt-ie9 lt-ie8"  lang="en" dir="ltr"><![endif]-->
-<!--[if IE 8]><html class="lt-ie9"  lang="en" dir="ltr"><![endif]-->
-<!--[if (gte IE 9)|(gt IEMobile 7)]><!--><html  lang="en" dir="ltr"><!--<![endif]-->
 <head>
 <meta charset="utf-8" />
 <!--<base href="/igc1" />-->
@@ -18,23 +13,12 @@
 <title>The 1st GEOS-Chem Meeting</title>
 <meta http-equiv="x-ua-compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<link type="text/css" rel="stylesheet" href="css/css_xE-rWrJf-fncB6ztZfd2huxqgxu4WO-qwma6Xer30m4%EF%B9%96m=1675397288.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_1kR8T1_c-l5pBT6ZwbDT7BFda-4fyqW9Jjum29_2IY8%EF%B9%96m=1675397312.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_YnlUIvHP13qgpYEqubzE8JyDwlSxUnVibfnVkSoSDb0%EF%B9%96m=1675397273.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_Ku-3OcT9qU9h7dnGig5e23q6EVryY8orK4wzVDxsweE%EF%B9%96m=1675397367.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_vprtFTrWyg23GbY50_zJZHWGYMNfS8vsrRS26i4-ISk%EF%B9%96m=1675397406.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_dW-aNNrctRhQNc-KECjtQd0PxuW-h19IEum-TX2MeEk%EF%B9%96m=1675397301.css" media="print" />
-<link type="text/css" rel="stylesheet" href="css/css_SH2Lx3Qprh0GZo_9xRp85U9NsWfkSXn_Bi-rJoMY1sw%EF%B9%96m=1675397273.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_uaIDKcYMUK5osSQXuirpr3ZleXtnnpBN-eiECm7N0M0%EF%B9%96m=1675397395.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/responsive.blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/geos-chem.css" media="all"/>
 <script type="text/javascript" src="dropdown-menu.js"></script>
-<!--[if lte IE 8]>
-<script type="text/javascript">
-  var os_c = document.createElement;os_c('header');os_c('nav');os_c('section');os_c('article');os_c('aside');os_c('footer');os_c('hgroup');os_c('figure');
-</script>
-<![endif]-->
 </head>
 
 <body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-1585687 node-type-page og-context og-context-node og-context-node-1585652 navbar-on">
@@ -74,17 +58,18 @@
 </header>
 <!--header regions end-->
 
+
 <!--main menu region beg-->
 <div id="menu-bar" class="nav region-menu-bar clearfix">
-<nav id="block-os-igc1-menu" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="igc1_menu">  
-<ul class="nice-menu nice-menu-down nice-menu-igc1_menu" id="nice-menu-igc1_menu">
-  <li class="menu-861303 menu-path-node-1587366  first   odd  "><a href="igc1.html" >Home</a></li>
-  <li class="menu-861308 menu-path-node-1587367   even  "><a href="igc1-presentations.html"  class="active">Presentations</a></li>
-  <li class="menu-861316 menu-path-node-1587368   odd   last "><a href="igc1-attendees.html" >Attendees</a></li>
+<nav id="block-os-igc1-menu" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="igc1_menu">
+<ul class="nice-menu nice-menu-down">
+  <li><a href="igc1.html" class="active">IGC1 Home</a></li>
+  <li><a href="igc1-presentations.html">Presentations and Posters</a></li>
+  <li><a href="index.html">GEOS-Chem Home</a></li>
 </ul>
 </nav>
 </div>
-<!--main menu region end-->	
+<!--main menu region end-->
 
 <div id="columns" class="clearfix">
 <div class="hg-container">
@@ -155,64 +140,16 @@
 </div>
 </div>
 
-<!--footer region beg-->
+<!--footer-->
 <footer id="footer" class="clearfix" role="contentinfo">
-
-<!-- Three column 3x33 Gpanel -->
-<div class="at-panel gpanel panel-display footer clearfix">
-<div class="region region-footer">
-<div class="region-inner clearfix">
-<div id="block-boxes-1617037690" class="block block-boxes block-boxes-os_boxes_html no-title"  module="boxes" delta="1617037690">
-<div class="block-inner clearfix">  
-<div class="block-content content" ng-non-bindable="">  
-<div id='boxes-box-1617037690' class='boxes-box'>  
 <div class="boxes-box-content">
   <p style="text-align:center">
-    Copyright © 2023 by the International GEOS-Chem Community. All rights reserved.
+    Copyright © 2026 by the International GEOS-Chem Community. All rights reserved.
   </p>
 </div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-<div class="region region-footer-bottom">  
-<div class="region-inner clearfix">  
-<div id="block-boxes-1616879798" class="block block-boxes block-boxes-os_boxes_media no-title"  module="boxes" delta="1616879798">  
-<div class="block-inner clearfix">  
-<div class="block-content content"> 
-<div id='boxes-box-1616879798' class='boxes-box'> 
-<div class="boxes-box-content"> 
-<div id="file-3900146" class="file file-html file-html-embed">
-<h2 class="element-invisible"><a href="">css-brand</a></h2>
-<div class="content">
-<div class="file-info">
-</div>
-<div class="field field-name-field-html-code field-type-text-long field-label-hidden view-mode-full">
-<div class="field-items">
-<div class="field-item even">
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-
-<!--footer region end-->
 </footer>
-</div>
-</div>
 
-<!--page area ends-->
-<div id="extradiv"></div>
+</div>
 </div>
 
 </body>

--- a/igc10-presentations.html
+++ b/igc10-presentations.html
@@ -1,9 +1,4 @@
 <!DOCTYPE html>
-<!--[if IEMobile 7]><html class="iem7"  lang="en" dir="ltr"><![endif]-->
-<!--[if lte IE 6]><html class="lt-ie9 lt-ie8 lt-ie7"  lang="en" dir="ltr"><![endif]-->
-<!--[if (IE 7)&(!IEMobile)]><html class="lt-ie9 lt-ie8"  lang="en" dir="ltr"><![endif]-->
-<!--[if IE 8]><html class="lt-ie9"  lang="en" dir="ltr"><![endif]-->
-<!--[if (gte IE 9)|(gt IEMobile 7)]><!--><html  lang="en" dir="ltr"><!--<![endif]-->
 <head>
 <meta charset="utf-8" />
 <!--<base href="/igc10-presentations" />-->
@@ -18,23 +13,12 @@
 <title>The 10th International GEOS-Chem Meeting</title>
 <meta http-equiv="x-ua-compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<link type="text/css" rel="stylesheet" href="css/css_xE-rWrJf-fncB6ztZfd2huxqgxu4WO-qwma6Xer30m4%EF%B9%96m=1675397288.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_1kR8T1_c-l5pBT6ZwbDT7BFda-4fyqW9Jjum29_2IY8%EF%B9%96m=1675397312.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_YnlUIvHP13qgpYEqubzE8JyDwlSxUnVibfnVkSoSDb0%EF%B9%96m=1675397273.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_Ku-3OcT9qU9h7dnGig5e23q6EVryY8orK4wzVDxsweE%EF%B9%96m=1675397367.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_vprtFTrWyg23GbY50_zJZHWGYMNfS8vsrRS26i4-ISk%EF%B9%96m=1675397406.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_dW-aNNrctRhQNc-KECjtQd0PxuW-h19IEum-TX2MeEk%EF%B9%96m=1675397301.css" media="print" />
-<link type="text/css" rel="stylesheet" href="css/css_SH2Lx3Qprh0GZo_9xRp85U9NsWfkSXn_Bi-rJoMY1sw%EF%B9%96m=1675397273.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_uaIDKcYMUK5osSQXuirpr3ZleXtnnpBN-eiECm7N0M0%EF%B9%96m=1675397395.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/responsive.blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/geos-chem.css" media="all"/>
 <script type="text/javascript" src="dropdown-menu.js"></script>
-<!--[if lte IE 8]>
-<script type="text/javascript">
-  var os_c = document.createElement;os_c('header');os_c('nav');os_c('section');os_c('article');os_c('aside');os_c('footer');os_c('hgroup');os_c('figure');
-</script>
-<![endif]-->
 </head>
 
 <body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-1585687 node-type-page og-context og-context-node og-context-node-1585652 navbar-on">
@@ -45,7 +29,7 @@
 <div id="page_wrap" class="page_wrap">
 <div id="page" class="container page header-main content-top footer-none">
 <div id="page-wrapper">
-		
+
 <!--header regions beg-->
 <header id="header" class="clearfix" role="banner">
 <div id="header-container">
@@ -53,7 +37,7 @@
 <div class="region region-header-second">
 <div class="region-inner clearfix">
 <div id="block-boxes-1617807424" class="block block-boxes block-boxes-os_boxes_html no-title"  module="boxes" delta="1617807424">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <div class="block-content content" ng-non-bindable="">
 <div id='boxes-box-1617807424' class='boxes-box'>
 <div class="boxes-box-content">
@@ -76,15 +60,16 @@ The 10th International GEOS-Chem Meeting (IGC10) June 6-10, 2022
 
 <!--main menu region beg-->
 <div id="menu-bar" class="nav region-menu-bar clearfix">
-<nav id="block-os-igc10-menu" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="igc10_menu">  
-<ul class="nice-menu nice-menu-down nice-menu-igc10_menu" id="nice-menu-igc10_menu">
-  <li class="menu-1043794 menu-path-https--geos-chemseasharvardedu-igc10  first   odd  "><a href="igc10.html" >Home</a></li>
-  <li class="menu-1043986 menu-path-node-1644721   even   last "><a href="igc10-presentations.html"  title="">Presentations and Posters</a></li>
+<nav id="block-os-igc10-menu" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="igc10_menu">
+<ul class="nice-menu nice-menu-down">
+  <li><a href="igc10.html" class="active">IGC10 Home</a></li>
+  <li><a href="igc10-presentations.html">Presentations and Posters</a></li>
+  <li><a href="index.html">GEOS-Chem Home</a></li>
 </ul>
 </nav>
 </div>
 <!--main menu region end-->
-		
+
 <div id="columns" class="clearfix">
 <div class="hg-container">
 <div id="content-column" role="main">
@@ -94,497 +79,517 @@ The 10th International GEOS-Chem Meeting (IGC10) June 6-10, 2022
 <a name="main-content"></a>
 <h1 id="page-title" ng-non-bindable="">Presentations and Posters</h1>
 </header>
-														
+
 <!--front panel regions beg-->
 <div id="content-panels" class="at-panel gpanel panel-display content clearfix">
 <div class="region region-content-top">
 <div class="region-inner clearfix">
 <div id="block-os-pages-main-content" class="block block-os-pages no-title"  module="os_pages" delta="main_content">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <div class="block-content content" ng-non-bindable="">
 <article id="node-1585687" class="node node-page article clearfix" role="article">
 <div class="node-content" ng-non-bindable="">
 <div class="field field-name-body field-type-text-with-summary field-label-hidden view-mode-full">
 <div class="field-items">
 <div class="field-item even">
-  
+
 <p align="justify">
-	<strong>Monday, June 6: <a href="#clinics">Model Clinics</a><br class="clearfix" />Tuesday, June 7: <a href="#overview">Model Overview and New Developments</a> | <a href="#chemistryI">Chemistry I</a> | <a href="#aerosols">Aerosols</a> | <a href="#tuesday_posters">Posters</a><br class="clearfix" />Wednesday, June 8: <a href="#emissions">Emissions and surface fluxes</a> | <a href="#carbon">Carbon Gases</a> | <a href="#chemistryII">Chemistry II</a> | <a href="#wednesday_posters">Posters</a><br class="clearfix" />Thursday, June 9: <a href="#climate">Chemistry-Ecosystem-Climate</a> | <a href="#model_dev">Model Developments</a> | <a href="#air_quality">Air quality</a>| <a href="#thursday_posters">Posters</a><br class="clearfix" />Friday, June 10: <a href="#fires">Fires</a> | <a href="#community">GEOS-Chem &amp; Community</a></strong>
+  <strong>Monday, June 6: <a href="#clinics">Model Clinics</a><br class="clearfix" />Tuesday, June 7: <a href="#overview">Model Overview and New Developments</a> | <a href="#chemistryI">Chemistry I</a> | <a href="#aerosols">Aerosols</a> | <a href="#tuesday_posters">Posters</a><br class="clearfix" />Wednesday, June 8: <a href="#emissions">Emissions and surface fluxes</a> | <a href="#carbon">Carbon Gases</a> | <a href="#chemistryII">Chemistry II</a> | <a href="#wednesday_posters">Posters</a><br class="clearfix" />Thursday, June 9: <a href="#climate">Chemistry-Ecosystem-Climate</a> | <a href="#model_dev">Model Developments</a> | <a href="#air_quality">Air quality</a>| <a href="#thursday_posters">Posters</a><br class="clearfix" />Friday, June 10: <a href="#fires">Fires</a> | <a href="#community">GEOS-Chem &amp; Community</a></strong>
 </p>
 
-<div>
-	<h2>
-		Monday, June 6
-	</h2>
-	<a name="clinics" id="clinics"></a><strong>Model Clinics</strong>
+<h2>Monday, June 6</h2>
 
-	<ul><li>
-			<a href="https://drive.google.com/file/d/1htOuHOVpNAz7l1TVWWzfwVJKFOtNCv-u/view?usp=share_link" title="">Getting Started with GEOS-Chem</a> (Bob Yantosca, Harvard; Melissa Sulprizio, Harvard)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1FIMqO7npckEU0YzCBJG9bFe_94Cr2a1h/view?usp=share_link" title="">Working with the high-performance GEOS-Chem (GCHP)</a> (Liam Bindle, WashU; Lizzie Lundgren, Harvard)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1UyOhJBb04LRM-oSl1w5zOkVkymlT1hlX/view?usp=share_link">Running GEOS-Chem with WRF (WRF-GC)</a> (Xu Feng, Harvard; Haipeng Lin, Harvard)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1bl4rcqBFI6FEi2aKG0uuykDPDucYRlln/view?usp=share_link">Working with the GEOS-Chem adjoint</a> (<a href="https://drive.google.com/file/d/1k4IG5lquD4due5g-y7cr24WItxHKKFg7/view?usp=share_link">Handout</a>) + <a href="https://drive.google.com/file/d/1k4IG5lquD4due5g-y7cr24WItxHKKFg7/view?usp=share_link">GCHP adjoint</a> (Daven Henze, UMN)
-		</li>
-		<li>
-			<a href="https://docs.google.com/presentation/d/1ikNDW8JGxUXcY-ww0QT1q0hdORjiA8UN/edit?usp=share_link&ouid=116746565761151195371&rtpof=true&sd=true">Running GC within CESM</a> (Sebastian Eastham, MIT)
-		</li>
-	</ul></div>
+<a name="clinics" id="clinics"></a><strong>Model Clinics</strong>
 
-<div>
-	<h2>
-		Tuesday, June 7
-	</h2>
-	<a name="overview" id="overview"></a><strong>Model overview and new developments (Chair: Daniel Jacob, Harvard)</strong>
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1htOuHOVpNAz7l1TVWWzfwVJKFOtNCv-u/view?usp=share_link" title="">Getting Started with GEOS-Chem</a> (Bob Yantosca, Harvard; Melissa Sulprizio, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1FIMqO7npckEU0YzCBJG9bFe_94Cr2a1h/view?usp=share_link" title="">Working with the high-performance GEOS-Chem (GCHP)</a> (Liam Bindle, WashU; Lizzie Lundgren, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1UyOhJBb04LRM-oSl1w5zOkVkymlT1hlX/view?usp=share_link">Running GEOS-Chem with WRF (WRF-GC)</a> (Xu Feng, Harvard; Haipeng Lin, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1bl4rcqBFI6FEi2aKG0uuykDPDucYRlln/view?usp=share_link">Working with the GEOS-Chem adjoint</a> (<a href="https://drive.google.com/file/d/1k4IG5lquD4due5g-y7cr24WItxHKKFg7/view?usp=share_link">Handout</a>) + <a href="https://drive.google.com/file/d/1k4IG5lquD4due5g-y7cr24WItxHKKFg7/view?usp=share_link">GCHP adjoint</a> (Daven Henze, UMN)
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1ikNDW8JGxUXcY-ww0QT1q0hdORjiA8UN/edit?usp=share_link&ouid=116746565761151195371&rtpof=true&sd=true">Running GC within CESM</a> (Sebastian Eastham, MIT)
+  </li>
+</ul>
 
-	<ul><li>
-			Welcome to IGC10 (Daniel Jacob, Harvard)
-		</li>
-		<li>
-			Welcome to Washington University (Dean Aaron Bobick, WashU)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/19PxCuDtcDwXtxHYl5rDEwIrl3d1ZtPw1/view?usp=share_link">Welcome and GEOS-Chem overview</a> (Randall Martin, WashU)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1Jsnz3vAeRKDm5tozATTn1n72pAllW6Dq/view?usp=share_link">GEOS-Chem as a chemistry option in CESM</a> (Sebastian Eastham, MIT)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/14OCHbVE0MGdH64R7wca_VL0DxuMwRal6/view?usp=share_link">GEOS-Chem adjoint overview</a> (Daven Henze, Colorado U. Boulder)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1vOw3FQepmTJmkPjusKjI9a7U3ONXu_az/view?usp=share_link">Supporting NASA missions with the GEOS Composition Forecast System</a> (Emma Knowland, NASA)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/17I1eHADWOyn4FKLVGUrNs1ccjpf4kl-D/view?usp=share_link">Evolving GEOS Systems: Snapshots and Timelines</a> (Steven Pawson, NASA)
-		</li>
-	</ul><a name="chemistryI" id="chemistryI"></a><strong>Chemistry I (Chair: Eloise Marais, U. College London)</strong>
+<h2>Tuesday, June 7</h2>
 
-	<ul><li>
-			<a href="https://drive.google.com/file/d/1ODr3OgkgmzwQE6GKK6n8fZZ1jQW3XsWf/view?usp=share_link">A new ozone photochemical regime</a> (Mat Evans, U. York)
-		</li>
-		<li>
-			Constraining Organic Nitrate Formation &amp; Monoterpene Oxidation in GEOS-Chem (Jessica Haskins, MIT)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1AWTbomupI5gli0U6vNFjLqomXVBlB3S0/view?usp=share_link">Sources and chemistry of ethanol </a>(Kelvin Bates, Harvard)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1jFnZYwA_QHjbhQ3x2eRW9x8TFPDCqKQH/view?usp=share_link">Applications of the GEOS-Chem Stratosphere in the GEOS Composition Forecast Model </a>(Pamela Wales, NASA GSFC)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1xCIA6YPA0oEFDV1ameC3-dfoj5lRwpD7/view?usp=share_link">Comparing the impacts of isoprene and iodine on tropospheric photochemistry</a> (Ryan Pound, U. York)
-		</li>
-		<li>
-			Snowpack reactive bromine production and the implications on ice core interpretation (Shuting Zhai, U. Washington)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1bP-y8Wr3NEtDt21iSMSl1Ufa2l2QENax/view?usp=share_link">Simulation of NO2 vertical profiles over East Asia and their relation to oxidant chemistr</a>y (Laura Yang, Harvard)
-		</li>
-	</ul><a name="aerosols" id="aerosols"></a><strong>Aerosols (chair: Will Porter, UC Riverside)</strong>
+<a name="overview" id="overview"></a><strong>Model overview and new developments (Chair: Daniel Jacob, Harvard)</strong>
 
-	<ul><li>
-			<a href="https://drive.google.com/file/d/1FGkivPdnOl1BPpBcsqLz0Vg97Wex-hOs/view?usp=share_link">KEYNOTE: Experimental constraints on hydrolysis and photochemical fates of monoterpene organic nitrates</a> (Nga Lee Ng, Georgia Tech)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/19RfOr_rYkV5CgrWHQtV-rujE-OnWwjnb/view?usp=share_link">Simulating Aerosol Number and Size with TOMAS in GCHP</a> (Betty Croft, Dalhousie/WashU)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1QBa565Rt3GdXYe91f_iVH_1_21HWK3A7/view?usp=share_link">New measurements of 3-10 nm particle dry deposition and implications for chemical transport and climate models</a> (Nicholas Meskhidze, NCSU)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/154N4S0Roo6QXGpRW3CYT3uqdHkKPI4I7/view?usp=share_link">Study of particle number concentrations and size distributions in the stratosphere using GEOS-Chem- APM</a> (Fangqun Yu, SUNY Albany)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1ftpIJhp3VhRYT8486L_Ofo24khfSRnMz/view?usp=share_link">Application of GEOS-Chem in ‘Satellite-derived’ PM2.5</a> (Aaron van Donkelaar, WashU)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1Xllu4wqLujidiVWZ3ybgFFY8PLGVGFcz/view?usp=share_link">Letting a BAT fly in GEOS-Chem: water-sensitive organic aerosol formation</a> (Camilo Serrano Damha, McGill U.)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1JX5Rua9qTc0ysf4vkEFpfXCkPmgriML8/view?usp=share_link">Parameterization of Aerosol Size of Organic and Secondary Inorganic Aerosol for Efficient Representation of Global Aerosol Optical Properties</a> (Haihui Zhu, WashU)
-		</li>
-		<li>
-			Coarse particulate matter air quality in East Asia: implications for particulate nitrate (Shixian Zhai, Harvard U.)
-		</li>
-		<li>
-			Contributions of marine sulfur chemistry to the seasonal variability of sulfate aerosol size distributions (Linia Tashmim, UC Riverside)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1XcqEQEv6Zb5SqE0c8hnsYWu3pP9CZgks/view?usp=share_link">Increasing influence of Canada anthropogenic SO2 emission and the Great Lakes Region shipment SO2 emission on ultrafine particle number concentrations in New York State</a> (Gan Luo, SUNY Albany)
-		</li>
-	</ul><a name="tuesday_posters" id="tuesday_posters"></a><strong>Posters</strong>
+<ul>
+  <li>
+    Welcome to IGC10 (Daniel Jacob, Harvard)
+  </li>
+  <li>
+    Welcome to Washington University (Dean Aaron Bobick, WashU)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/19PxCuDtcDwXtxHYl5rDEwIrl3d1ZtPw1/view?usp=share_link">Welcome and GEOS-Chem overview</a> (Randall Martin, WashU)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Jsnz3vAeRKDm5tozATTn1n72pAllW6Dq/view?usp=share_link">GEOS-Chem as a chemistry option in CESM</a> (Sebastian Eastham, MIT)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/14OCHbVE0MGdH64R7wca_VL0DxuMwRal6/view?usp=share_link">GEOS-Chem adjoint overview</a> (Daven Henze, Colorado U. Boulder)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1vOw3FQepmTJmkPjusKjI9a7U3ONXu_az/view?usp=share_link">Supporting NASA missions with the GEOS Composition Forecast System</a> (Emma Knowland, NASA)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/17I1eHADWOyn4FKLVGUrNs1ccjpf4kl-D/view?usp=share_link">Evolving GEOS Systems: Snapshots and Timelines</a> (Steven Pawson, NASA)
+  </li>
+</ul><a name="chemistryI" id="chemistryI"></a><strong>Chemistry I (Chair: Eloise Marais, U. College London)</strong>
 
-	<ul><li>
-			<a href="https://drive.google.com/file/d/1RbDEylLWAZwcijpM4F01uUir3TQ-0pKY/view?usp=share_link">Anthropogenic Sources of Methanol and Ethanol in East Asia</a> (Ellie Beaudry, Harvard)
-		</li>
-		<li>
-			Modeling atmospheric production of perchlorate (Yuk Chun Chan, U. Washington)
-		</li>
-		<li>
-			Reactive carbon over Europe with constraints from a Zeppelin study (Xin Chen, MIT)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1Lo0lRScHXqnT1sdCzXRBnDLhYaNYcFZ6/view?usp=share_link">Atmospheric Chemistry, Carbon Cycle and Climate (AC4) Program</a> (Shibajyoti Das, NOAA)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1569soVA060W-2DaUW07rKPUp_QFL89Gx/view?usp=share_link">Retrievals of peroxyacetyl nitrate (PAN) from FTIR ground-based solar spectra, comparison with GEOS-Chem and satellite data</a> (Irene Pardo Cantos, U. Liege)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1vFIILKK7ghRfFq_LlTVU1lkEoyi7O14z/view?usp=share_link">Modelling the primary production of molecular hydrogen (H2) from the photolysis of aldehydes and its implications on the H2 tropospheric budget</a> (Maria Paula Perez-Pena, UNSW Sydney)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1c_h713giU6x4UpHoQtipQCBoo6jOgkpF/view?usp=share_link">Contributions to Arctic reactive bromine from snowpack and blowing snow sources in 2015</a> (William Swanson, U. Alaska)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1Cvq8lp-GHy1_F7Fjs4-yPIYGG4eTu_UZ/view?usp=share_link">Climatology of reactive nitrogen in the global upper troposphere deduced with recent and historical aircraft campaigns and GEOS-Chem</a> (Nana Wei, U. College London)
-		</li>
-		<li>
-			Assessing Atmospheric Oxidation in GEOS-Chem with CrIS Isoprene Measurements (Joshua Shutter, U. Minnesota)
-		</li>
-		<li>
-			Understanding sources of cloud condensation nuclei during summertime in Southeast US (Suqian Chu, SUNY Albany)
-		</li>
-		<li>
-			An assessment of the uncertainty in PM2.5 estimates and trends due to discontinuity in instruments and retrievals (Melanie Hammer, WashU)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1DKFoBnWM3FNcRcIwK9y4B9BUGCs2zHxG/view?usp=share_link">Evaluating GEOS-Chem simulations of secondary inorganic aerosols using a suite of aircraft campaigns</a> (Olivia Norman, MIT)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/15JnTif3MqO367DQhL8_W5Wc4LAfErP49/view?usp=share_link">Effects of Dust Non-sphericity on Atmospheric Modeling</a> (Inderjeet Singh, WashU)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1D1SStzJ13rRQTDrGKyZSxuJ2rPbzLNR7/view?usp=share_link">Implications of using MERRA-2 cloud water in aerosol wet scavenging for Pb-210 surface concentrations and vertical profiles in GEOS-Chem</a> (Bo Zhang, NASA LaRC)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/15pq6HwWbBXw3pSgLscZDuu_107ZxO1A-/view?usp=share_link">A scheme for representing aromatic secondary organic aerosols in chemical transport models: application to source attribution of organic aerosols over South Korea during the KORUS-AQ campaign</a> (Jared Brewer, Harvard)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1g2WRGEVGWfH1vNsor6qnt3iXgByoeobz/view?usp=share_link">Application of High Spectral Resolution Lidar (HSRL)-based methods for estimating PM2.5 during KORUS-AQ campaign (Application of High Spectral Resolution Lidar (HSRL)-based methods for estimating PM2.5 during KORUS-AQ campaign</a> (Bethany Sutherland, North Carolina State U.)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1PceOb_5A6lZkijcV3wrqBOj2MxgagQ5c/view?usp=share_link">Smoke in the western United States: a comparison between satellite and airport observations</a> (Tianjia (Tina) Liu, Harvard)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/19r0F2bwsRievhwPxDvPU22_9qfuEy5GH/view?usp=share_link">Quantifying the smoke aerosol mass injected into the stratosphere by pyrocumulonimbus activity</a> (Will Julstrom, U. Iowa)
-		</li>
-	</ul></div>
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1ODr3OgkgmzwQE6GKK6n8fZZ1jQW3XsWf/view?usp=share_link">A new ozone photochemical regime</a> (Mat Evans, U. York)
+  </li>
+  <li>
+    Constraining Organic Nitrate Formation &amp; Monoterpene Oxidation in GEOS-Chem (Jessica Haskins, MIT)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1AWTbomupI5gli0U6vNFjLqomXVBlB3S0/view?usp=share_link">Sources and chemistry of ethanol </a>(Kelvin Bates, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1jFnZYwA_QHjbhQ3x2eRW9x8TFPDCqKQH/view?usp=share_link">Applications of the GEOS-Chem Stratosphere in the GEOS Composition Forecast Model </a>(Pamela Wales, NASA GSFC)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1xCIA6YPA0oEFDV1ameC3-dfoj5lRwpD7/view?usp=share_link">Comparing the impacts of isoprene and iodine on tropospheric photochemistry</a> (Ryan Pound, U. York)
+  </li>
+  <li>
+    Snowpack reactive bromine production and the implications on ice core interpretation (Shuting Zhai, U. Washington)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1bP-y8Wr3NEtDt21iSMSl1Ufa2l2QENax/view?usp=share_link">Simulation of NO2 vertical profiles over East Asia and their relation to oxidant chemistr</a>y (Laura Yang, Harvard)
+  </li>
+</ul>
 
-<div>
-	<h2>
-		Wednesday, June 8
-	</h2>
-	<a name="emissions" id="emissions"></a><strong>Emissions and surface fluxes (chair: Dylan Millet, U. Minnesota)</strong>
+<a name="aerosols" id="aerosols"></a><strong>Aerosols (chair: Will Porter, UC Riverside)</strong>
 
-	<ul><li>
-			<a href="https://drive.google.com/file/d/12ty7_MsFFii0ZhClCvn7_kqRuCevs9nw/view?usp=share_link">Brief Tutorial: GCHP, stretched grid, and bash data catalog</a> (Liam Bindle, WashU)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1ZtQrQavACN01DeYCAmX1zXy7BbHvNdbT/view?usp=share_link">Constraining Long-Term NOx Emissions over the United States and Europe to Improve Simulations of Tropospheric Ozone</a> (Amy Christiansen, U. Montana)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1FQGi1wlIzvKxKwdlE6GAxZMrDaS9ZaZB/view?usp=share_link">Background NOx from aviation and fire emissions: implications for satellite NO2 observations</a> (Ruijun Dang, Harvard)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1Z9eegd3FVWugjgyi5rfifJVZqaGUJKXb/view?usp=share_link">Exploring Deposition Observations as a Constraint on Emissions in the United States</a> (Ishir Dutta, MIT)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1mGoofM14nMJ3p3IFrI8QBaxrF8SwLuGG/view?usp=share_link">Biogenic VOC emissions in the Arctic: knowns and unknowns </a>(Lu Hu, U. Montana)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1TgNZY6THYAfMlRZJXoOWJK3wBlJS0wZz/view?usp=share_link">Updating ethane and propane sources in GEOS-Chem</a> (Matthew Rowlinson, U. York)
-		</li>
-	</ul><a name="carbon" id="carbon"></a><strong>Carbon gases (chair: Seb Eastham, MIT)</strong>
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1FGkivPdnOl1BPpBcsqLz0Vg97Wex-hOs/view?usp=share_link">KEYNOTE: Experimental constraints on hydrolysis and photochemical fates of monoterpene organic nitrates</a> (Nga Lee Ng, Georgia Tech)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/19RfOr_rYkV5CgrWHQtV-rujE-OnWwjnb/view?usp=share_link">Simulating Aerosol Number and Size with TOMAS in GCHP</a> (Betty Croft, Dalhousie/WashU)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1QBa565Rt3GdXYe91f_iVH_1_21HWK3A7/view?usp=share_link">New measurements of 3-10 nm particle dry deposition and implications for chemical transport and climate models</a> (Nicholas Meskhidze, NCSU)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/154N4S0Roo6QXGpRW3CYT3uqdHkKPI4I7/view?usp=share_link">Study of particle number concentrations and size distributions in the stratosphere using GEOS-Chem- APM</a> (Fangqun Yu, SUNY Albany)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1ftpIJhp3VhRYT8486L_Ofo24khfSRnMz/view?usp=share_link">Application of GEOS-Chem in ‘Satellite-derived’ PM2.5</a> (Aaron van Donkelaar, WashU)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Xllu4wqLujidiVWZ3ybgFFY8PLGVGFcz/view?usp=share_link">Letting a BAT fly in GEOS-Chem: water-sensitive organic aerosol formation</a> (Camilo Serrano Damha, McGill U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1JX5Rua9qTc0ysf4vkEFpfXCkPmgriML8/view?usp=share_link">Parameterization of Aerosol Size of Organic and Secondary Inorganic Aerosol for Efficient Representation of Global Aerosol Optical Properties</a> (Haihui Zhu, WashU)
+  </li>
+  <li>
+    Coarse particulate matter air quality in East Asia: implications for particulate nitrate (Shixian Zhai, Harvard U.)
+  </li>
+  <li>
+    Contributions of marine sulfur chemistry to the seasonal variability of sulfate aerosol size distributions (Linia Tashmim, UC Riverside)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1XcqEQEv6Zb5SqE0c8hnsYWu3pP9CZgks/view?usp=share_link">Increasing influence of Canada anthropogenic SO2 emission and the Great Lakes Region shipment SO2 emission on ultrafine particle number concentrations in New York State</a> (Gan Luo, SUNY Albany)
+  </li>
+</ul>
 
-	<ul><li>
-			<a href="https://drive.google.com/file/d/11D60TDLzWMsVTpouJNpfxp28Lfa_76nQ/view?usp=share_link">Methane emissions from China: a high-resolution inversion of TROPOMI satellite observations</a> (Zichong Chen, Harvard)
-		</li>
-		<li>
-			Improving CO2 flux estimates by mitigating biases online in the CO2 assimilation (Feng Deng, U. Toronto)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/151PN5SJ4xhHyIzGdigIdI0RNZPAidXj5/view?usp=share_link">High-resolution 2019 North American methane emissions inferred from TROPOMI satellite observations of atmospheric methane</a> (Hannah Nesser, Harvard)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1U0QElXBolHSHi6tlOOAoXxCBBLMjvbeH/view?usp=share_link">Inferring methane emissions and OH concentrations using AIRS + GOSAT satellite observations of methane</a> (Elise Penn, Harvard)
-		</li>
-		<li>
-			Constraining global methane fluxes based on TROPOMI measurements (Xueying Yu, U. Minnesota)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1uuvUIvopwNZ5fgi1J3RaH0pSBlZ-qPdn/view?usp=share_link">Attribution of the surge of global methane in 2020 using inverse analysis of GOSAT observations</a> (Zhen Qu, Harvard)
-		</li>
-	</ul><strong><a name="chemistryII" id="chemistryII"></a>Chemistry II (chair: Pam Wales, NASA GSFC)</strong>
+<a name="tuesday_posters" id="tuesday_posters"></a><strong>Posters</strong>
 
-	<ul><li>
-			<a href="https://drive.google.com/file/d/1IqFxkKULCw-9ppc7C06Zo5vw-eHHAAmX/view?usp=share_link">KEYNOTE: Looking for chemical gradients to challenge atmospheric models</a> (Jim Crawford, NASA LaRC)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1ELvOJ_CiWYAT1i3F4xLbCHsz4dZxFZTm/view?usp=share_link">Global vertical profiles of NO2 from cloud-slicing satellite observations of total NO2 columns</a> (Bex Horner, U. College London)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1J_X-QyCyRA5-xV93lRkfARZB7TfJz4B9/view?usp=share_link">Addressing model uncertainties in upper tropospheric NOx</a> (Robert Ryan, U. College London)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1EFbrd7ha1rF4J24frtZqlCLp1bWXGwmp/view?usp=share_link">Global VOC measurements from CrIS</a> (Kelley Wells, U. Minnesota)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1d7BPDs85u3Ak6W3Tp-gijQ2oL8V0kgvP/view?usp=share_link">Vertical distribution of NO2 over the US and the global oceans: Implications for the satellite NO2 measurements and tropospheric background ozone</a> (Viral Shah, Harvard)
-		</li>
-		<li>
-			Resolution-dependent bias in GEOS-Chem predicted urban nitrogen oxides spreads to regional scale (Chi Li, WashU)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1tsO8Svi-TJou6hiDCMllo_Ac_k3GmmnW/view?usp=share_link">The impact of Pyrocumulonimbus on atmospheric composition in UTLS</a> (Xi Chen, U. Iowa)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1zz7Tio16vuPTC9_G_3KhNYEuGkTNqZ1N/view?usp=share_link">Quantifying the potential of TEMPO satellite HCHO retrievals on constraining Fire VOC emissions at hourly resolution</a> (Sree Chaliyakunnel, U. Montana)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1LMeTVKbN8U_TXpv-H5XgW5NaopfzUEaD/view?usp=share_link">Global Emissions of Hydrogen Chloride and Particulate Chloride from Continental Sources</a> (Bingqing Zhang, Georgia Tech)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1dthPgzIxJvHRNSz7NPMnerUuhrCkv1Lz/view?usp=share_link">Evaluating GEOS-Chem model performance using a cluster-based characterization of multi-dimensional lidar tropospheric ozone measurements in coastal regions</a> (Claudia Bernier, U. Houston)
-		</li>
-	</ul><a name="wednesday_posters" id="wednesday_posters"></a><strong>Posters</strong>
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1RbDEylLWAZwcijpM4F01uUir3TQ-0pKY/view?usp=share_link">Anthropogenic Sources of Methanol and Ethanol in East Asia</a> (Ellie Beaudry, Harvard)
+  </li>
+  <li>
+    Modeling atmospheric production of perchlorate (Yuk Chun Chan, U. Washington)
+  </li>
+  <li>
+    Reactive carbon over Europe with constraints from a Zeppelin study (Xin Chen, MIT)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Lo0lRScHXqnT1sdCzXRBnDLhYaNYcFZ6/view?usp=share_link">Atmospheric Chemistry, Carbon Cycle and Climate (AC4) Program</a> (Shibajyoti Das, NOAA)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1569soVA060W-2DaUW07rKPUp_QFL89Gx/view?usp=share_link">Retrievals of peroxyacetyl nitrate (PAN) from FTIR ground-based solar spectra, comparison with GEOS-Chem and satellite data</a> (Irene Pardo Cantos, U. Liege)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1vFIILKK7ghRfFq_LlTVU1lkEoyi7O14z/view?usp=share_link">Modelling the primary production of molecular hydrogen (H2) from the photolysis of aldehydes and its implications on the H2 tropospheric budget</a> (Maria Paula Perez-Pena, UNSW Sydney)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1c_h713giU6x4UpHoQtipQCBoo6jOgkpF/view?usp=share_link">Contributions to Arctic reactive bromine from snowpack and blowing snow sources in 2015</a> (William Swanson, U. Alaska)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Cvq8lp-GHy1_F7Fjs4-yPIYGG4eTu_UZ/view?usp=share_link">Climatology of reactive nitrogen in the global upper troposphere deduced with recent and historical aircraft campaigns and GEOS-Chem</a> (Nana Wei, U. College London)
+  </li>
+  <li>
+    Assessing Atmospheric Oxidation in GEOS-Chem with CrIS Isoprene Measurements (Joshua Shutter, U. Minnesota)
+  </li>
+  <li>
+    Understanding sources of cloud condensation nuclei during summertime in Southeast US (Suqian Chu, SUNY Albany)
+  </li>
+  <li>
+    An assessment of the uncertainty in PM2.5 estimates and trends due to discontinuity in instruments and retrievals (Melanie Hammer, WashU)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1DKFoBnWM3FNcRcIwK9y4B9BUGCs2zHxG/view?usp=share_link">Evaluating GEOS-Chem simulations of secondary inorganic aerosols using a suite of aircraft campaigns</a> (Olivia Norman, MIT)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/15JnTif3MqO367DQhL8_W5Wc4LAfErP49/view?usp=share_link">Effects of Dust Non-sphericity on Atmospheric Modeling</a> (Inderjeet Singh, WashU)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1D1SStzJ13rRQTDrGKyZSxuJ2rPbzLNR7/view?usp=share_link">Implications of using MERRA-2 cloud water in aerosol wet scavenging for Pb-210 surface concentrations and vertical profiles in GEOS-Chem</a> (Bo Zhang, NASA LaRC)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/15pq6HwWbBXw3pSgLscZDuu_107ZxO1A-/view?usp=share_link">A scheme for representing aromatic secondary organic aerosols in chemical transport models: application to source attribution of organic aerosols over South Korea during the KORUS-AQ campaign</a> (Jared Brewer, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1g2WRGEVGWfH1vNsor6qnt3iXgByoeobz/view?usp=share_link">Application of High Spectral Resolution Lidar (HSRL)-based methods for estimating PM2.5 during KORUS-AQ campaign (Application of High Spectral Resolution Lidar (HSRL)-based methods for estimating PM2.5 during KORUS-AQ campaign</a> (Bethany Sutherland, North Carolina State U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1PceOb_5A6lZkijcV3wrqBOj2MxgagQ5c/view?usp=share_link">Smoke in the western United States: a comparison between satellite and airport observations</a> (Tianjia (Tina) Liu, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/19r0F2bwsRievhwPxDvPU22_9qfuEy5GH/view?usp=share_link">Quantifying the smoke aerosol mass injected into the stratosphere by pyrocumulonimbus activity</a> (Will Julstrom, U. Iowa)
+  </li>
+</ul>
 
-	<ul><li>
-			<a href="https://drive.google.com/file/d/1OwP7GNT5WQPCXj4APtdFmt0lvn4iRBWN/view?usp=share_link">Joint inversions of formaldehyde and isoprene to constrain global VOC emissions</a> (Jinkyul Choi, U. Colorado)
-		</li>
-		<li>
-			Evaluation and intercomparison of ozone dry deposition models (Christopher Holmes, FSU)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1xN__J_szbXWb5Ne4N8z8x-valjUvbHc2/view?usp=share_link">Simulating sea salt aerosol emissions from sea ice leads in the Arctic</a> (Hannah Horowitz, U. Illinois)
-		</li>
-		<li>
-			Comparison of NO2 GEMS satellite data and modeling in South Korea (Hyerim Kim, U. Iowa)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1667ZPrFKnHN16ieyLROPbjBnmmkHBovF/view?usp=share_link">Evaluating the potential for a direct marine source of NOx to the atmosphere within GEOS-Chem</a> (Matthew Loman, U. Rochester)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1INhkz9Ep2pPbRmFtibanZ5GSU1TFDoJ1/view?usp=share_link">Understand Soil NOx Emissions over Midwestern U.S.</a> (Qiyu Wang, U. Iowa)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1GgUuWVD1ovXnrAgvxB3ZFSDuxEtAGMfa/view?usp=share_link">Improvement of NEI emission inventory of PM2.5 and NOx through atmospheric modeling and ground-based and satellite observation</a> (Chengzhe Li, U. Iowa)
-		</li>
-		<li>
-			Combining VIIRS-retrieved Modified Combustion Efficiency and WRF-Chem model to Constrain CO emissions during the 2019 Williams Flats Fires (Weizhi Deng, U. Iowa)
-		</li>
-		<li>
-			Validation of methane modeling using multiple-platform observations (Yang Li, Baylor U.)
-		</li>
-		<li>
-			Evaluation of the stable isotopologue budget of methane within GEOS-Chem (Mingjian Shi, U. Rochester)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1wYqoAlsa0TIBsHEjENKYw0QUy_2R0sWc/view?usp=share_link">The role of chlorine in the global methane budget at and since the Last Glacial Maximum</a> (Xin Tie, U. Rochester)
-		</li>
-		<li>
-			Uncertainty in parameterized convection in chemical transport models remains a key bottleneck to reliably estimating surface fluxes of carbon dioxide (Andrew Schuh, CSU)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/19YNeA4f8RaG-b-75i-3t4I6DK5NXirAD/view?usp=share_link">Assimilation of NO2 – a comparison of multiple products and multiple models</a> (Barron Henderson, US EPA)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1xLQtofn3KSGe_rAPKxBBvrYB9LqzlkeI/view?usp=share_link">How well is ozone production during KORUS-AQ represented in models?</a> (Katherine Travis, NASA LaRC)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1NHhqOeoi6G6rLOojQFZV36c-IkC63fZi/view?usp=share_link">Impact of rocket launch and ablation air pollution on stratospheric ozone and global climate</a> (Eloise Marais, U. College London)
-		</li>
-		<li>
-			Impacts of aerosol radiation interaction on ozone photochemistry over the Indian subcontinent (Lakhima Chutia, U. Iowa)
-		</li>
-		<li>
-			Quantifying ocean-air VOC fluxes using aircraft measurements over the Western Subarctic Atlantic (Xin Chen, MIT)
-		</li>
-		<li>
-			Comparison of BTEX simulation and observation at Beijing and Seoul in winter and summer 2021 (Eunlak Choi, Ewha Womans University)
-		</li>
-	</ul></div>
+<h2>Wednesday, June 8</h2>
 
-<div>
-	<h2>
-		Thursday, June 9
-	</h2>
-	<a name="climate" id="climate"></a><strong>Chemistry-Ecosystem-Climate (chair: Chris Holmes, FSU)</strong>
+<a name="emissions" id="emissions"></a><strong>Emissions and surface fluxes (chair: Dylan Millet, U. Minnesota)</strong>
 
-	<ul><li>
-			<a href="https://drive.google.com/file/d/16napkU__Jtv9QRHBxB1wICqmPy9v1Zhq/view?usp=share_link">Brief Tutorial: WRF-GC(v2.0) online two-way coupling of WRF and GEOS-Chem for modelling regional atmospheric chemistry-meteorology interactions</a> (Xu Feng, Harvard)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1XgHjWRCQKB8dbfb1djjvgmzL6xrXzczP/view?usp=share_link">KEYNOTE: OMI, TROPOMI and ACOM and me</a> (Pieternel Levelt, NCAR)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1FWuEXuSmQBwigdlNp6LAtBZ9RMs6c65S/view?usp=share_link">Modelling the Impact of Amazon Land Use Changes on the Vegetation Sink of Atmospheric Mercury</a> (Ari Feinberg, MIT)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1jQb0YctEaS-IYJ9cnXe64mvf66FaV6Mz/view?usp=share_link"">Forecasted climate penalties and benefits to ozone and PM2.5 across the 21st century under different SSP scenarios</a> (Lee Murray, U. Rochester)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1zlA0umUNIxkm1WuewvdqJb9TGorsWqEL/view?usp=share_link">Black Carbon Radiative Impacts Reduced Form Modeling for Policy Scenarios</a> (Lyssa Freese, MIT)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1NXhkqh6YmgBnLow7m1bDLiRKpmgJ5Ruq/view?usp=share_link">Satellite-derived Constraints on the Effect of Drought Stress on Biogenic Isoprene Emissions in the Southeast US</a> (Wei Li, U. Houston)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1iNXzM2fIN0DEM9bezbBpKrZGT4t2yYLe/view?usp=share_link">Model-Measurement Comparison of the Biosphere-Atmosphere Exchange of Reactive Carbon over a Colorado Pine Forest</a> (Michael Vermeuel, U. Minnesota)
-		</li>
-	</ul><a name="model_dev" id="model_dev"></a><strong>Model developments (chair: Dylan Jones, U. Toronto)</strong>
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/12ty7_MsFFii0ZhClCvn7_kqRuCevs9nw/view?usp=share_link">Brief Tutorial: GCHP, stretched grid, and bash data catalog</a> (Liam Bindle, WashU)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1ZtQrQavACN01DeYCAmX1zXy7BbHvNdbT/view?usp=share_link">Constraining Long-Term NOx Emissions over the United States and Europe to Improve Simulations of Tropospheric Ozone</a> (Amy Christiansen, U. Montana)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1FQGi1wlIzvKxKwdlE6GAxZMrDaS9ZaZB/view?usp=share_link">Background NOx from aviation and fire emissions: implications for satellite NO2 observations</a> (Ruijun Dang, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Z9eegd3FVWugjgyi5rfifJVZqaGUJKXb/view?usp=share_link">Exploring Deposition Observations as a Constraint on Emissions in the United States</a> (Ishir Dutta, MIT)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1mGoofM14nMJ3p3IFrI8QBaxrF8SwLuGG/view?usp=share_link">Biogenic VOC emissions in the Arctic: knowns and unknowns </a>(Lu Hu, U. Montana)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1TgNZY6THYAfMlRZJXoOWJK3wBlJS0wZz/view?usp=share_link">Updating ethane and propane sources in GEOS-Chem</a> (Matthew Rowlinson, U. York)
+  </li>
+</ul>
 
-	<ul><li>
-			<a href="https://drive.google.com/file/d/1VmIqeA1c2QQ5VdJTUfc5vc4ykwSZSy1J/view?usp=share_link">Improvements in simulated transport through direct ingestion of mass flux data</a> (Sebastian Eastham, MIT)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1TnJzUf4SXvWgUtJHBfWyGcPU88ohxVjC/view?usp=share_link">GEOS-Chem-APM for physics-informed machine learning emulators and parameterizations</a> (Arshad Nair, SUNY Albany)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1JB3zZBlrDpL7axrrILa4rQXepOHxNPNM/view?usp=share_link">An Online-Learned Neural Network Chemical Solver for Stable Long-Term Global Simulations of Atmospheric Chemistry</a> (Makoto Kelp, Harvard)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1urx6EehSaiHt_K1Ymt7bQGB6Onj7yBjN/view?usp=share_link">An auto-reduction solver to speed up chemical kinetics calculations within GEOS-Chem</a> (Haipeng Lin, Harvard)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1zwUWiog5R2kRqODFx0lkuHAuqGeT-X_U/view?usp=share_link">Integrated Methane Inversion (IMI 1.0): A user-friendly, cloud-based facility for inferring high-resolution methane emissions from TROPOMI satellite observations</a> (Lucas Estrada, Harvard)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1jy7xUMRnl1_A-lJkYa9aEfEakMaeINqV/view?usp=share_link">Developing CHEEREIO: An open-source data assimilation tool for GEOS-Chem using an Ensemble Kalman Filter</a> (Drew Pendergrass, Harvard)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1H-2gpCNhoxp0UV4gHBH7nU7Eqa1Kjzw1/view?usp=share_link">Developing and coupling a plume model into GEOS-Chem to resolve sub-grid plumes in the stratosphere</a> (Hongwei Sun, Harvard)
-		</li>
-	</ul><a name="air_quality" id="air_quality"></a><strong>Air quality (chair: Yuxuan Wang, U. Houston)</strong>
+<a name="carbon" id="carbon"></a><strong>Carbon gases (chair: Seb Eastham, MIT)</strong>
 
-	<ul><li>
-			<a href="https://drive.google.com/file/d/15RbirpNPG9NHaeCAEW2436DDzxLB1Dyt/view?usp=share_link">Brief Tutorial: GISS-GC</a> (Lee Murray, U. Rochester)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1qlnEEbsT_ZH_KVukbX_VU66lxDWN_ePg/view?usp=share_link">Understanding Drivers of Recent Ozone Trends in Seoul</a> (Nadia Colombi, Harvard)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1Rs7tLitKP76dOVeYO55Ws5CF49rkwp8c/view?usp=share_link">Advances in simulating the spatial heterogeneity of air quality and source contributions using GCHP</a> (Dandan Zhang, WashU)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1-taOePY8Uo0jKDSvWgV8i9Q1UxHgOi1B/view?usp=share_link">Modelling UK Air Pollution</a> (Luke Fakes, U. York)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1lx9GG3-Oviu7Rzmwe91jeeW9zC_VI53-/view?usp=share_link">Source Contributions to Fine Particulate Matter and Attributable Mortality in India and the Surrounding Region</a> (Deepangsu Chatterjee, WashU)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1CWPxt0smJT2CMjRM7_MBMSk1mGkHHg1p/view?usp=share_link">Sources of PM2.5 associated health risks in Europe and corresponding changes affected by the emission changes during 2005-2015</a> (Yixuan Gu, U. Colorado Boulder)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1BuPEK8AJ7egidACwbWHRIsvil6A8ZdUK/view?usp=share_link">Improving surface PM2.5 forecasts in the US using an ensemble of chemical transport models: bias correction with satellite data for rural areas</a> (Huanxin Zhang, U. Iowa)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1egnXWs3XI9gu7WdL92PyjQkNa9Nv8VTS/view?usp=share_link">Leveraging satellite-derived data in GEOS-Chem adjoint simulations to characterize the sources of PM2.5-, O3-, and NO2-related health impacts at multiple spatial scales</a> (Omar Nawaz, U. Colorado)
-		</li>
-		<li>
-			Modeling diel PM2.5 mass variations over the US using GEOS-Chem (Yanshun Li, WashU)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1sU9LLWpfEUzDCwUhhTReTEodJzEiUdwD/view?usp=share_link">Health impact of air pollution linked to oil and gas supply chain in Texas</a> (Karn Vohra, U. College London)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1faAs8xK_IRLjrM92GGaCGdksoTCKgf8O/view?usp=share_link">Evaluation of GEOS-Chem Africa nested grid simulations using a novel surface PM2.5 dataset</a> (Dan Westervelt, Columbia U.)
-		</li>
-	</ul><a name="thursday_posters" id="thursday_posters"></a><strong>Posters</strong>
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/11D60TDLzWMsVTpouJNpfxp28Lfa_76nQ/view?usp=share_link">Methane emissions from China: a high-resolution inversion of TROPOMI satellite observations</a> (Zichong Chen, Harvard)
+  </li>
+  <li>
+    Improving CO2 flux estimates by mitigating biases online in the CO2 assimilation (Feng Deng, U. Toronto)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/151PN5SJ4xhHyIzGdigIdI0RNZPAidXj5/view?usp=share_link">High-resolution 2019 North American methane emissions inferred from TROPOMI satellite observations of atmospheric methane</a> (Hannah Nesser, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1U0QElXBolHSHi6tlOOAoXxCBBLMjvbeH/view?usp=share_link">Inferring methane emissions and OH concentrations using AIRS + GOSAT satellite observations of methane</a> (Elise Penn, Harvard)
+  </li>
+  <li>
+    Constraining global methane fluxes based on TROPOMI measurements (Xueying Yu, U. Minnesota)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1uuvUIvopwNZ5fgi1J3RaH0pSBlZ-qPdn/view?usp=share_link">Attribution of the surge of global methane in 2020 using inverse analysis of GOSAT observations</a> (Zhen Qu, Harvard)
+  </li>
+</ul><strong><a name="chemistryII" id="chemistryII"></a>Chemistry II (chair: Pam Wales, NASA GSFC)</strong>
 
-	<ul><li>
-			<a href="https://drive.google.com/file/d/1dR8HTMV25S8CUypj_3NnLVAkHANu9Iat/view?usp=share_link">Radiative forcing during wildfire over the Arctic Region</a> (Kunal Bali, U. Alaska)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1Tazps7JcmmJwgm3ntPYOUZ3iMV1kXwC1/view?usp=share_link">Earth’s Radiation Budget (ERB) Program 101</a> (Victoria Breeze, NOAA)
-		</li>
-		<li>
-			Impact of Global Climate and Land Use Change on Soil Reactive Nitrogen Emissions (Jeffrey Geddes, Boston U.)
-		</li>
-		<li>
-			Underestimated passive volcanic degassing implies overestimated aerosol forcing (Ursula Jongebloed, U. Washington)
-		</li>
-		<li>
-			Impacts of marine aerosols on chemistry and climate over the Benguela upwelling zone (Mashiat Hossain, U. Illinois at Urbana-Champaign)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1AwsUJpb6S_rLRYYNU9p1Wrsfxm0uYFU6/view?usp=share_link">Development of a GCHP-EnKF chemical data assimilation system</a> (Kazuyuki Miyazaki, NASA JPL)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1NipoyGYJzZpreYVExqoeSAOwxabcidu3/view?usp=share_link">Demonstration of Satellite-Chemical Transport Model Framework to Estimate Near-Real-Time PM Composition</a> (Tessa Clarizio, U. Illinois)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1o7fiI9dA6e9CUyLz8T7pIrM4SVHvGfO4/view?usp=share_link">Fire Light Detection Algorithm-2 (FILDA2): A New Dataset for Numerical Modeling of Wildfire</a> (Meng Zhou, U. Iowa)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1RRgaZ3hLXIo4KoEvbhjgU8FVo572Wtzy/view?usp=share_link">Tropospheric Mean Age in GEOS-Replay</a> (Clara Orbe, NASA GISS)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1c5DGYjFhVWhgM2PWqMbMXchrQLlif-i-/view?usp=share_link">The development of a machine learning chemistry emulation package for use with GEOS-Chem</a> (Peter Ivatt, U. Maryland)
-		</li>
-		<li>
-			Quantifying Unreported NO2 Hotspots in the Southern United States (Tabitha Lee, U. Houston)
-		</li>
-		<li>
-			Modeling analysis of TRACER-AQ observations (Xueying Liu, U. Houston)
-		</li>
-		<li>
-			Assessment of fuels and emissions in a prescribed fire landscape: case studies at Blackwater River State Forest and sugarcane burning at the Everglades Agricultural Area in Florida (Holly Nowell, FSU)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1MDs-uRDaQqbu7sJ5gfVQ1OBjUn3vuOBz/view?usp=share_link">Applying Machine Learning to Improve the GEOS-Chem-based AOD-PM2.5 Relationship</a> (Siyuan Shen, WashU)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1t7Jal1SoGfNdy8blJpBuiKgD8sIbpp5_/view?usp=share_link">Transport analysis of passive tracers during Black and Brown Carbon Monitoring Campaign: A Case Study in Houston and El Paso</a> (Ehsan Soleimanian, U. Houston)
-		</li>
-		<li>
-			Exploring trends of regional and global NH3 concentrations and emissions using satellite remote sensing measurements (Hansen Cao, CU Boulder)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1w9sdthQJW5UXpaNBeByMMN35u-Au8-HV/view?usp=share_link">Comparing one-year simulations of surface PM2.5 and Ozone in Western US between GEOS-Chem v13.3.4 and CAM-Chem at the month and sub-regional scales</a> (Yuyan Cui, CARB)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1sCvRaGIcvlJorIPq804ADe5oeZQFxiyS/view?usp=share_link">How to focus your transport model at the surface and gain a factor of 3 finer resolution for the same computational cost</a> (David Baker, CIRA/CSU)
-		</li>
-	</ul></div>
+<ul><li>
+    <a href="https://drive.google.com/file/d/1IqFxkKULCw-9ppc7C06Zo5vw-eHHAAmX/view?usp=share_link">KEYNOTE: Looking for chemical gradients to challenge atmospheric models</a> (Jim Crawford, NASA LaRC)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1ELvOJ_CiWYAT1i3F4xLbCHsz4dZxFZTm/view?usp=share_link">Global vertical profiles of NO2 from cloud-slicing satellite observations of total NO2 columns</a> (Bex Horner, U. College London)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1J_X-QyCyRA5-xV93lRkfARZB7TfJz4B9/view?usp=share_link">Addressing model uncertainties in upper tropospheric NOx</a> (Robert Ryan, U. College London)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1EFbrd7ha1rF4J24frtZqlCLp1bWXGwmp/view?usp=share_link">Global VOC measurements from CrIS</a> (Kelley Wells, U. Minnesota)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1d7BPDs85u3Ak6W3Tp-gijQ2oL8V0kgvP/view?usp=share_link">Vertical distribution of NO2 over the US and the global oceans: Implications for the satellite NO2 measurements and tropospheric background ozone</a> (Viral Shah, Harvard)
+  </li>
+  <li>
+    Resolution-dependent bias in GEOS-Chem predicted urban nitrogen oxides spreads to regional scale (Chi Li, WashU)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1tsO8Svi-TJou6hiDCMllo_Ac_k3GmmnW/view?usp=share_link">The impact of Pyrocumulonimbus on atmospheric composition in UTLS</a> (Xi Chen, U. Iowa)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1zz7Tio16vuPTC9_G_3KhNYEuGkTNqZ1N/view?usp=share_link">Quantifying the potential of TEMPO satellite HCHO retrievals on constraining Fire VOC emissions at hourly resolution</a> (Sree Chaliyakunnel, U. Montana)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1LMeTVKbN8U_TXpv-H5XgW5NaopfzUEaD/view?usp=share_link">Global Emissions of Hydrogen Chloride and Particulate Chloride from Continental Sources</a> (Bingqing Zhang, Georgia Tech)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1dthPgzIxJvHRNSz7NPMnerUuhrCkv1Lz/view?usp=share_link">Evaluating GEOS-Chem model performance using a cluster-based characterization of multi-dimensional lidar tropospheric ozone measurements in coastal regions</a> (Claudia Bernier, U. Houston)
+  </li>
+</ul>
 
-<div>
-	<h2>
-		Friday, June 10
-	</h2>
-	<a name="fires" id="fires"></a><strong>Fires (chair: Barron Henderson, US EPA)</strong>
+<a name="wednesday_posters" id="wednesday_posters"></a><strong>Posters</strong>
 
-	<ul><li>
-			<a href="https://drive.google.com/file/d/1aUc9IYGlYg7cEuTegOQDHq7J7fAoQoOp/view?usp=share_link">Brief Tutorial: Nested GEOS-Chem</a> (Yuxuan Wang, U. Houston)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1Jj5e_SFCNt4ToF2j9Fw_dLIXTRDz7JkC/view?usp=share_link">Towards an Improved Representation of Fire Non-Methane Organic Gases (NMOGs): Emissions to Reactivity</a> (Tess Carter, MIT)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1NHbXYO3WoJk_SrB7ZwqrYo9FZrSjvGOf/view?usp=share_link">Evidence Of Large Prescribed Fire Emissions In The Eastern United States</a> (Charley Fite, FSU)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/11VA7dELcOM949ZsCzgGBaYlbhqFBPuY-/view?usp=share_link">Long-term AOD-PM2.5 Relationship in Alaska during Summer Fire Season</a> (Tianlang Zhao, U. Alaska)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1FwtqtZA72qSSzFf6lnMkOdv6wr6EibpG/view?usp=share_link">Constraining emissions of volatile organic compounds from western US wildfires with WE-CAN and FIREX-AQ airborne observations</a> (Lixu Jin, U. Montana)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1nAGtlcY-HG4DvlJBpXiRmgsvZ-uamlKN/view?usp=share_link">Evaluations of Alaskan summer PM2.5 with GEOS-Chem</a> (Zhiwei Dong, U. Alaska)
-		</li>
-	</ul><a name="community" id="community"></a><strong>GEOS-Chem &amp; Community (chair: Randall Martin, WashU)</strong>
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1OwP7GNT5WQPCXj4APtdFmt0lvn4iRBWN/view?usp=share_link">Joint inversions of formaldehyde and isoprene to constrain global VOC emissions</a> (Jinkyul Choi, U. Colorado)
+  </li>
+  <li>
+    Evaluation and intercomparison of ozone dry deposition models (Christopher Holmes, FSU)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1xN__J_szbXWb5Ne4N8z8x-valjUvbHc2/view?usp=share_link">Simulating sea salt aerosol emissions from sea ice leads in the Arctic</a> (Hannah Horowitz, U. Illinois)
+  </li>
+  <li>
+    Comparison of NO2 GEMS satellite data and modeling in South Korea (Hyerim Kim, U. Iowa)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1667ZPrFKnHN16ieyLROPbjBnmmkHBovF/view?usp=share_link">Evaluating the potential for a direct marine source of NOx to the atmosphere within GEOS-Chem</a> (Matthew Loman, U. Rochester)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1INhkz9Ep2pPbRmFtibanZ5GSU1TFDoJ1/view?usp=share_link">Understand Soil NOx Emissions over Midwestern U.S.</a> (Qiyu Wang, U. Iowa)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1GgUuWVD1ovXnrAgvxB3ZFSDuxEtAGMfa/view?usp=share_link">Improvement of NEI emission inventory of PM2.5 and NOx through atmospheric modeling and ground-based and satellite observation</a> (Chengzhe Li, U. Iowa)
+  </li>
+  <li>
+    Combining VIIRS-retrieved Modified Combustion Efficiency and WRF-Chem model to Constrain CO emissions during the 2019 Williams Flats Fires (Weizhi Deng, U. Iowa)
+  </li>
+  <li>
+    Validation of methane modeling using multiple-platform observations (Yang Li, Baylor U.)
+  </li>
+  <li>
+    Evaluation of the stable isotopologue budget of methane within GEOS-Chem (Mingjian Shi, U. Rochester)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1wYqoAlsa0TIBsHEjENKYw0QUy_2R0sWc/view?usp=share_link">The role of chlorine in the global methane budget at and since the Last Glacial Maximum</a> (Xin Tie, U. Rochester)
+  </li>
+  <li>
+    Uncertainty in parameterized convection in chemical transport models remains a key bottleneck to reliably estimating surface fluxes of carbon dioxide (Andrew Schuh, CSU)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/19YNeA4f8RaG-b-75i-3t4I6DK5NXirAD/view?usp=share_link">Assimilation of NO2 – a comparison of multiple products and multiple models</a> (Barron Henderson, US EPA)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1xLQtofn3KSGe_rAPKxBBvrYB9LqzlkeI/view?usp=share_link">How well is ozone production during KORUS-AQ represented in models?</a> (Katherine Travis, NASA LaRC)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1NHhqOeoi6G6rLOojQFZV36c-IkC63fZi/view?usp=share_link">Impact of rocket launch and ablation air pollution on stratospheric ozone and global climate</a> (Eloise Marais, U. College London)
+  </li>
+  <li>
+    Impacts of aerosol radiation interaction on ozone photochemistry over the Indian subcontinent (Lakhima Chutia, U. Iowa)
+  </li>
+  <li>
+    Quantifying ocean-air VOC fluxes using aircraft measurements over the Western Subarctic Atlantic (Xin Chen, MIT)
+  </li>
+  <li>
+    Comparison of BTEX simulation and observation at Beijing and Seoul in winter and summer 2021 (Eunlak Choi, Ewha Womans University)
+  </li>
+</ul>
 
-	<ul><li>
-			<a href="https://drive.google.com/file/d/1sIrOjqlGR1oPCBYev3w6omQXlDDjFJz7/view?usp=share_link">KEYNOTE: 25 years of GEOS-Chem</a> (Daniel Jacob, Harvard)
-		</li>
-		<li>
-			Open discussion on model development priorities, Working Group concerns, and other GEOS-Chem topics (Randall Martin, WashU, discussion lead)
-		</li>
-	</ul></div>
+<h2>Thursday, June 9</h2>
+
+<a name="climate" id="climate"></a><strong>Chemistry-Ecosystem-Climate (chair: Chris Holmes, FSU)</strong>
+
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/16napkU__Jtv9QRHBxB1wICqmPy9v1Zhq/view?usp=share_link">Brief Tutorial: WRF-GC(v2.0) online two-way coupling of WRF and GEOS-Chem for modelling regional atmospheric chemistry-meteorology interactions</a> (Xu Feng, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1XgHjWRCQKB8dbfb1djjvgmzL6xrXzczP/view?usp=share_link">KEYNOTE: OMI, TROPOMI and ACOM and me</a> (Pieternel Levelt, NCAR)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1FWuEXuSmQBwigdlNp6LAtBZ9RMs6c65S/view?usp=share_link">Modelling the Impact of Amazon Land Use Changes on the Vegetation Sink of Atmospheric Mercury</a> (Ari Feinberg, MIT)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1jQb0YctEaS-IYJ9cnXe64mvf66FaV6Mz/view?usp=share_link">Forecasted climate penalties and benefits to ozone and PM2.5 across the 21st century under different SSP scenarios</a> (Lee Murray, U. Rochester)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1zlA0umUNIxkm1WuewvdqJb9TGorsWqEL/view?usp=share_link">Black Carbon Radiative Impacts Reduced Form Modeling for Policy Scenarios</a> (Lyssa Freese, MIT)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1NXhkqh6YmgBnLow7m1bDLiRKpmgJ5Ruq/view?usp=share_link">Satellite-derived Constraints on the Effect of Drought Stress on Biogenic Isoprene Emissions in the Southeast US</a> (Wei Li, U. Houston)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1iNXzM2fIN0DEM9bezbBpKrZGT4t2yYLe/view?usp=share_link">Model-Measurement Comparison of the Biosphere-Atmosphere Exchange of Reactive Carbon over a Colorado Pine Forest</a> (Michael Vermeuel, U. Minnesota)
+  </li>
+</ul>
+
+<a name="model_dev" id="model_dev"></a><strong>Model developments (chair: Dylan Jones, U. Toronto)</strong>
+
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1VmIqeA1c2QQ5VdJTUfc5vc4ykwSZSy1J/view?usp=share_link">Improvements in simulated transport through direct ingestion of mass flux data</a> (Sebastian Eastham, MIT)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1TnJzUf4SXvWgUtJHBfWyGcPU88ohxVjC/view?usp=share_link">GEOS-Chem-APM for physics-informed machine learning emulators and parameterizations</a> (Arshad Nair, SUNY Albany)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1JB3zZBlrDpL7axrrILa4rQXepOHxNPNM/view?usp=share_link">An Online-Learned Neural Network Chemical Solver for Stable Long-Term Global Simulations of Atmospheric Chemistry</a> (Makoto Kelp, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1urx6EehSaiHt_K1Ymt7bQGB6Onj7yBjN/view?usp=share_link">An auto-reduction solver to speed up chemical kinetics calculations within GEOS-Chem</a> (Haipeng Lin, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1zwUWiog5R2kRqODFx0lkuHAuqGeT-X_U/view?usp=share_link">Integrated Methane Inversion (IMI 1.0): A user-friendly, cloud-based facility for inferring high-resolution methane emissions from TROPOMI satellite observations</a> (Lucas Estrada, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1jy7xUMRnl1_A-lJkYa9aEfEakMaeINqV/view?usp=share_link">Developing CHEEREIO: An open-source data assimilation tool for GEOS-Chem using an Ensemble Kalman Filter</a> (Drew Pendergrass, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1H-2gpCNhoxp0UV4gHBH7nU7Eqa1Kjzw1/view?usp=share_link">Developing and coupling a plume model into GEOS-Chem to resolve sub-grid plumes in the stratosphere</a> (Hongwei Sun, Harvard)
+  </li>
+</ul>
+
+<a name="air_quality" id="air_quality"></a><strong>Air quality (chair: Yuxuan Wang, U. Houston)</strong>
+
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/15RbirpNPG9NHaeCAEW2436DDzxLB1Dyt/view?usp=share_link">Brief Tutorial: GISS-GC</a> (Lee Murray, U. Rochester)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1qlnEEbsT_ZH_KVukbX_VU66lxDWN_ePg/view?usp=share_link">Understanding Drivers of Recent Ozone Trends in Seoul</a> (Nadia Colombi, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Rs7tLitKP76dOVeYO55Ws5CF49rkwp8c/view?usp=share_link">Advances in simulating the spatial heterogeneity of air quality and source contributions using GCHP</a> (Dandan Zhang, WashU)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1-taOePY8Uo0jKDSvWgV8i9Q1UxHgOi1B/view?usp=share_link">Modelling UK Air Pollution</a> (Luke Fakes, U. York)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1lx9GG3-Oviu7Rzmwe91jeeW9zC_VI53-/view?usp=share_link">Source Contributions to Fine Particulate Matter and Attributable Mortality in India and the Surrounding Region</a> (Deepangsu Chatterjee, WashU)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1CWPxt0smJT2CMjRM7_MBMSk1mGkHHg1p/view?usp=share_link">Sources of PM2.5 associated health risks in Europe and corresponding changes affected by the emission changes during 2005-2015</a> (Yixuan Gu, U. Colorado Boulder)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1BuPEK8AJ7egidACwbWHRIsvil6A8ZdUK/view?usp=share_link">Improving surface PM2.5 forecasts in the US using an ensemble of chemical transport models: bias correction with satellite data for rural areas</a> (Huanxin Zhang, U. Iowa)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1egnXWs3XI9gu7WdL92PyjQkNa9Nv8VTS/view?usp=share_link">Leveraging satellite-derived data in GEOS-Chem adjoint simulations to characterize the sources of PM2.5-, O3-, and NO2-related health impacts at multiple spatial scales</a> (Omar Nawaz, U. Colorado)
+  </li>
+  <li>
+    Modeling diel PM2.5 mass variations over the US using GEOS-Chem (Yanshun Li, WashU)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1sU9LLWpfEUzDCwUhhTReTEodJzEiUdwD/view?usp=share_link">Health impact of air pollution linked to oil and gas supply chain in Texas</a> (Karn Vohra, U. College London)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1faAs8xK_IRLjrM92GGaCGdksoTCKgf8O/view?usp=share_link">Evaluation of GEOS-Chem Africa nested grid simulations using a novel surface PM2.5 dataset</a> (Dan Westervelt, Columbia U.)
+  </li>
+</ul>
+
+<a name="thursday_posters" id="thursday_posters"></a><strong>Posters</strong>
+
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1dR8HTMV25S8CUypj_3NnLVAkHANu9Iat/view?usp=share_link">Radiative forcing during wildfire over the Arctic Region</a> (Kunal Bali, U. Alaska)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Tazps7JcmmJwgm3ntPYOUZ3iMV1kXwC1/view?usp=share_link">Earth’s Radiation Budget (ERB) Program 101</a> (Victoria Breeze, NOAA)
+  </li>
+  <li>
+    Impact of Global Climate and Land Use Change on Soil Reactive Nitrogen Emissions (Jeffrey Geddes, Boston U.)
+  </li>
+  <li>
+    Underestimated passive volcanic degassing implies overestimated aerosol forcing (Ursula Jongebloed, U. Washington)
+  </li>
+  <li>
+    Impacts of marine aerosols on chemistry and climate over the Benguela upwelling zone (Mashiat Hossain, U. Illinois at Urbana-Champaign)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1AwsUJpb6S_rLRYYNU9p1Wrsfxm0uYFU6/view?usp=share_link">Development of a GCHP-EnKF chemical data assimilation system</a> (Kazuyuki Miyazaki, NASA JPL)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1NipoyGYJzZpreYVExqoeSAOwxabcidu3/view?usp=share_link">Demonstration of Satellite-Chemical Transport Model Framework to Estimate Near-Real-Time PM Composition</a> (Tessa Clarizio, U. Illinois)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1o7fiI9dA6e9CUyLz8T7pIrM4SVHvGfO4/view?usp=share_link">Fire Light Detection Algorithm-2 (FILDA2): A New Dataset for Numerical Modeling of Wildfire</a> (Meng Zhou, U. Iowa)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1RRgaZ3hLXIo4KoEvbhjgU8FVo572Wtzy/view?usp=share_link">Tropospheric Mean Age in GEOS-Replay</a> (Clara Orbe, NASA GISS)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1c5DGYjFhVWhgM2PWqMbMXchrQLlif-i-/view?usp=share_link">The development of a machine learning chemistry emulation package for use with GEOS-Chem</a> (Peter Ivatt, U. Maryland)
+  </li>
+  <li>
+    Quantifying Unreported NO2 Hotspots in the Southern United States (Tabitha Lee, U. Houston)
+  </li>
+  <li>
+    Modeling analysis of TRACER-AQ observations (Xueying Liu, U. Houston)
+  </li>
+  <li>
+    Assessment of fuels and emissions in a prescribed fire landscape: case studies at Blackwater River State Forest and sugarcane burning at the Everglades Agricultural Area in Florida (Holly Nowell, FSU)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1MDs-uRDaQqbu7sJ5gfVQ1OBjUn3vuOBz/view?usp=share_link">Applying Machine Learning to Improve the GEOS-Chem-based AOD-PM2.5 Relationship</a> (Siyuan Shen, WashU)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1t7Jal1SoGfNdy8blJpBuiKgD8sIbpp5_/view?usp=share_link">Transport analysis of passive tracers during Black and Brown Carbon Monitoring Campaign: A Case Study in Houston and El Paso</a> (Ehsan Soleimanian, U. Houston)
+  </li>
+  <li>
+    Exploring trends of regional and global NH3 concentrations and emissions using satellite remote sensing measurements (Hansen Cao, CU Boulder)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1w9sdthQJW5UXpaNBeByMMN35u-Au8-HV/view?usp=share_link">Comparing one-year simulations of surface PM2.5 and Ozone in Western US between GEOS-Chem v13.3.4 and CAM-Chem at the month and sub-regional scales</a> (Yuyan Cui, CARB)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1sCvRaGIcvlJorIPq804ADe5oeZQFxiyS/view?usp=share_link">How to focus your transport model at the surface and gain a factor of 3 finer resolution for the same computational cost</a> (David Baker, CIRA/CSU)
+  </li>
+</ul>
+
+<h2>Friday, June 10</h2>
+
+<a name="fires" id="fires"></a><strong>Fires (chair: Barron Henderson, US EPA)</strong>
+
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1aUc9IYGlYg7cEuTegOQDHq7J7fAoQoOp/view?usp=share_link">Brief Tutorial: Nested GEOS-Chem</a> (Yuxuan Wang, U. Houston)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Jj5e_SFCNt4ToF2j9Fw_dLIXTRDz7JkC/view?usp=share_link">Towards an Improved Representation of Fire Non-Methane Organic Gases (NMOGs): Emissions to Reactivity</a> (Tess Carter, MIT)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1NHbXYO3WoJk_SrB7ZwqrYo9FZrSjvGOf/view?usp=share_link">Evidence Of Large Prescribed Fire Emissions In The Eastern United States</a> (Charley Fite, FSU)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/11VA7dELcOM949ZsCzgGBaYlbhqFBPuY-/view?usp=share_link">Long-term AOD-PM2.5 Relationship in Alaska during Summer Fire Season</a> (Tianlang Zhao, U. Alaska)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1FwtqtZA72qSSzFf6lnMkOdv6wr6EibpG/view?usp=share_link">Constraining emissions of volatile organic compounds from western US wildfires with WE-CAN and FIREX-AQ airborne observations</a> (Lixu Jin, U. Montana)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1nAGtlcY-HG4DvlJBpXiRmgsvZ-uamlKN/view?usp=share_link">Evaluations of Alaskan summer PM2.5 with GEOS-Chem</a> (Zhiwei Dong, U. Alaska)
+  </li>
+</ul>
+
+<a name="community" id="community"></a><strong>GEOS-Chem &amp; Community (chair: Randall Martin, WashU)</strong>
+
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1sIrOjqlGR1oPCBYev3w6omQXlDDjFJz7/view?usp=share_link">KEYNOTE: 25 years of GEOS-Chem</a> (Daniel Jacob, Harvard)
+  </li>
+  <li>
+    Open discussion on model development priorities, Working Group concerns, and other GEOS-Chem topics (Randall Martin, WashU, discussion lead)
+  </li>
+</ul>
 
 </div>
 </div>
@@ -604,64 +609,16 @@ The 10th International GEOS-Chem Meeting (IGC10) June 6-10, 2022
 </div>
 </div>
 
-<!--footer region beg-->
+<!--footer-->
 <footer id="footer" class="clearfix" role="contentinfo">
-
-<!-- Three column 3x33 Gpanel -->
-<div class="at-panel gpanel panel-display footer clearfix">
-<div class="region region-footer">
-<div class="region-inner clearfix">
-<div id="block-boxes-1617037690" class="block block-boxes block-boxes-os_boxes_html no-title"  module="boxes" delta="1617037690">
-<div class="block-inner clearfix">  
-<div class="block-content content" ng-non-bindable="">  
-<div id='boxes-box-1617037690' class='boxes-box'>  
 <div class="boxes-box-content">
   <p style="text-align:center">
-    Copyright © 2023 by the International GEOS-Chem Community. All rights reserved.
+    Copyright © 2026 by the International GEOS-Chem Community. All rights reserved.
   </p>
 </div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-<div class="region region-footer-bottom">  
-<div class="region-inner clearfix">  
-<div id="block-boxes-1616879798" class="block block-boxes block-boxes-os_boxes_media no-title"  module="boxes" delta="1616879798">  
-<div class="block-inner clearfix">  
-<div class="block-content content"> 
-<div id='boxes-box-1616879798' class='boxes-box'> 
-<div class="boxes-box-content"> 
-<div id="file-3900146" class="file file-html file-html-embed">
-<h2 class="element-invisible"><a href="">css-brand</a></h2>
-<div class="content">
-<div class="file-info">
-</div>
-<div class="field field-name-field-html-code field-type-text-long field-label-hidden view-mode-full">
-<div class="field-items">
-<div class="field-item even">
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-
-<!--footer region end-->
 </footer>
-</div>
-</div>
 
-<!--page area ends-->
-<div id="extradiv"></div>
+</div>
 </div>
 
 </body>

--- a/igc10.html
+++ b/igc10.html
@@ -1,9 +1,4 @@
 <!DOCTYPE html>
-<!--[if IEMobile 7]><html class="iem7"  lang="en" dir="ltr"><![endif]-->
-<!--[if lte IE 6]><html class="lt-ie9 lt-ie8 lt-ie7"  lang="en" dir="ltr"><![endif]-->
-<!--[if (IE 7)&(!IEMobile)]><html class="lt-ie9 lt-ie8"  lang="en" dir="ltr"><![endif]-->
-<!--[if IE 8]><html class="lt-ie9"  lang="en" dir="ltr"><![endif]-->
-<!--[if (gte IE 9)|(gt IEMobile 7)]><!--><html  lang="en" dir="ltr"><!--<![endif]-->
 <head>
 <meta charset="utf-8" />
 <!--<base href="/igc10" />-->
@@ -18,23 +13,12 @@
 <title>The 10th International GEOS-Chem Meeting</title>
 <meta http-equiv="x-ua-compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<link type="text/css" rel="stylesheet" href="css/css_xE-rWrJf-fncB6ztZfd2huxqgxu4WO-qwma6Xer30m4%EF%B9%96m=1675397288.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_1kR8T1_c-l5pBT6ZwbDT7BFda-4fyqW9Jjum29_2IY8%EF%B9%96m=1675397312.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_YnlUIvHP13qgpYEqubzE8JyDwlSxUnVibfnVkSoSDb0%EF%B9%96m=1675397273.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_Ku-3OcT9qU9h7dnGig5e23q6EVryY8orK4wzVDxsweE%EF%B9%96m=1675397367.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_vprtFTrWyg23GbY50_zJZHWGYMNfS8vsrRS26i4-ISk%EF%B9%96m=1675397406.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_dW-aNNrctRhQNc-KECjtQd0PxuW-h19IEum-TX2MeEk%EF%B9%96m=1675397301.css" media="print" />
-<link type="text/css" rel="stylesheet" href="css/css_SH2Lx3Qprh0GZo_9xRp85U9NsWfkSXn_Bi-rJoMY1sw%EF%B9%96m=1675397273.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_uaIDKcYMUK5osSQXuirpr3ZleXtnnpBN-eiECm7N0M0%EF%B9%96m=1675397395.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/responsive.blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/geos-chem.css" media="all"/>
 <script type="text/javascript" src="dropdown-menu.js"></script>
-<!--[if lte IE 8]>
-<script type="text/javascript">
-  var os_c = document.createElement;os_c('header');os_c('nav');os_c('section');os_c('article');os_c('aside');os_c('footer');os_c('hgroup');os_c('figure');
-</script>
-<![endif]-->
 </head>
 
 <body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-1585687 node-type-page og-context og-context-node og-context-node-1585652 navbar-on">
@@ -45,7 +29,7 @@
 <div id="page_wrap" class="page_wrap">
 <div id="page" class="container page header-main content-top footer-none">
 <div id="page-wrapper">
-		
+
 <!--header regions beg-->
 <header id="header" class="clearfix" role="banner">
 <div id="header-container">
@@ -53,7 +37,7 @@
 <div class="region region-header-second">
 <div class="region-inner clearfix">
 <div id="block-boxes-1617807424" class="block block-boxes block-boxes-os_boxes_html no-title"  module="boxes" delta="1617807424">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <div class="block-content content" ng-non-bindable="">
 <div id='boxes-box-1617807424' class='boxes-box'>
 <div class="boxes-box-content">
@@ -76,15 +60,16 @@ The 10th International GEOS-Chem Meeting (IGC10) June 6-10, 2022
 
 <!--main menu region beg-->
 <div id="menu-bar" class="nav region-menu-bar clearfix">
-<nav id="block-os-igc10-menu" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="igc10_menu">  
-<ul class="nice-menu nice-menu-down nice-menu-igc10_menu" id="nice-menu-igc10_menu">
-  <li class="menu-1043794 menu-path-https--geos-chemseasharvardedu-igc10  first   odd  "><a href="igc10.html" >Home</a></li>
-  <li class="menu-1043986 menu-path-node-1644721   even   last "><a href="igc10-presentations.html"  title="">Presentations and Posters</a></li>
+<nav id="block-os-igc10-menu" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="igc10_menu">
+<ul class="nice-menu nice-menu-down">
+  <li><a href="igc10.html" class="active">IGC10 Home</a></li>
+  <li><a href="igc10-presentations.html">Presentations and Posters</a></li>
+  <li><a href="index.html">GEOS-Chem Home</a></li>
 </ul>
 </nav>
 </div>
 <!--main menu region end-->
-		
+
 <div id="columns" class="clearfix">
 <div class="hg-container">
 <div id="content-column" role="main">
@@ -94,47 +79,42 @@ The 10th International GEOS-Chem Meeting (IGC10) June 6-10, 2022
 <a name="main-content"></a>
 <h1 id="page-title" ng-non-bindable="">Overview</h1>
 </header>
-														
+
 <!--front panel regions beg-->
 <div id="content-panels" class="at-panel gpanel panel-display content clearfix">
 <div class="region region-content-top">
 <div class="region-inner clearfix">
 <div id="block-os-pages-main-content" class="block block-os-pages no-title"  module="os_pages" delta="main_content">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <div class="block-content content" ng-non-bindable="">
 <article id="node-1585687" class="node node-page article clearfix" role="article">
 <div class="node-content" ng-non-bindable="">
 <div class="field field-name-body field-type-text-with-summary field-label-hidden view-mode-full">
 <div class="field-items">
 <div class="field-item even">
-  
-<p style="text-align:center">
-	<img height="404" width="716" alt="IGC10 group photo" class="media-element file-default file-os-files-xlarge" src="img/igc10_photo.jpg" title="" /></p>
-
-<p align="justify">
-	The 10th International GEOS-Chem Meeting (IGC10) was held at Washington University in St. Louis (Missouri, USA) on June 7–10, 2022 with <a href="https://drive.google.com/file/d/1Ofqh6LiVNfXd17dGg87_rp2bMo2enSSQ/view?usp=sharing" target="_blank" title="">272 registrants from 103 institutions and 17 countries</a>. Model clinics were held on June 6, 2022. Follow the links for:
-</p>
-
-<ul><li>
-		<a href="igc10-presentations.html" title="">Oral and poster presentations from the meeting</a>;
-	</li>
-	<li>
-		<a href="http://wiki.seas.harvard.edu/geos-chem/index.php/GEOS-Chem_model_development_priorities" title="">Model development priority list coming out of the meeting</a>.
-	</li>
-</ul><p>
-	We are grateful for the financial support for the meeting offered by NASA, NSF, NOAA, EPRI, and Washington University in St. Louis, James McKelvey School of Engineering..
-</p>
-
-<p>
-	We look forward to seeing you at the 11th International GEOS-Chem Meeting.
-</p>
-
-<p>
-	<a href="steering-committee.html" target="_blank" title="">The GEOS-Chem Steering Committee</a>
-</p>
 
 <p style="text-align:center">
-	<img height="364" width="832" alt="IGC10 sponsors" class="media-element file-default file-os-files-xxlarge" src="img/igc10_sponsors.png" title="" /></p>
+  <img height="404" width="716" alt="IGC10 group photo" class="media-element file-default file-os-files-xlarge" src="img/igc10_photo.jpg" title="" /></p>
+
+<p>The 10th International GEOS-Chem Meeting (IGC10) was held at Washington University in St. Louis (Missouri, USA) on June 7–10, 2022 with <a href="https://drive.google.com/file/d/1Ofqh6LiVNfXd17dGg87_rp2bMo2enSSQ/view?usp=sharing" target="_blank" title="">272 registrants from 103 institutions and 17 countries</a>. Model clinics were held on June 6, 2022. Follow the links for:
+</p>
+
+<ul>
+  <li>
+    <a href="igc10-presentations.html" title="">Oral and poster presentations from the meeting</a>;
+  </li>
+  <li>
+    <a href="http://wiki.seas.harvard.edu/geos-chem/index.php/GEOS-Chem_model_development_priorities" title="">Model development priority list coming out of the meeting</a>.
+  </li>
+</ul>
+
+<p>We are grateful for the financial support for the meeting offered by NASA, NSF, NOAA, EPRI, and Washington University in St. Louis, James McKelvey School of Engineering..</p>
+
+<p>We look forward to seeing you at the 11th International GEOS-Chem Meeting.</p>
+
+<p><a href="steering-committee.html" target="_blank" title="">The GEOS-Chem Steering Committee</a></p>
+
+<p style="text-align:center"><img height="364" width="832" alt="IGC10 sponsors" class="media-element file-default file-os-files-xxlarge" src="img/igc10_sponsors.png" title="" /></p>
 
 </div>
 </div>
@@ -154,64 +134,16 @@ The 10th International GEOS-Chem Meeting (IGC10) June 6-10, 2022
 </div>
 </div>
 
-<!--footer region beg-->
+<!--footer-->
 <footer id="footer" class="clearfix" role="contentinfo">
-
-<!-- Three column 3x33 Gpanel -->
-<div class="at-panel gpanel panel-display footer clearfix">
-<div class="region region-footer">
-<div class="region-inner clearfix">
-<div id="block-boxes-1617037690" class="block block-boxes block-boxes-os_boxes_html no-title"  module="boxes" delta="1617037690">
-<div class="block-inner clearfix">  
-<div class="block-content content" ng-non-bindable="">  
-<div id='boxes-box-1617037690' class='boxes-box'>  
 <div class="boxes-box-content">
   <p style="text-align:center">
-    Copyright © 2023 by the International GEOS-Chem Community. All rights reserved.
+    Copyright © 2026 by the International GEOS-Chem Community. All rights reserved.
   </p>
 </div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-<div class="region region-footer-bottom">  
-<div class="region-inner clearfix">  
-<div id="block-boxes-1616879798" class="block block-boxes block-boxes-os_boxes_media no-title"  module="boxes" delta="1616879798">  
-<div class="block-inner clearfix">  
-<div class="block-content content"> 
-<div id='boxes-box-1616879798' class='boxes-box'> 
-<div class="boxes-box-content"> 
-<div id="file-3900146" class="file file-html file-html-embed">
-<h2 class="element-invisible"><a href="">css-brand</a></h2>
-<div class="content">
-<div class="file-info">
-</div>
-<div class="field field-name-field-html-code field-type-text-long field-label-hidden view-mode-full">
-<div class="field-items">
-<div class="field-item even">
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-
-<!--footer region end-->
 </footer>
-</div>
-</div>
 
-<!--page area ends-->
-<div id="extradiv"></div>
+</div>
 </div>
 
 </body>

--- a/igc11-presentations.html
+++ b/igc11-presentations.html
@@ -1,9 +1,4 @@
 <!DOCTYPE html>
-<!--[if IEMobile 7]><html class="iem7"  lang="en" dir="ltr"><![endif]-->
-<!--[if lte IE 6]><html class="lt-ie9 lt-ie8 lt-ie7"  lang="en" dir="ltr"><![endif]-->
-<!--[if (IE 7)&(!IEMobile)]><html class="lt-ie9 lt-ie8"  lang="en" dir="ltr"><![endif]-->
-<!--[if IE 8]><html class="lt-ie9"  lang="en" dir="ltr"><![endif]-->
-<!--[if (gte IE 9)|(gt IEMobile 7)]><!--><html  lang="en" dir="ltr"><!--<![endif]-->
 <head>
 <meta charset="utf-8" />
 <!--<base href="/igc11-presentations" />-->
@@ -18,23 +13,12 @@
 <title>The 11th International GEOS-Chem Meeting</title>
 <meta http-equiv="x-ua-compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<link type="text/css" rel="stylesheet" href="css/css_xE-rWrJf-fncB6ztZfd2huxqgxu4WO-qwma6Xer30m4%EF%B9%96m=1675397288.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_1kR8T1_c-l5pBT6ZwbDT7BFda-4fyqW9Jjum29_2IY8%EF%B9%96m=1675397312.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_YnlUIvHP13qgpYEqubzE8JyDwlSxUnVibfnVkSoSDb0%EF%B9%96m=1675397273.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_Ku-3OcT9qU9h7dnGig5e23q6EVryY8orK4wzVDxsweE%EF%B9%96m=1675397367.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_vprtFTrWyg23GbY50_zJZHWGYMNfS8vsrRS26i4-ISk%EF%B9%96m=1675397406.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_dW-aNNrctRhQNc-KECjtQd0PxuW-h19IEum-TX2MeEk%EF%B9%96m=1675397301.css" media="print" />
-<link type="text/css" rel="stylesheet" href="css/css_SH2Lx3Qprh0GZo_9xRp85U9NsWfkSXn_Bi-rJoMY1sw%EF%B9%96m=1675397273.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_uaIDKcYMUK5osSQXuirpr3ZleXtnnpBN-eiECm7N0M0%EF%B9%96m=1675397395.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/responsive.blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/geos-chem.css" media="all"/>
 <script type="text/javascript" src="dropdown-menu.js"></script>
-<!--[if lte IE 8]>
-<script type="text/javascript">
-  var os_c = document.createElement;os_c('header');os_c('nav');os_c('section');os_c('article');os_c('aside');os_c('footer');os_c('hgroup');os_c('figure');
-</script>
-<![endif]-->
 </head>
 
 <body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-1585687 node-type-page og-context og-context-node og-context-node-1585652 navbar-on">
@@ -45,7 +29,7 @@
 <div id="page_wrap" class="page_wrap">
 <div id="page" class="container page header-main content-top footer-none">
 <div id="page-wrapper">
-		
+
 <!--header regions beg-->
 <header id="header" class="clearfix" role="banner">
 <div id="header-container">
@@ -53,7 +37,7 @@
 <div class="region region-header-second">
 <div class="region-inner clearfix">
 <div id="block-boxes-1617807424" class="block block-boxes block-boxes-os_boxes_html no-title"  module="boxes" delta="1617807424">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <div class="block-content content" ng-non-bindable="">
 <div id='boxes-box-1617807424' class='boxes-box'>
 <div class="boxes-box-content">
@@ -76,16 +60,16 @@ The 11th International GEOS-Chem Meeting (IGC11) June 11-14, 2024
 
 <!--main menu region beg-->
 <div id="menu-bar" class="nav region-menu-bar clearfix">
-<nav id="block-os-igc11-menu" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="igc11_menu">  
-<ul class="nice-menu nice-menu-down nice-menu-igc11_menu" id="nice-menu-igc11_menu">
-  <li class="menu-857212 menu-path-node-1586486  first   odd  "><a href="igc11.html" >Home</a></li>
-  <li class="menu-857214 menu-path-node-1586487   even  "><a href="igc11-presentations.html"  title="">Presentations and Posters</a></li>
-  <li class="menu-857216 menu-path-node-1586490   odd   last "><a href="igc11-webcast.html" >Webcast Archive</a></li>
+<nav id="block-os-igc11-menu" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="igc11_menu">
+<ul class="nice-menu nice-menu-down">
+  <li><a href="igc11.html" class="active">IGC11 Home</a></li>
+  <li><a href="igc11-presentations.html">Presentations and Posters</a></li>
+  <li><a href="index.html">GEOS-Chem Home</a></li>
 </ul>
 </nav>
 </div>
 <!--main menu region end-->
-		
+
 <div id="columns" class="clearfix">
 <div class="hg-container">
 <div id="content-column" role="main">
@@ -95,478 +79,474 @@ The 11th International GEOS-Chem Meeting (IGC11) June 11-14, 2024
 <a name="main-content"></a>
 <h1 id="page-title" ng-non-bindable="">Presentations and Posters</h1>
 </header>
-														
+
 <!--front panel regions beg-->
 <div id="content-panels" class="at-panel gpanel panel-display content clearfix">
 <div class="region region-content-top">
 <div class="region-inner clearfix">
 <div id="block-os-pages-main-content" class="block block-os-pages no-title"  module="os_pages" delta="main_content">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <div class="block-content content" ng-non-bindable="">
 <article id="node-1585687" class="node node-page article clearfix" role="article">
 <div class="node-content" ng-non-bindable="">
 <div class="field field-name-body field-type-text-with-summary field-label-hidden view-mode-full">
 <div class="field-items">
 <div class="field-item even">
-  
+
 <p align="justify">
-	<strong>
-	Monday, June 10: <a href="#clinics">Model Clinics</a>
-	<br class="clearfix" />
-	Tuesday, June 11: <a href="#overview">Model Overview</a> | <a href="#chem-climate">Chemistry-Climate</a> | <a href="#airquality">Air Quality</a> | <a href="#tue_wg">Breakouts</a> | <a href="#tue_posters">Posters</a>
-	<br class="clearfix" />
-	Wednesday, June 12: <a href="#chemistryI">Chemistry I</a> | <a href="#model_dev">Model Developments</a> | <a href="#aerosols">Aerosols</a> | <a href="#wed_wg">Breakouts</a> | <a href="#wed_posters">Posters</a>
-	<br class="clearfix" />
-	Thursday, June 13: <a href="#chemistryII">Chemistry II</a> | <a href="#fires">Fires</a> | <a href="#carbon">Carbon Gases</a>| <a href="#thu_wg">reakouts</a> | <a href="#thu_posters">Posters</a>
-	<br class="clearfix" />
-	Friday, June 14: <a href="#wg">Working Groups</a> | <a href="#future">Looking Ahead</a></strong>
+  <strong>
+  Monday, June 10: <a href="#clinics">Model Clinics</a>
+  <br class="clearfix" />
+  Tuesday, June 11: <a href="#overview">Model Overview</a> | <a href="#chem-climate">Chemistry-Climate</a> | <a href="#airquality">Air Quality</a> | <a href="#tue_wg">Breakouts</a> | <a href="#tue_posters">Posters</a>
+  <br class="clearfix" />
+  Wednesday, June 12: <a href="#chemistryI">Chemistry I</a> | <a href="#model_dev">Model Developments</a> | <a href="#aerosols">Aerosols</a> | <a href="#wed_wg">Breakouts</a> | <a href="#wed_posters">Posters</a>
+  <br class="clearfix" />
+  Thursday, June 13: <a href="#chemistryII">Chemistry II</a> | <a href="#fires">Fires</a> | <a href="#carbon">Carbon Gases</a>| <a href="#thu_wg">reakouts</a> | <a href="#thu_posters">Posters</a>
+  <br class="clearfix" />
+  Friday, June 14: <a href="#wg">Working Groups</a> | <a href="#future">Looking Ahead</a></strong>
 </p>
 
-<div>
-	<h2>
-		Monday, June 10
-	</h2>
-	<a name="clinics" id="clinics"></a><strong>Model Clinics</strong>
+<h2>Monday, June 10</h2>
+<a name="clinics" id="clinics"></a><strong>Model Clinics</strong>
 
-	<ul>
-	    <li>
-			<a href="https://drive.google.com/file/d/1R9jaYR-fF3lfk2G436uskGzuhr-9Dd95/view?usp=drive_link">Getting Started with GEOS-Chem</a> (Bob Yantosca, Harvard; Melissa Sulprizio, Harvard)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1QZnQgk6SVHCK7bplgYyuNXVoP_s-0bwj/view?usp=drive_link">Working with the high-performance GEOS-Chem (GCHP)</a> (Sebastian Eastham, Imperial College London)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1K5pk4Y-S37_b105MEd0533f4Et3cQJJy/view?usp=drive_link">Running GEOS-Chem with WRF (WRF-GC)</a> (Xu Feng, Harvard; Haipeng Lin, Harvard)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1cgu1cGDpM2LrnNYC7Y3Bl1_-L-NS0oi1/view?usp=drive_link">Working with the GEOS-Chem adjoint</a> (Daven Henze, CU Boulder)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1VHWL32K43kKqmOre0xSWv6QinbF0SSkL/view?usp=drive_link">Running GC within CESM</a> (Haipeng Lin, Harvard)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/16kSMlB3uOCMGgQqwfExbDtprMReNgcVO/view?usp=drive_link">Running GISS-GC/GCAP/ICECAP</a> (Lee Murray, U. Rochester)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1m5WFqxT-1sVFNqlJfudRLIYBUyHz3IN0/view?usp=drive_link">Using CHEEREIO LETKF</a> (Drew Pendergrass, Harvard)
-		</li>
-	</ul>
-</div>
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1R9jaYR-fF3lfk2G436uskGzuhr-9Dd95/view?usp=drive_link">Getting Started with GEOS-Chem</a> (Bob Yantosca, Harvard; Melissa Sulprizio, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1QZnQgk6SVHCK7bplgYyuNXVoP_s-0bwj/view?usp=drive_link">Working with the high-performance GEOS-Chem (GCHP)</a> (Sebastian Eastham, Imperial College London)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1K5pk4Y-S37_b105MEd0533f4Et3cQJJy/view?usp=drive_link">Running GEOS-Chem with WRF (WRF-GC)</a> (Xu Feng, Harvard; Haipeng Lin, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1cgu1cGDpM2LrnNYC7Y3Bl1_-L-NS0oi1/view?usp=drive_link">Working with the GEOS-Chem adjoint</a> (Daven Henze, CU Boulder)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1VHWL32K43kKqmOre0xSWv6QinbF0SSkL/view?usp=drive_link">Running GC within CESM</a> (Haipeng Lin, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/16kSMlB3uOCMGgQqwfExbDtprMReNgcVO/view?usp=drive_link">Running GISS-GC/GCAP/ICECAP</a> (Lee Murray, U. Rochester)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1m5WFqxT-1sVFNqlJfudRLIYBUyHz3IN0/view?usp=drive_link">Using CHEEREIO LETKF</a> (Drew Pendergrass, Harvard)
+  </li>
+</ul>
 
-<div>
-	<h2>
-		Tuesday, June 11
-	</h2>
-	<a name="overview" id="overview"></a><strong>Model overview (Chair: Eloise Marais, U. College London)</strong>
+<h2>Tuesday, June 11</h2>
+<a name="overview" id="overview"></a><strong>Model overview (Chair: Eloise Marais, U. College London)</strong>
 
-	<ul>
-	    <li>
-			Welcome to IGC11 (Eloise Marais, U. College London)
-		</li>
-		<li>
-			Welcome to Washington University (Dean Aaron Bobick, WashU)
-		</li>
-		<li>
-		    Welcome from Center for the Environment (Dan Giammar, WashU)
-		</li>
-		<li>
-			Welcome from McDonnell Academy (Laura Benoist, WashU)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1TCWoltnHCiTPmAnlT8b-N2Ajon0FgEyn/view?usp=drive_link">GEOS-Chem overview</a> (Randall Martin, WashU)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1bP6rr3i474phzMR0fb4ZJgE2IV5bVgib/view?usp=drive_link">GEOS-Chem adjoint overview</a> (Daven Henze, Colorado U. Boulder)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1MkLroHB9S-8RZx9CZ7ubPV0JkDrjpnWC/view?usp=drive_link">WRF-GC v3.0: developments and applications</a> (Tzung-May Fu, SUSTech)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1eZi0CW6JfRo-OKBN1FyXbbuiRgn_SoRH/view?usp=drive_link">GEOS system updates</a> (Steven Pawson, NASA GMAO)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1rwlAlYfeCxz95DNfJ3SCXWmEAn9LRuVJ/view?usp=drive_link">GEOS-Chem in GEOS: New developments and comparison with the offline model</a> (Viral Shah, NASA GSFC)
-		</li>
-	</ul>
-	
-	<a name="chem-climate" id="chem-climate"></a>
-	<strong>Chemistry-climate-ecosystems-health (Chair: Lyatt Jaeglé, U. Washington)</strong>
-	<ul>
-	    <li>
-			GEOS-Chem as a testbed for assessing aerosol radiative effects (Bethany Sutherland, North Carolina State U.)
-	    <li>
-	        <a href="https://drive.google.com/file/d/1JxydQLfzNln9wvdbfeUvQ04X0iZfiEmp/view?usp=drive_link">Using GEOS-Chem to estimate future climate penalties and benefits to human mortality and crop losses</a> (Lee Murray, U Rochester)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1xoczYkfabSsYh-49eaErGrSvCpMY5ihQ/view?usp=drive_link">Air pollution-vegetation interactions in GEOS-Chem</a> (Hong Liao, NUIST)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1D4vb1NCobDPXhFrCWSE1mGFEpB6D2nCr/view?usp=drive_link">Global health burden of ammonia emissions from fossil-fuel derived synthetic nitrogen fertiliser</a> (Karn Vohra, U. College London)
-		</li>
-		<li>
-			Exploring atmospheric phosphorus sources, transport, and trends: Development of an atmospheric phosphorus description in GEOS-Chem (Olivia Norman, MIT)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1uUKpptIO_BmZYcExphi82UJaUUONuf4U/view?usp=drive_link">The growing impact of satellite megaconstellation launch and re-entry emissions on radiative forcing and stratospheric ozone depletion</a> (Connor Barker, U. College London)
-		</li>
-	</ul>
-	
-	<a name="airquality" id="airquality"></a>
-	<strong>Air Quality (Chair: Seb Eastham, Imperial College London)</strong>
-	<ul>
-	    <li>
-			KEYNOTE: Evolving urban air quality (Brian McDonald, NOAA)
-		</li>
-		<li>
-			The impacts of reactive nitrogen emissions on global PM2.5 air pollution (Lin Zhang, Peking U.)
-		</li>
-		<li>
-			Complex ozone-temperature relationship over the North China Plain (Ke Li, NUIST)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1i8gHY10DpVDaDlrHd75QMATWuNNjQX7y/view?usp=drive_link">Improving top-down NOx emission estimates with synthetic columns from GEOS-Chem: Application in African hotspots</a> (Eloise Marais, U. College London)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1yjShrSwakLemAjoI77i3NVLyQuaTUoRT/view?usp=drive_link">Factors affecting urban HONO interpreted with a MAX-DOAS instrument and GEOS-Chem</a> (Eleanor Gershenson-Smith, U. College London)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1if0fde5zfNq7bNBM9mY8d2q4GoYJvpRR/view?usp=drive_link">Aggravated surface O3 pollution primarily driven by meteorological variation in China during the COVID-19 pandemic lockdown period</a> (Zhendong Lu, U. Iowa)
-		</li>
-		<li>
-			Sensitivity of air quality in Eastern Canada to transboundary pollution and meteorology: Understanding potential climate-AQ feedbacks (Robin Stevens, U. Montréal)
-		</li>
-	</ul>
+<ul>
+  <li>
+    Welcome to IGC11 (Eloise Marais, U. College London)
+  </li>
+  <li>
+    Welcome to Washington University (Dean Aaron Bobick, WashU)
+  </li>
+  <li>
+      Welcome from Center for the Environment (Dan Giammar, WashU)
+  </li>
+  <li>
+    Welcome from McDonnell Academy (Laura Benoist, WashU)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1TCWoltnHCiTPmAnlT8b-N2Ajon0FgEyn/view?usp=drive_link">GEOS-Chem overview</a> (Randall Martin, WashU)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1bP6rr3i474phzMR0fb4ZJgE2IV5bVgib/view?usp=drive_link">GEOS-Chem adjoint overview</a> (Daven Henze, Colorado U. Boulder)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1MkLroHB9S-8RZx9CZ7ubPV0JkDrjpnWC/view?usp=drive_link">WRF-GC v3.0: developments and applications</a> (Tzung-May Fu, SUSTech)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1eZi0CW6JfRo-OKBN1FyXbbuiRgn_SoRH/view?usp=drive_link">GEOS system updates</a> (Steven Pawson, NASA GMAO)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1rwlAlYfeCxz95DNfJ3SCXWmEAn9LRuVJ/view?usp=drive_link">GEOS-Chem in GEOS: New developments and comparison with the offline model</a> (Viral Shah, NASA GSFC)
+  </li>
+</ul>
 
-	<a name="tuewg" id="tue_wg"></a>
-	<strong>Working Group Breakouts</strong>
-	<ul>
-	    <li>
-            Emissions Working Group (chairs: Eloise Marais, U. College London; Lyatt Jaeglé, U. Washington; Jintai Lin, Peking U.)
-		</li>
-		<li>
-			Chemistry-Climate Working Group (chairs: Lee Murray, U. Rochester; Hong Liao, NUIST)
-		</li>
-		<li>
-			Transport Working Group (chairs: Katie Travis, NASA LaRC; Andrew Schuh, CSU)
-		</li>
-		<li>
-			Stratosphere Working Group (chairs: Seb Eastham, MIT; Dylan Jones, U. Toronto; Pam Wales, NASA GSFC)
-		</li>
-	</ul>
-	
-	<a name="tue_posters" id="tue_posters"></a>
-	<strong>Posters</strong>
-	<ul>
-	    <li>Constraining the California ammonia budget (Will Porter, UC Riverside)</li>
-	    <li>Modeling the effect of drought stress on biogenic isoprene emissions in South Korea (Yongcheol Jeong, U. Houston)</li>
-	    <li>Isoprene emissions impact atmospheric oxidative capacity and methane lifetimes (James Yoon, U. Washington)</li>
-	    <li>Estimating the contribution of anthropogenic NOx emissions to the 2019 global annual pediatric asthma health burden attributable to NO2 with the GEOS Chem adjoint (Patrick Wiecko, CU Boulder)</li>
-	    <li>GEOS-Chem-APM for (1) physics-guided machine learning parameterizations and (2) aerosol pollution exposure and health disparities (Arshad Nair, SUNY Albany)</li>
-	    <li>Linking water usage to future air quality: Adding a source of halogens from playa dust to GEOS-Chem (Joey Bail, U. Utah)</li>
-	    <li>Near-real-time satellite AOD measurements and chemical transport modeling (Tessa Clarizio, UIUC)</li>
-	    <li>Investigating rocket launch emissions impact variation with changing launch latitude (Helena McDonald, MIT)</li>
-	    <li>Modeling and remote Sensing of NO2 and HCHO diurnal variability: Results from Boston and Salt Lake City (Jeff Geddes, Boston U.)</li>
-	    <li>A bias-corrected GEMS NO2 satellite product and its applications (Yujin Oak, Harvard)</li>
-	    <li>Constraining model sulfate production mechanisms with observations in South Korea (Katie Travis, NASA LaRC)</li>
-	    <li>Emission inventories underestimate black carbon in the Global South as revealed by comparison of GCHP simulations with measurements (Yuxuan Ren, WashU)</li>
-	    <li>Background ozone in China (Danyuting Zhang, NUIST and Harvard)</li>
-	    <li>Ozone production, VOC sources, and model-measurement comparisons from the AEROMMA field campaign (Kelvin Bates, NOAA CSL and CU Boulder)</li>
-	    <li>Enhancing regional estimation of fine particulate matter species concentrations by including GEOS-Chem a priori information into deep learning (Siyuan Shen, WashU)</li>
-	    <li>Impacts of anthropogenic emissions and meteorology on spring ozone differences in San Antonio, Texas between 2017 and 2021 (Tabitha Lee, U. Houston)
-	    <li>Interpretating driving factors of global diel fine particulate matter variation using GEOS- Chem and in situ observations (Yanshun Li, WashU)</li>
-	    <li>Evaluating WRF-GC v2.0 predictions of boundary layer height and vertical ozone profile during the 2021 TRACER-AQ campaign in Houston, Texas (Shailaja Wasti, U, Houston)</li>
-	    <li>Constraining summertime anthropogenic VOC emissions in Salt Lake City, Utah (Emily Cope, U. Montana)</li>
-	    <li>Adding a source of halogens from road-salt applications to GEOS-Chem (Shuying Zhao, U. Utah)</li>
-	    <li>Wildfire emissions and impact in Missoula, Montana during 2021 wildfire season (Lu Tan, U. Montana)</li>
-	</ul>
-</div>
+<a name="chem-climate" id="chem-climate"></a>
+<strong>Chemistry-climate-ecosystems-health (Chair: Lyatt Jaeglé, U. Washington)</strong>
 
-<div>
-	<h2>
-		Wednesday, June 12
-	</h2>
+<ul>
+  <li>
+    GEOS-Chem as a testbed for assessing aerosol radiative effects (Bethany Sutherland, North Carolina State U.)
+  <li>
+    <a href="https://drive.google.com/file/d/1JxydQLfzNln9wvdbfeUvQ04X0iZfiEmp/view?usp=drive_link">Using GEOS-Chem to estimate future climate penalties and benefits to human mortality and crop losses</a> (Lee Murray, U Rochester)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1xoczYkfabSsYh-49eaErGrSvCpMY5ihQ/view?usp=drive_link">Air pollution-vegetation interactions in GEOS-Chem</a> (Hong Liao, NUIST)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1D4vb1NCobDPXhFrCWSE1mGFEpB6D2nCr/view?usp=drive_link">Global health burden of ammonia emissions from fossil-fuel derived synthetic nitrogen fertiliser</a> (Karn Vohra, U. College London)
+  </li>
+  <li>
+    Exploring atmospheric phosphorus sources, transport, and trends: Development of an atmospheric phosphorus description in GEOS-Chem (Olivia Norman, MIT)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1uUKpptIO_BmZYcExphi82UJaUUONuf4U/view?usp=drive_link">The growing impact of satellite megaconstellation launch and re-entry emissions on radiative forcing and stratospheric ozone depletion</a> (Connor Barker, U. College London)
+  </li>
+</ul>
 
-	<a name="chemistryI" id="chemistryI"></a>
-	<strong>Chemistry I (Chair: Lu Hu, U. Montana)</strong>
-	<ul>
-	    <li>
-			<a href="https://drive.google.com/file/d/14axS-PYXbvEMIvEW7MLLt4M46AjzjgRW/view?usp=drive_link">Drivers of increasingly high tropospheric ozone in East Asia</a> (Nadia Colombi, Harvard)
-		</li>
-		<li>
-			The shrinking climate niche for tropospheric ozone and mercury depletion events (Chris Holmes, FSU)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1wRn4bsy0dMciu0dDpgXMZK5ndQM97lmd/view?usp=drive_link">Interpreting GEMS geostationary satellite observations of the diurnal variation of nitrogen dioxide (NO2) over East Asia</a> (Laura Yang, Harvard)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1WzEGZgVx_20d1zBXWUcEqndl9Nv5zVbc/view?usp=drive_link">Using GEOS-Chem to interpret summertime hourly variation of NO2 columns with implications for geostationary satellite applications</a> (Deepangsu Chatterjee, WashU)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/17VOkG1bwpe6FVsEuc-1q1R9hltFmq_HB/view?usp=drive_link">Development, evaluation and interpretation of a simultaneous simulation of CH4, 13CH4 and CH3D within GEOS-Chem during the Recent Hiatus Period</a> (Mingjian Shi, U. Rochester)
-		</li>
-	</ul>
-	
-	<a name="model_dev" id="model_dev"></a>
-	<strong>Model developments (Chair: Hannah Horowitz, UIUC)</strong>
-	<ul>
-	    <li>
-			<a href="https://drive.google.com/file/d/1P5rki2Az0biEkb3svFJRivo_S3uyPqCa/view?usp=drive_link">Intercomparison of GEOS-Chem and CAM-chem tropospheric oxidant chemistry within the Community Earth System Model version 2 (CESM2)</a> (Haipeng Lin, Harvard)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1nGxKdrQkR6Rh4viVHYxMugw5mJjtYtbK/view?usp=drive_link">Using GCHP with containers and clouds</a> (Yidan Tang, WashU)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1Xiy4oZDvzpkwHTZUBCgcv02luoXA7f7w/view?usp=drive_link">Integrated Methane Inversion (IMI 2.0)</a> (Melissa Sulprizio, Harvard)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1mZEUyJCJ5FqpkCkwyR5vAmFvd7AOjyXp/view?usp=drive_link">New GEOS-Chem developments to examine biosphere-agriculture-atmosphere interactions and implications for air quality</a> (Amos Tai, Chinese U. Hong Kong)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1Cwas8vzif40cuOHecrXIoLSkHlsKCXr6/view?usp=drive_link">Impact of GCHP spatial resolution on global geophysical satellite-derived fine particulate matter</a> (Dandan Zhang, WashU)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1yQxpxid0yN3YUl75x-zH69ucG0mIWQ1G/view?usp=drive_link">Chemistry in the twilight zone: creation of a mechanism analysis interface for GEOS- Chem to address a computational bottleneck in air quality forecasts</a> (Obin Sturm, USC)
-		</li>
-	</ul>
-	
-	<a name="aerosols" id="aerosols"></a>
-	<strong>Aerosols (Chair: Colette Heald, ETH)</strong>
-	<ul>
-	    <li>
-			KEYNOTE: Evolution of reactive organic carbon and its toxicity in wildfire plumes (Havala Pye, EPA)
-		</li>
-		<li>
-			Impact of horizontal resolution on aerosol number and size in GCHP-TOMAS (Betty Croft, WashU and Dalhousie)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/14m32oXndzdQfpGbk3tGzwxbDdotCSUG8/view?usp=drive_link">Impact of air refreshing and cloud ice uptake limitations on vertical profiles and wet depositions of nitrate, ammonium, and sulfate</a> (Gan Luo, SUNY Albany)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1P6bdeZf2IOWkKbiSIl4IoPI1LaHXUzOc/view?usp=drive_link">Diagnosing the sensitivity of particulate nitrate to precursor emissions using satellite observations of NH3 and NO2</a> (Ruijun Dang, Harvard)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1aWtYNdcfMRANB3wxUTL0RMnEZv86vCSd/view?usp=drive_link">Global spatial variation in the PM2.5 to AOD relationship and Its driving factors</a> (Haihui Zhu, WashU)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1oy-_VA5PEiPcH-6dHOg2Vjbtcv3o38gd/view?usp=drive_link">Capturing the relative-humidity-sensitive gas–particle partitioning of organic aerosols in GEOS-Chem</a> (Camilo Serrano Damha, McGill)
-		</li>
-	</ul>
-	
-    <a name="wed_wg" id="wed_wg"></a>
-    <strong>Working Group Breakouts</strong>
-	<ul>
-	    <li>
-			Aerosols Working Group (chairs: Becky Alexander, U. Washington; Jeff Pierce, CSU; Will Porter, UC Riverside; Fangqun Yu, SUNY-Albany)
-		</li>
-		<li>
-			Carbon gases Working Group (chairs: Kevin Bowman, JPL; Dylan Jones, U. Toronto)
-		</li>
-		<li>
-			Surface-atmosphere exchange Working Group (chairs: Jeff Geddes, Boston U.; Chris Holmes, Florida State U.; Amos Tai, Chinese U. Hong Kong)
-		</li>
-		<li>
-			Hg and POPs Working Group (chairs: Jenny Fisher, U Wollongong; Hannah Horowitz, UIUC; Yanxu Zhang, Nanjing U.)
-		</li>
-	</ul>
-	
-    <a name="wed_posters" id="wed_posters"></a>
-    <strong>Posters</strong>
-	<ul>
-	    <li>2022 GEOS-Chem v14 ozone evaluation using sondes, satellites and surface measurements (Barron Henderson, EPA)</li>
-	    <li>A new source of HO2? (Paolo Sebastianelli, U. Wollongong)</li>
-	    <li>Variable sensitivity of GCHP simulated ozone to grid resolution: combined effects from meteorology and chemistry (Chi Li, WashU)</li>
-	    <li>Improved representation of lightning NOx in GEOS-Chem informed by vertical profiles of NO2 and O3 from cloud-slicing TROPOMI (Bex Horner, U. College London)</li>
-	    <li>Current chemical mechanisms fail to reproduce trends in DMS oxidation products observed in Arctic ice cores (Ursula Jongebloed, U. Washington)</li>
-	    <li>Development and evaluation of dimethyl sulfide oxidation mechanism in the marine atmosphere (Linia Tashmim, UC Riverside)</li>
-	    <li>Characterizing the global tropospheric budget of NOy (Ishir Dutta, MIT)</li>
-	    <li>Global model of atmospheric chlorate (Yuk Chun Chan, U. Washington)</li>
-	    <li>Space-based observations of tropospheric ethane map emissions from fossil fuel extraction (Jared Brewer, U Minnesota)</li>
-	    <li>Automated GEOS-Chem mechanism emulator for F0AM box model (Jessica Haskins, U. Utah)</li>
-	    <li>GCHP-EnKF multi-constituent satellite data assimilation (Kazuyuki Miyazaki, JPL)</li>
-	    <li>GEOS-Chem-hyd: Enabling calculation of numerically exact, second-order sensitivities (Samuel Akinjole, Drexel)</li>
-	    <li>Lagrangian versus Eulerian perspectives of new particle formation events (Sam O’Donnell. Colorado State U.)</li>
-	    <li>Calculation of sub-micron and super-micron particle fluxes by coupling CALIPSO and GEOS-Chem (Ajmal Rasheeda, North Carolina State U.)</li>
-	    <li>Integrated model-measurement approaches to laboratory SOA studies (Hannah Kenagy, MIT)</li>
-	    <li>Reconciling differences of GEOS-Chem simulations and globally-distributed ground- based measurements of mineral dust (Yu Yan, WashU)</li>
-	    <li>Global simulations of secondary organic aerosol phase state and equilibration timescales with GEOS-Chem (Regina Luu, UC Irvine)</li>
-	    <li>Framework for modeling dark-brown carbon optical properties (Taveen Singh Kapoor, WashU)</li>
-	    <li>Using accumulated precipitation and air mass history along transport trajectories to interpret aerosol observations over the western North Atlantic Ocean (Bo Zhang, National Institute of Aerospace)</li>
-	    <li>Global modeling of organic aerosols based on a new emission inventory and an updated mechanism in GEOS-Chem (Ruochong Xu, Tsinghua U.)</li>
-	</ul>
-</div>
+<a name="airquality" id="airquality"></a>
+<strong>Air Quality (Chair: Seb Eastham, Imperial College London)</strong>
 
-<div>
-	<h2>
-		Thursday, June 13
-	</h2>
-	
-	<a name="chemistryII" id="chemistryII"></a>
-	<strong>Chemistry II (Chair: Becky Alexander, U. Washington)</strong>
-	<ul>
-	    <li>
-			Joint inversion of formaldehyde and isoprene to constrain non-methane VOC emissions (Jinkyul Choi, CU Boulder)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1Gj9mPCrCGvb_HbvPcuJBkimUGvTHxY2k/view?usp=drive_link">A vertically-resolved canopy significantly improves chemical transport model predictions of ozone deposition to north temperate forests</a> (Michael Vermeuel, U. Minnesota)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/14lzyXChC_pI1blCtdDbIcTHCAMSawBsw/view?usp=drive_link">Assessing the role of RO2 accretion reactions in SOA formation</a> (Alfred Mayhew, U. Utah)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1SiCy6nPrUFOZF2kkw4N4AH9qyf53m5wM/view?usp=drive_link">Evaluation of formaldehyde (HCHO) diurnal variability over North America using Pandonia Global Network (PGN)</a> (Tianlang Zhao, U. Alaska Fairbanks)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1k07wsJk6IO2TytaaRB1hi7lyWq-ynW2L/view?usp=drive_link">Global chemical impacts of furanoids: model analysis and constraints from in-situ observations</a> (Lixu Jin, U. Montana)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1BO7cML3ErP8xzuUks4L_k-5MI8CRDdjH/view?usp=drive_link">GEOS-Chem Adjoint as a decision support tool in Europe</a> (Yixuan Gu, CU Boulder)
-		</li>
-	</ul>
-	
-	<a name="fires" id="fires"></a>
-	<strong>Fires (Chair: Jingqiu Mao, U. Alaska Fairbanks)</strong>
-	<ul>
-	    <li>
-			The impact of smoke PM on ozone photochemical regimes (Jiaqi Shen, Rutgers)
-		</li>
-		<li>
-			Drivers of smoke air quality in the western United States from 1992 to 2020: natural variability and anthropogenic climate change (Xu Feng, Harvard)
-		</li>
-		<li>
-			Global PM2.5 exposure and health impacts from 2023 Canada extreme wildfire (Yuexuanzi Wang, Tsinghua)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1BKeJgdySoErNRCVOimlGVBeif-pFgoMa/view?usp=drive_link">Influence of model resolution on wildfire impact</a> (Anas Ali, U. Toronto)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1uuTWke6iSTrAOHmrqd1Wdk4Qt1BxYHqS/view?usp=drive_link">When smoke goes up: Effects of biomass burning plume injection height in GEOS-Chem-TOMAS</a> (Nicole June, Colorado State U.)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1S7o7OKsto0tTDTxGqOnG_EiwFNPMl5vb/view?usp=drive_link">Assessing wildfire emissions of CO using 4D-Var inverse modelling</a> (Olalekan Balogun, U. Toronto)
-		</li>
-	</ul>
-	
-	<a name="carbon" id="carbon"></a>
-	<strong>Carbon gases (Chair: Prasad Kasibhatla, Duke)</strong>
-	<ul>
-	    <li>
-			<a href="https://drive.google.com/file/d/1ned3n4Vf691AhokhDNT6JZpi7wfs46x-/view?usp=drive_link">KEYNOTE: GEOS Modeling in Support of the U.S. Greenhouse Gas Center: Challenges and opportunities in stakeholder-driven product development</a> (Lesley Ott, NASA GSFC)
-		</li>
-		<li>
-			Inverse modeling of satellite methane and in-situ carbon isotopic observations shows that inundation of the wet tropics drove the 2020-2022 methane surge (Zhen Qu, North Carolina State U.)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1Oeji6_adO3DLE-VaIKbwWrTQtAYgImWw/view?usp=drive_link">Interpreting the seasonality of atmospheric methane</a> (James East, Harvard)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1hGFHBJc-9vN1k4P5Swp4wl-lQwXo2xZg/view?usp=drive_link">Quantifying urban and landfill methane emissions in the US using inverse modeling of TROPOMI data at 12 km resolution</a> (Xiaolin Wang, Harvard)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1nI22ylJ2h8qWBkeaR5G8xHfC_257tK-M/view?usp=drive_link">Analytical estimation of carbon dioxide fluxes and information content from OCO-2 satellite data</a> (Hannah Nesser, JPL)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1DIeAFwj4HcfYWHJIcKB1rGytxLn_75g6/view?usp=drive_link">Observation-based assessment of China's methane emissions</a> (Yuzhong Zhang, Westlake)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1fymd7-3cwYVo5NGJCvHPZ3jykkwyR0Km/view?usp=drive_link">Stratospheric methane in GEOS-Chem and its implications for inversions</a> (Todd Mooring, Harvard)
-		</li>
-	</ul>
+<ul>
+  <li>
+    KEYNOTE: Evolving urban air quality (Brian McDonald, NOAA)
+  </li>
+  <li>
+    The impacts of reactive nitrogen emissions on global PM2.5 air pollution (Lin Zhang, Peking U.)
+  </li>
+  <li>
+    Complex ozone-temperature relationship over the North China Plain (Ke Li, NUIST)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1i8gHY10DpVDaDlrHd75QMATWuNNjQX7y/view?usp=drive_link">Improving top-down NOx emission estimates with synthetic columns from GEOS-Chem: Application in African hotspots</a> (Eloise Marais, U. College London)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1yjShrSwakLemAjoI77i3NVLyQuaTUoRT/view?usp=drive_link">Factors affecting urban HONO interpreted with a MAX-DOAS instrument and GEOS-Chem</a> (Eleanor Gershenson-Smith, U. College London)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1if0fde5zfNq7bNBM9mY8d2q4GoYJvpRR/view?usp=drive_link">Aggravated surface O3 pollution primarily driven by meteorological variation in China during the COVID-19 pandemic lockdown period</a> (Zhendong Lu, U. Iowa)
+  </li>
+  <li>
+    Sensitivity of air quality in Eastern Canada to transboundary pollution and meteorology: Understanding potential climate-AQ feedbacks (Robin Stevens, U. Montréal)
+  </li>
+</ul>
 
-	<a name="thu_wg" id="thu_wg"></a>
-	<strong>Working Group Breakouts</strong>
-	<ul>
-	    <li>
-			Chemistry Working Group (chairs: Barron Henderson, US EPA; Lu Hu, U. Montana)
-		</li>
-		<li>
-			Adjoint Model and Data Assimilation Working Group (chairs: Daven Henze, U. Colorado; Jun Wang, U. Iowa)
-		</li>
-		<li>
-			Software engineering Working Group (chairs: Lizzie Lundgren, Harvard; Melissa Sulprizio, Harvard; Bob Yantosca, Harvard)
-		</li>
-	</ul>
-		
-	<a name="thu_posters" id="thu_posters"></a>
-	<strong>Posters</strong>
-	<ul>
-	    <li>Impacts of Aromatic Chemistry on the Global Atmosphere (Stephen MacFarlane, U. Wollongong)</li>
-	    <li>Investigating the combined constraints on isoprene emissions from satellite observations of isoprene, HCHO, and NO2 (Uzzal Kumar Dash, U. Minnesota)</li>
-	    <li>Investigating the role of marine aerosols in the critical stratocumulus region over the Southeast Atlantic ocean (Mashiat Hossain, UIUC)</li>
-	    <li>Size-resolved and seasonal aerosol depletion of chlorine and bromine in Bermuda during BLEACH (Alli Moon, U. Washington)</li>
-	    <li>Assessing GEOS-Chem representation of regional and long-range transport of VOCs using observations from the Mount Bachelor Observatory, OR (Wade Permar, U. Montana)</li>
-	    <li>Unintended consequences of enhanced atmospheric methane oxidation (Hannah Horowitz, UIUC)</li>
-	    <li>Evaluating OH, O3, and PAN in Biomass Burning Plumes: Insights from MCM and GEOS-Chem Mechanisms (Lu Hu, U Montana)</li>
-	    <li>Contribution of biomass burning to North American air quality from 2000-2022 using satellites, GEOS-Chem and ground-based observations (Aaron van Donkelaar, WashU)</li>
-	    <li>Assessing wildfire-induced ozone production across scales (Joe Palmo, MIT)</li>
-	    <li>Biomass Burning – A comparative study between ACE-FTS observations and the GEOS-Chem High Performance Model (Kevin Bloxam, U. Toronto)</li>
-	    <li>Investigating the effects of combustion phase on modeled wildland fire plume vertical distribution and air quality (Soroush Neyestani, UC Riverside)</li>
-	    <li>Evaluating Cross track Infrared Sounder (CrIS) retrievals of Volatile Organic Compounds (VOCs) in wildfire smoke plumes using aircraft observations and GEOS-Chem model output (Julieta Juncosa Calahorrano, U. Minnesota)</li>
-	    <li>Constraining vertical distribution of aerosols in GEOS-Chem: estimation of surface PM2.5 during wildfire events over continental United States and Canada (Inderjeet Singh, WashU)</li>
-	    <li>Simulating stratospheric halogen partitioning in the 2020-2021 Australian wildfire plume (Will Julstrom, U. Iowa)</li>
-	    <li>Detecting and quantifying wildfire VOCs using airborne remote sensing (Chengyuan Hu, U. Minnesota)</li>
-	    <li>Quantifying CO emissions from boreal wildfires using CHEEREIO with TROPOMI and TCCON data (Dylan Jones, U. Toronto)</li>
-	    <li>Quantifying the global methane budget based on TROPOMI satellite measurements (Xueying Yu, Stanford)</li>
-	    <li>Inferring global methane emissions from blended TROPOMI+GOSAT observations using the Integrated Methane Inversion (IMI) (Megan He, Harvard)</li>
-	    <li>Evaluation of a new high-resolution gridded inventory of methane for New York State in GEOS-Chem using surface and satellite measurements (Matt Loman, U. Rochester)</li>
-	    <li>Leveraging chlorine for reassessment of the global methane budget at and since the Last Glacial Maximum (Xin Tie, U. Rochester)</li>
-	    <li>Inferring global methane emissions from an ensemble Kalman filter at weekly 2°x2.5° degree resolution using TROPOMI observations (Drew Pendergrass, Harvard)</li>
-	</ul>
-</div>
+<a name="tuewg" id="tue_wg"></a>
+<strong>Working Group Breakouts</strong>
 
-<div>
-	<h2>
-		Friday, June 14
-	</h2>
-	
-	<a name="wg" id="wg"></a>
-	<strong>GEOS-Chem Working Group Priorities (chair: Randall Martin, WashU)</strong>
-	<ul>
-	    <li>
-			<a href="https://drive.google.com/file/d/14BzRDDfX2iiI1v0RF8R-qD8w0vuYuF1i/view?usp=drive_link">Emissions</a> (Eloise Marais, U. College London)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1Qum_f2TUZqINATIBkljzm7jAqokBmyE0/view?usp=drive_link">Chemistry</a> (Lu Hu, U. Montana)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1qivKd_yWOWQfOp6rKF4VZkdgJGVv22uO/view?usp=drive_link">Aerosols</a> (Becky Alexander, U. Washington)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1_rH1T29imPifCQSt9ax_-_El18j-RI1q/view?usp=drive_link">Chemistry-climate</a> (Lee Murray, U. Rochester)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/16_VmTZ_eSGv3aEC9cC7fSd5spANq0sW4/view?usp=drive_link">Model adjoint and data assimilation</a> (Daven Henze, CU Boulder)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/19Q6duIwhvlP4NYHSEjzLm1Ht89ufC98H/view?usp=drive_link">Transport</a> (Katie Travis, NASA LaRC)
-		</li>
-		<li>
-			Surface-atmosphere exchange (Amos Tai, Chinese U. Hong Kong)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/10TpPbbF0fl3BIubHrczorGe4Q_fi3QFA/view?usp=drive_link">Carbon gases</a> (Dylan Jones, U. Toronto)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1TUn1MnGnZok6OpOU6aZ60wIXj2SGIZ7W/view?usp=drive_link">Software engineering</a> (Bob Yantosca, Harvard)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1h4IdSyptg5I3q-_-mDFYC6TFQPUWE15g/view?usp=drive_link">Mercury and POPs</a> (Viral Shah, NASA GMAO)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1SKp99tJb_dGXU-bUIUy_JXRyH1wMwXv_/view?usp=drive_link">Stratosphere</a> (Dylan Jones, U. Toronto)
-		</li>
-	</ul>
-	
-	<a name="future" id="future"></a>
-	<strong>Looking ahead (Chair: Randall Martin, WashU)</strong>
-    <ul>
-		<li>
-			<a href="https://drive.google.com/file/d/1ZJM1zk4azcZmSQCuzdbb7fMrlKf99i9m/view?usp=drive_link">Potential GEOS-Chem contributions to CMIP7</a> (Lee Murray, U. Rochester)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1MMLRhveVE6fq-63dVCKH6KaIvobtB-CC/view?usp=drive_link">Open discussion on GEOS-Chem priorities</a> (Randall Martin, WashU, discussion lead)
-		</li>
-	</ul>
-</div>
+<ul>
+  <li>
+    Emissions Working Group (chairs: Eloise Marais, U. College London; Lyatt Jaeglé, U. Washington; Jintai Lin, Peking U.)
+  </li>
+  <li>
+    Chemistry-Climate Working Group (chairs: Lee Murray, U. Rochester; Hong Liao, NUIST)
+  </li>
+  <li>
+    Transport Working Group (chairs: Katie Travis, NASA LaRC; Andrew Schuh, CSU)
+  </li>
+  <li>
+    Stratosphere Working Group (chairs: Seb Eastham, MIT; Dylan Jones, U. Toronto; Pam Wales, NASA GSFC)
+  </li>
+</ul>
+
+<a name="tue_posters" id="tue_posters"></a>
+<strong>Posters</strong>
+
+<ul>
+  <li>Constraining the California ammonia budget (Will Porter, UC Riverside)</li>
+  <li>Modeling the effect of drought stress on biogenic isoprene emissions in South Korea (Yongcheol Jeong, U. Houston)</li>
+  <li>Isoprene emissions impact atmospheric oxidative capacity and methane lifetimes (James Yoon, U. Washington)</li>
+  <li>Estimating the contribution of anthropogenic NOx emissions to the 2019 global annual pediatric asthma health burden attributable to NO2 with the GEOS Chem adjoint (Patrick Wiecko, CU Boulder)</li>
+  <li>GEOS-Chem-APM for (1) physics-guided machine learning parameterizations and (2) aerosol pollution exposure and health disparities (Arshad Nair, SUNY Albany)</li>
+  <li>Linking water usage to future air quality: Adding a source of halogens from playa dust to GEOS-Chem (Joey Bail, U. Utah)</li>
+  <li>Near-real-time satellite AOD measurements and chemical transport modeling (Tessa Clarizio, UIUC)</li>
+  <li>Investigating rocket launch emissions impact variation with changing launch latitude (Helena McDonald, MIT)</li>
+  <li>Modeling and remote Sensing of NO2 and HCHO diurnal variability: Results from Boston and Salt Lake City (Jeff Geddes, Boston U.)</li>
+  <li>A bias-corrected GEMS NO2 satellite product and its applications (Yujin Oak, Harvard)</li>
+  <li>Constraining model sulfate production mechanisms with observations in South Korea (Katie Travis, NASA LaRC)</li>
+  <li>Emission inventories underestimate black carbon in the Global South as revealed by comparison of GCHP simulations with measurements (Yuxuan Ren, WashU)</li>
+  <li>Background ozone in China (Danyuting Zhang, NUIST and Harvard)</li>
+  <li>Ozone production, VOC sources, and model-measurement comparisons from the AEROMMA field campaign (Kelvin Bates, NOAA CSL and CU Boulder)</li>
+  <li>Enhancing regional estimation of fine particulate matter species concentrations by including GEOS-Chem a priori information into deep learning (Siyuan Shen, WashU)</li>
+  <li>Impacts of anthropogenic emissions and meteorology on spring ozone differences in San Antonio, Texas between 2017 and 2021 (Tabitha Lee, U. Houston)
+  <li>Interpretating driving factors of global diel fine particulate matter variation using GEOS- Chem and in situ observations (Yanshun Li, WashU)</li>
+  <li>Evaluating WRF-GC v2.0 predictions of boundary layer height and vertical ozone profile during the 2021 TRACER-AQ campaign in Houston, Texas (Shailaja Wasti, U, Houston)</li>
+  <li>Constraining summertime anthropogenic VOC emissions in Salt Lake City, Utah (Emily Cope, U. Montana)</li>
+  <li>Adding a source of halogens from road-salt applications to GEOS-Chem (Shuying Zhao, U. Utah)</li>
+  <li>Wildfire emissions and impact in Missoula, Montana during 2021 wildfire season (Lu Tan, U. Montana)</li>
+</ul>
+
+<h2>Wednesday, June 12</h2>
+
+<a name="chemistryI" id="chemistryI"></a>
+<strong>Chemistry I (Chair: Lu Hu, U. Montana)</strong>
+
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/14axS-PYXbvEMIvEW7MLLt4M46AjzjgRW/view?usp=drive_link">Drivers of increasingly high tropospheric ozone in East Asia</a> (Nadia Colombi, Harvard)
+  </li>
+  <li>
+    The shrinking climate niche for tropospheric ozone and mercury depletion events (Chris Holmes, FSU)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1wRn4bsy0dMciu0dDpgXMZK5ndQM97lmd/view?usp=drive_link">Interpreting GEMS geostationary satellite observations of the diurnal variation of nitrogen dioxide (NO2) over East Asia</a> (Laura Yang, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1WzEGZgVx_20d1zBXWUcEqndl9Nv5zVbc/view?usp=drive_link">Using GEOS-Chem to interpret summertime hourly variation of NO2 columns with implications for geostationary satellite applications</a> (Deepangsu Chatterjee, WashU)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/17VOkG1bwpe6FVsEuc-1q1R9hltFmq_HB/view?usp=drive_link">Development, evaluation and interpretation of a simultaneous simulation of CH4, 13CH4 and CH3D within GEOS-Chem during the Recent Hiatus Period</a> (Mingjian Shi, U. Rochester)
+  </li>
+</ul>
+
+<a name="model_dev" id="model_dev"></a>
+<strong>Model developments (Chair: Hannah Horowitz, UIUC)</strong>
+
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1P5rki2Az0biEkb3svFJRivo_S3uyPqCa/view?usp=drive_link">Intercomparison of GEOS-Chem and CAM-chem tropospheric oxidant chemistry within the Community Earth System Model version 2 (CESM2)</a> (Haipeng Lin, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1nGxKdrQkR6Rh4viVHYxMugw5mJjtYtbK/view?usp=drive_link">Using GCHP with containers and clouds</a> (Yidan Tang, WashU)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Xiy4oZDvzpkwHTZUBCgcv02luoXA7f7w/view?usp=drive_link">Integrated Methane Inversion (IMI 2.0)</a> (Melissa Sulprizio, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1mZEUyJCJ5FqpkCkwyR5vAmFvd7AOjyXp/view?usp=drive_link">New GEOS-Chem developments to examine biosphere-agriculture-atmosphere interactions and implications for air quality</a> (Amos Tai, Chinese U. Hong Kong)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Cwas8vzif40cuOHecrXIoLSkHlsKCXr6/view?usp=drive_link">Impact of GCHP spatial resolution on global geophysical satellite-derived fine particulate matter</a> (Dandan Zhang, WashU)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1yQxpxid0yN3YUl75x-zH69ucG0mIWQ1G/view?usp=drive_link">Chemistry in the twilight zone: creation of a mechanism analysis interface for GEOS- Chem to address a computational bottleneck in air quality forecasts</a> (Obin Sturm, USC)
+  </li>
+</ul>
+
+<a name="aerosols" id="aerosols"></a>
+<strong>Aerosols (Chair: Colette Heald, ETH)</strong>
+
+<ul>
+  <li>
+    KEYNOTE: Evolution of reactive organic carbon and its toxicity in wildfire plumes (Havala Pye, EPA)
+  </li>
+  <li>
+    Impact of horizontal resolution on aerosol number and size in GCHP-TOMAS (Betty Croft, WashU and Dalhousie)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/14m32oXndzdQfpGbk3tGzwxbDdotCSUG8/view?usp=drive_link">Impact of air refreshing and cloud ice uptake limitations on vertical profiles and wet depositions of nitrate, ammonium, and sulfate</a> (Gan Luo, SUNY Albany)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1P6bdeZf2IOWkKbiSIl4IoPI1LaHXUzOc/view?usp=drive_link">Diagnosing the sensitivity of particulate nitrate to precursor emissions using satellite observations of NH3 and NO2</a> (Ruijun Dang, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1aWtYNdcfMRANB3wxUTL0RMnEZv86vCSd/view?usp=drive_link">Global spatial variation in the PM2.5 to AOD relationship and Its driving factors</a> (Haihui Zhu, WashU)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1oy-_VA5PEiPcH-6dHOg2Vjbtcv3o38gd/view?usp=drive_link">Capturing the relative-humidity-sensitive gas–particle partitioning of organic aerosols in GEOS-Chem</a> (Camilo Serrano Damha, McGill)
+  </li>
+</ul>
+
+<a name="wed_wg" id="wed_wg"></a>
+<strong>Working Group Breakouts</strong>
+
+<ul>
+  <li>
+    Aerosols Working Group (chairs: Becky Alexander, U. Washington; Jeff Pierce, CSU; Will Porter, UC Riverside; Fangqun Yu, SUNY-Albany)
+  </li>
+  <li>
+    Carbon gases Working Group (chairs: Kevin Bowman, JPL; Dylan Jones, U. Toronto)
+  </li>
+  <li>
+    Surface-atmosphere exchange Working Group (chairs: Jeff Geddes, Boston U.; Chris Holmes, Florida State U.; Amos Tai, Chinese U. Hong Kong)
+  </li>
+  <li>
+    Hg and POPs Working Group (chairs: Jenny Fisher, U Wollongong; Hannah Horowitz, UIUC; Yanxu Zhang, Nanjing U.)
+  </li>
+</ul>
+
+<a name="wed_posters" id="wed_posters"></a>
+<strong>Posters</strong>
+
+<ul>
+  <li>2022 GEOS-Chem v14 ozone evaluation using sondes, satellites and surface measurements (Barron Henderson, EPA)</li>
+  <li>A new source of HO2? (Paolo Sebastianelli, U. Wollongong)</li>
+  <li>Variable sensitivity of GCHP simulated ozone to grid resolution: combined effects from meteorology and chemistry (Chi Li, WashU)</li>
+  <li>Improved representation of lightning NOx in GEOS-Chem informed by vertical profiles of NO2 and O3 from cloud-slicing TROPOMI (Bex Horner, U. College London)</li>
+  <li>Current chemical mechanisms fail to reproduce trends in DMS oxidation products observed in Arctic ice cores (Ursula Jongebloed, U. Washington)</li>
+  <li>Development and evaluation of dimethyl sulfide oxidation mechanism in the marine atmosphere (Linia Tashmim, UC Riverside)</li>
+  <li>Characterizing the global tropospheric budget of NOy (Ishir Dutta, MIT)</li>
+  <li>Global model of atmospheric chlorate (Yuk Chun Chan, U. Washington)</li>
+  <li>Space-based observations of tropospheric ethane map emissions from fossil fuel extraction (Jared Brewer, U Minnesota)</li>
+  <li>Automated GEOS-Chem mechanism emulator for F0AM box model (Jessica Haskins, U. Utah)</li>
+  <li>GCHP-EnKF multi-constituent satellite data assimilation (Kazuyuki Miyazaki, JPL)</li>
+  <li>GEOS-Chem-hyd: Enabling calculation of numerically exact, second-order sensitivities (Samuel Akinjole, Drexel)</li>
+  <li>Lagrangian versus Eulerian perspectives of new particle formation events (Sam O’Donnell. Colorado State U.)</li>
+  <li>Calculation of sub-micron and super-micron particle fluxes by coupling CALIPSO and GEOS-Chem (Ajmal Rasheeda, North Carolina State U.)</li>
+  <li>Integrated model-measurement approaches to laboratory SOA studies (Hannah Kenagy, MIT)</li>
+  <li>Reconciling differences of GEOS-Chem simulations and globally-distributed ground- based measurements of mineral dust (Yu Yan, WashU)</li>
+  <li>Global simulations of secondary organic aerosol phase state and equilibration timescales with GEOS-Chem (Regina Luu, UC Irvine)</li>
+  <li>Framework for modeling dark-brown carbon optical properties (Taveen Singh Kapoor, WashU)</li>
+  <li>Using accumulated precipitation and air mass history along transport trajectories to interpret aerosol observations over the western North Atlantic Ocean (Bo Zhang, National Institute of Aerospace)</li>
+  <li>Global modeling of organic aerosols based on a new emission inventory and an updated mechanism in GEOS-Chem (Ruochong Xu, Tsinghua U.)</li>
+</ul>
+
+<h2>Thursday, June 13</h2>
+
+<a name="chemistryII" id="chemistryII"></a>
+<strong>Chemistry II (Chair: Becky Alexander, U. Washington)</strong>
+
+<ul>
+  <li>
+    Joint inversion of formaldehyde and isoprene to constrain non-methane VOC emissions (Jinkyul Choi, CU Boulder)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Gj9mPCrCGvb_HbvPcuJBkimUGvTHxY2k/view?usp=drive_link">A vertically-resolved canopy significantly improves chemical transport model predictions of ozone deposition to north temperate forests</a> (Michael Vermeuel, U. Minnesota)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/14lzyXChC_pI1blCtdDbIcTHCAMSawBsw/view?usp=drive_link">Assessing the role of RO2 accretion reactions in SOA formation</a> (Alfred Mayhew, U. Utah)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1SiCy6nPrUFOZF2kkw4N4AH9qyf53m5wM/view?usp=drive_link">Evaluation of formaldehyde (HCHO) diurnal variability over North America using Pandonia Global Network (PGN)</a> (Tianlang Zhao, U. Alaska Fairbanks)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1k07wsJk6IO2TytaaRB1hi7lyWq-ynW2L/view?usp=drive_link">Global chemical impacts of furanoids: model analysis and constraints from in-situ observations</a> (Lixu Jin, U. Montana)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1BO7cML3ErP8xzuUks4L_k-5MI8CRDdjH/view?usp=drive_link">GEOS-Chem Adjoint as a decision support tool in Europe</a> (Yixuan Gu, CU Boulder)
+  </li>
+</ul>
+
+<a name="fires" id="fires"></a>
+<strong>Fires (Chair: Jingqiu Mao, U. Alaska Fairbanks)</strong>
+
+<ul>
+  <li>
+    The impact of smoke PM on ozone photochemical regimes (Jiaqi Shen, Rutgers)
+  </li>
+  <li>
+    Drivers of smoke air quality in the western United States from 1992 to 2020: natural variability and anthropogenic climate change (Xu Feng, Harvard)
+  </li>
+  <li>
+    Global PM2.5 exposure and health impacts from 2023 Canada extreme wildfire (Yuexuanzi Wang, Tsinghua)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1BKeJgdySoErNRCVOimlGVBeif-pFgoMa/view?usp=drive_link">Influence of model resolution on wildfire impact</a> (Anas Ali, U. Toronto)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1uuTWke6iSTrAOHmrqd1Wdk4Qt1BxYHqS/view?usp=drive_link">When smoke goes up: Effects of biomass burning plume injection height in GEOS-Chem-TOMAS</a> (Nicole June, Colorado State U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1S7o7OKsto0tTDTxGqOnG_EiwFNPMl5vb/view?usp=drive_link">Assessing wildfire emissions of CO using 4D-Var inverse modelling</a> (Olalekan Balogun, U. Toronto)
+  </li>
+</ul>
+
+<a name="carbon" id="carbon"></a>
+<strong>Carbon gases (Chair: Prasad Kasibhatla, Duke)</strong>
+
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1ned3n4Vf691AhokhDNT6JZpi7wfs46x-/view?usp=drive_link">KEYNOTE: GEOS Modeling in Support of the U.S. Greenhouse Gas Center: Challenges and opportunities in stakeholder-driven product development</a> (Lesley Ott, NASA GSFC)
+  </li>
+  <li>
+    Inverse modeling of satellite methane and in-situ carbon isotopic observations shows that inundation of the wet tropics drove the 2020-2022 methane surge (Zhen Qu, North Carolina State U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Oeji6_adO3DLE-VaIKbwWrTQtAYgImWw/view?usp=drive_link">Interpreting the seasonality of atmospheric methane</a> (James East, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1hGFHBJc-9vN1k4P5Swp4wl-lQwXo2xZg/view?usp=drive_link">Quantifying urban and landfill methane emissions in the US using inverse modeling of TROPOMI data at 12 km resolution</a> (Xiaolin Wang, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1nI22ylJ2h8qWBkeaR5G8xHfC_257tK-M/view?usp=drive_link">Analytical estimation of carbon dioxide fluxes and information content from OCO-2 satellite data</a> (Hannah Nesser, JPL)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1DIeAFwj4HcfYWHJIcKB1rGytxLn_75g6/view?usp=drive_link">Observation-based assessment of China's methane emissions</a> (Yuzhong Zhang, Westlake)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1fymd7-3cwYVo5NGJCvHPZ3jykkwyR0Km/view?usp=drive_link">Stratospheric methane in GEOS-Chem and its implications for inversions</a> (Todd Mooring, Harvard)
+  </li>
+</ul>
+
+<a name="thu_wg" id="thu_wg"></a>
+<strong>Working Group Breakouts</strong>
+
+<ul>
+  <li>
+    Chemistry Working Group (chairs: Barron Henderson, US EPA; Lu Hu, U. Montana)
+  </li>
+  <li>
+    Adjoint Model and Data Assimilation Working Group (chairs: Daven Henze, U. Colorado; Jun Wang, U. Iowa)
+  </li>
+  <li>
+    Software engineering Working Group (chairs: Lizzie Lundgren, Harvard; Melissa Sulprizio, Harvard; Bob Yantosca, Harvard)
+  </li>
+</ul>
+
+<a name="thu_posters" id="thu_posters"></a>
+<strong>Posters</strong>
+
+<ul>
+  <li>Impacts of Aromatic Chemistry on the Global Atmosphere (Stephen MacFarlane, U. Wollongong)</li>
+  <li>Investigating the combined constraints on isoprene emissions from satellite observations of isoprene, HCHO, and NO2 (Uzzal Kumar Dash, U. Minnesota)</li>
+  <li>Investigating the role of marine aerosols in the critical stratocumulus region over the Southeast Atlantic ocean (Mashiat Hossain, UIUC)</li>
+  <li>Size-resolved and seasonal aerosol depletion of chlorine and bromine in Bermuda during BLEACH (Alli Moon, U. Washington)</li>
+  <li>Assessing GEOS-Chem representation of regional and long-range transport of VOCs using observations from the Mount Bachelor Observatory, OR (Wade Permar, U. Montana)</li>
+  <li>Unintended consequences of enhanced atmospheric methane oxidation (Hannah Horowitz, UIUC)</li>
+  <li>Evaluating OH, O3, and PAN in Biomass Burning Plumes: Insights from MCM and GEOS-Chem Mechanisms (Lu Hu, U Montana)</li>
+  <li>Contribution of biomass burning to North American air quality from 2000-2022 using satellites, GEOS-Chem and ground-based observations (Aaron van Donkelaar, WashU)</li>
+  <li>Assessing wildfire-induced ozone production across scales (Joe Palmo, MIT)</li>
+  <li>Biomass Burning – A comparative study between ACE-FTS observations and the GEOS-Chem High Performance Model (Kevin Bloxam, U. Toronto)</li>
+  <li>Investigating the effects of combustion phase on modeled wildland fire plume vertical distribution and air quality (Soroush Neyestani, UC Riverside)</li>
+  <li>Evaluating Cross track Infrared Sounder (CrIS) retrievals of Volatile Organic Compounds (VOCs) in wildfire smoke plumes using aircraft observations and GEOS-Chem model output (Julieta Juncosa Calahorrano, U. Minnesota)</li>
+  <li>Constraining vertical distribution of aerosols in GEOS-Chem: estimation of surface PM2.5 during wildfire events over continental United States and Canada (Inderjeet Singh, WashU)</li>
+  <li>Simulating stratospheric halogen partitioning in the 2020-2021 Australian wildfire plume (Will Julstrom, U. Iowa)</li>
+  <li>Detecting and quantifying wildfire VOCs using airborne remote sensing (Chengyuan Hu, U. Minnesota)</li>
+  <li>Quantifying CO emissions from boreal wildfires using CHEEREIO with TROPOMI and TCCON data (Dylan Jones, U. Toronto)</li>
+  <li>Quantifying the global methane budget based on TROPOMI satellite measurements (Xueying Yu, Stanford)</li>
+  <li>Inferring global methane emissions from blended TROPOMI+GOSAT observations using the Integrated Methane Inversion (IMI) (Megan He, Harvard)</li>
+  <li>Evaluation of a new high-resolution gridded inventory of methane for New York State in GEOS-Chem using surface and satellite measurements (Matt Loman, U. Rochester)</li>
+  <li>Leveraging chlorine for reassessment of the global methane budget at and since the Last Glacial Maximum (Xin Tie, U. Rochester)</li>
+  <li>Inferring global methane emissions from an ensemble Kalman filter at weekly 2°x2.5° degree resolution using TROPOMI observations (Drew Pendergrass, Harvard)</li>
+</ul>
+
+<h2>Friday, June 14</h2>
+
+<a name="wg" id="wg"></a>
+<strong>GEOS-Chem Working Group Priorities (chair: Randall Martin,
+  WashU)</strong>
+
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/14BzRDDfX2iiI1v0RF8R-qD8w0vuYuF1i/view?usp=drive_link">Emissions</a> (Eloise Marais, U. College London)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Qum_f2TUZqINATIBkljzm7jAqokBmyE0/view?usp=drive_link">Chemistry</a> (Lu Hu, U. Montana)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1qivKd_yWOWQfOp6rKF4VZkdgJGVv22uO/view?usp=drive_link">Aerosols</a> (Becky Alexander, U. Washington)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1_rH1T29imPifCQSt9ax_-_El18j-RI1q/view?usp=drive_link">Chemistry-climate</a> (Lee Murray, U. Rochester)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/16_VmTZ_eSGv3aEC9cC7fSd5spANq0sW4/view?usp=drive_link">Model adjoint and data assimilation</a> (Daven Henze, CU Boulder)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/19Q6duIwhvlP4NYHSEjzLm1Ht89ufC98H/view?usp=drive_link">Transport</a> (Katie Travis, NASA LaRC)
+  </li>
+  <li>
+    Surface-atmosphere exchange (Amos Tai, Chinese U. Hong Kong)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/10TpPbbF0fl3BIubHrczorGe4Q_fi3QFA/view?usp=drive_link">Carbon gases</a> (Dylan Jones, U. Toronto)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1TUn1MnGnZok6OpOU6aZ60wIXj2SGIZ7W/view?usp=drive_link">Software engineering</a> (Bob Yantosca, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1h4IdSyptg5I3q-_-mDFYC6TFQPUWE15g/view?usp=drive_link">Mercury and POPs</a> (Viral Shah, NASA GMAO)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1SKp99tJb_dGXU-bUIUy_JXRyH1wMwXv_/view?usp=drive_link">Stratosphere</a> (Dylan Jones, U. Toronto)
+  </li>
+</ul>
+
+<a name="future" id="future"></a>
+<strong>Looking ahead (Chair: Randall Martin, WashU)</strong>
+  <ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1ZJM1zk4azcZmSQCuzdbb7fMrlKf99i9m/view?usp=drive_link">Potential GEOS-Chem contributions to CMIP7</a> (Lee Murray, U. Rochester)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1MMLRhveVE6fq-63dVCKH6KaIvobtB-CC/view?usp=drive_link">Open discussion on GEOS-Chem priorities</a> (Randall Martin, WashU, discussion lead)
+  </li>
+</ul>
 
 </div>
 </div>
@@ -586,64 +566,16 @@ The 11th International GEOS-Chem Meeting (IGC11) June 11-14, 2024
 </div>
 </div>
 
-<!--footer region beg-->
+<!--footer-->
 <footer id="footer" class="clearfix" role="contentinfo">
-
-<!-- Three column 3x33 Gpanel -->
-<div class="at-panel gpanel panel-display footer clearfix">
-<div class="region region-footer">
-<div class="region-inner clearfix">
-<div id="block-boxes-1617037690" class="block block-boxes block-boxes-os_boxes_html no-title"  module="boxes" delta="1617037690">
-<div class="block-inner clearfix">  
-<div class="block-content content" ng-non-bindable="">  
-<div id='boxes-box-1617037690' class='boxes-box'>  
 <div class="boxes-box-content">
   <p style="text-align:center">
-    Copyright © 2024 by the International GEOS-Chem Community. All rights reserved.
+    Copyright © 2026 by the International GEOS-Chem Community. All rights reserved.
   </p>
 </div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-<div class="region region-footer-bottom">  
-<div class="region-inner clearfix">  
-<div id="block-boxes-1616879798" class="block block-boxes block-boxes-os_boxes_media no-title"  module="boxes" delta="1616879798">  
-<div class="block-inner clearfix">  
-<div class="block-content content"> 
-<div id='boxes-box-1616879798' class='boxes-box'> 
-<div class="boxes-box-content"> 
-<div id="file-3900146" class="file file-html file-html-embed">
-<h2 class="element-invisible"><a href="">css-brand</a></h2>
-<div class="content">
-<div class="file-info">
-</div>
-<div class="field field-name-field-html-code field-type-text-long field-label-hidden view-mode-full">
-<div class="field-items">
-<div class="field-item even">
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-
-<!--footer region end-->
 </footer>
-</div>
-</div>
 
-<!--page area ends-->
-<div id="extradiv"></div>
+</div>
 </div>
 
 </body>

--- a/igc11.html
+++ b/igc11.html
@@ -1,9 +1,4 @@
 <!DOCTYPE html>
-<!--[if IEMobile 7]><html class="iem7"  lang="en" dir="ltr"><![endif]-->
-<!--[if lte IE 6]><html class="lt-ie9 lt-ie8 lt-ie7"  lang="en" dir="ltr"><![endif]-->
-<!--[if (IE 7)&(!IEMobile)]><html class="lt-ie9 lt-ie8"  lang="en" dir="ltr"><![endif]-->
-<!--[if IE 8]><html class="lt-ie9"  lang="en" dir="ltr"><![endif]-->
-<!--[if (gte IE 9)|(gt IEMobile 7)]><!--><html  lang="en" dir="ltr"><!--<![endif]-->
 <head>
 <meta charset="utf-8" />
 <!--<base href="/igc11" />-->
@@ -18,23 +13,12 @@
 <title>The 11th International GEOS-Chem Meeting</title>
 <meta http-equiv="x-ua-compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<link type="text/css" rel="stylesheet" href="css/css_xE-rWrJf-fncB6ztZfd2huxqgxu4WO-qwma6Xer30m4%EF%B9%96m=1675397288.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_1kR8T1_c-l5pBT6ZwbDT7BFda-4fyqW9Jjum29_2IY8%EF%B9%96m=1675397312.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_YnlUIvHP13qgpYEqubzE8JyDwlSxUnVibfnVkSoSDb0%EF%B9%96m=1675397273.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_Ku-3OcT9qU9h7dnGig5e23q6EVryY8orK4wzVDxsweE%EF%B9%96m=1675397367.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_vprtFTrWyg23GbY50_zJZHWGYMNfS8vsrRS26i4-ISk%EF%B9%96m=1675397406.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_dW-aNNrctRhQNc-KECjtQd0PxuW-h19IEum-TX2MeEk%EF%B9%96m=1675397301.css" media="print" />
-<link type="text/css" rel="stylesheet" href="css/css_SH2Lx3Qprh0GZo_9xRp85U9NsWfkSXn_Bi-rJoMY1sw%EF%B9%96m=1675397273.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_uaIDKcYMUK5osSQXuirpr3ZleXtnnpBN-eiECm7N0M0%EF%B9%96m=1675397395.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/responsive.blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/geos-chem.css" media="all"/>
 <script type="text/javascript" src="dropdown-menu.js"></script>
-<!--[if lte IE 8]>
-<script type="text/javascript">
-  var os_c = document.createElement;os_c('header');os_c('nav');os_c('section');os_c('article');os_c('aside');os_c('footer');os_c('hgroup');os_c('figure');
-</script>
-<![endif]-->
 </head>
 
 <body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-1585687 node-type-page og-context og-context-node og-context-node-1585652 navbar-on">
@@ -45,7 +29,7 @@
 <div id="page_wrap" class="page_wrap">
 <div id="page" class="container page header-main content-top footer-none">
 <div id="page-wrapper">
-		
+    
 <!--header regions beg-->
 <header id="header" class="clearfix" role="banner">
 <div id="header-container">
@@ -76,16 +60,16 @@ The 11th International GEOS-Chem Meeting (IGC11) June 11-14, 2024
 
 <!--main menu region beg-->
 <div id="menu-bar" class="nav region-menu-bar clearfix">
-<nav id="block-os-igc11-menu" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="igc11_menu">  
-<ul class="nice-menu nice-menu-down nice-menu-igc11_menu" id="nice-menu-igc11_menu">
-  <li class="menu-857212 menu-path-node-1586486  first   odd  "><a href="igc11.html" >Home</a></li>
-  <li class="menu-857214 menu-path-node-1586487   even  "><a href="igc11-presentations.html"  title="">Presentations and Posters</a></li>
-  <!-- <li class="menu-857216 menu-path-node-1586490   odd   last "><a href="igc11-webcast.html" >Webcast Archive</a></li> -->
+<nav id="block-os-igc11-menu" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="igc11_menu">
+<ul class="nice-menu nice-menu-down">
+  <li><a href="igc11.html" class="active">IGC11 Home</a></li>
+  <li><a href="igc11-presentations.html">Presentations and Posters</a></li>
+  <li><a href="index.html">GEOS-Chem Home</a></li>
 </ul>
 </nav>
 </div>
 <!--main menu region end-->
-		
+    
 <div id="columns" class="clearfix">
 <div class="hg-container">
 <div id="content-column" role="main">
@@ -94,7 +78,7 @@ The 11th International GEOS-Chem Meeting (IGC11) June 11-14, 2024
 <header id="main-content-header">
 <a name="main-content"></a>
 </header>
-														
+                            
 <!--front panel regions beg-->
 <div id="content-panels" class="at-panel gpanel panel-display content clearfix">
 <div class="region region-content-top">
@@ -109,32 +93,26 @@ The 11th International GEOS-Chem Meeting (IGC11) June 11-14, 2024
 <div class="field-item even">
   
 <p style="text-align:center">
-	<img height="600" width="800" alt="IGC11 group photo" class="media-element file-default file-os-files-xlarge" src="img/igc11_photo.jpg" title="" /></p>
+  <img height="600" width="800" alt="IGC11 group photo" class="media-element file-default file-os-files-xlarge" src="img/igc11_photo.jpg" title="" /></p>
 
-<p align="justify">
-	The 11th International GEOS-Chem Meeting (IGC11) was held at Washington University in St. Louis (Missouri, USA) on June 11-14, 2024 with <a href="https://drive.google.com/file/d/1kbHHMc2di-mDn-fv7_uObpQdgDbuuwOY/view?usp=sharing" target="_blank" title="">278 registrants from 96 institutions and 22 countries</a>. Model clinics were held on June 10, 2024. Follow the links for:
-</p>
+<p>The 11th International GEOS-Chem Meeting (IGC11) was held at Washington University in St. Louis (Missouri, USA) on June 11-14, 2024 with <a href="https://drive.google.com/file/d/1kbHHMc2di-mDn-fv7_uObpQdgDbuuwOY/view?usp=sharing" target="_blank" title="">278 registrants from 96 institutions and 22 countries</a>. Model clinics were held on June 10, 2024. Follow the links for:</p>
 
-<ul><li>
-		<a href="igc11-presentations.html" title="">Oral and poster presentations from the meeting</a>;
-	</li>
-	<li>
-		<a href="http://wiki.seas.harvard.edu/geos-chem/index.php/GEOS-Chem_model_development_priorities" title="">Model development priority list coming out of the meeting</a>.
-	</li>
-</ul><p>
-	We are grateful for the financial support for the meeting offered by NASA, NSF, NOAA, EPRI, and the Washington University in St. Louis James McKelvey School of Engineering, Center for the Environment, and McDonnell Academy.
-</p>
+<ul>
+  <li>
+    <a href="igc11-presentations.html" title="">Oral and poster presentations from the meeting</a>;
+  </li>
+  <li>
+    <a href="http://wiki.seas.harvard.edu/geos-chem/index.php/GEOS-Chem_model_development_priorities" title="">Model development priority list coming out of the meeting</a>.
+  </li>
+</ul>
 
-<p>
-	We look forward to seeing you at the 12th International GEOS-Chem Meeting.
-</p>
+<p>We are grateful for the financial support for the meeting offered by NASA, NSF, NOAA, EPRI, and the Washington University in St. Louis James McKelvey School of Engineering, Center for the Environment, and McDonnell Academy.</p>
 
-<p>
-	<a href="steering-committee.html" target="_blank" title="">The GEOS-Chem Steering Committee</a>
-</p>
+<p>We look forward to seeing you at the 12th International GEOS-Chem Meeting.</p>
 
-<p style="text-align:center">
-	<img height="364" width="832" alt="IGC11 sponsors" class="media-element file-default file-os-files-xxlarge" src="img/igc11_sponsors.png" title="" /></p>
+<p><a href="steering-committee.html" target="_blank" title="">The GEOS-Chem Steering Committee</a></p>
+
+<p style="text-align:center"><img height="364" width="832" alt="IGC11 sponsors" class="media-element file-default file-os-files-xxlarge" src="img/igc11_sponsors.png" title="" /></p>
 
 </div>
 </div>
@@ -154,64 +132,16 @@ The 11th International GEOS-Chem Meeting (IGC11) June 11-14, 2024
 </div>
 </div>
 
-<!--footer region beg-->
+<!--footer-->
 <footer id="footer" class="clearfix" role="contentinfo">
-
-<!-- Three column 3x33 Gpanel -->
-<div class="at-panel gpanel panel-display footer clearfix">
-<div class="region region-footer">
-<div class="region-inner clearfix">
-<div id="block-boxes-1617037690" class="block block-boxes block-boxes-os_boxes_html no-title"  module="boxes" delta="1617037690">
-<div class="block-inner clearfix">  
-<div class="block-content content" ng-non-bindable="">  
-<div id='boxes-box-1617037690' class='boxes-box'>  
 <div class="boxes-box-content">
   <p style="text-align:center">
-    Copyright © 2024 by the International GEOS-Chem Community. All rights reserved.
+    Copyright © 2026 by the International GEOS-Chem Community. All rights reserved.
   </p>
 </div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-<div class="region region-footer-bottom">  
-<div class="region-inner clearfix">  
-<div id="block-boxes-1616879798" class="block block-boxes block-boxes-os_boxes_media no-title"  module="boxes" delta="1616879798">  
-<div class="block-inner clearfix">  
-<div class="block-content content"> 
-<div id='boxes-box-1616879798' class='boxes-box'> 
-<div class="boxes-box-content"> 
-<div id="file-3900146" class="file file-html file-html-embed">
-<h2 class="element-invisible"><a href="">css-brand</a></h2>
-<div class="content">
-<div class="file-info">
-</div>
-<div class="field field-name-field-html-code field-type-text-long field-label-hidden view-mode-full">
-<div class="field-items">
-<div class="field-item even">
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-
-<!--footer region end-->
 </footer>
-</div>
-</div>
 
-<!--page area ends-->
-<div id="extradiv"></div>
+</div>
 </div>
 
 </body>

--- a/igc2-presentations.html
+++ b/igc2-presentations.html
@@ -1,9 +1,4 @@
 <!DOCTYPE html>
-<!--[if IEMobile 7]><html class="iem7"  lang="en" dir="ltr"><![endif]-->
-<!--[if lte IE 6]><html class="lt-ie9 lt-ie8 lt-ie7"  lang="en" dir="ltr"><![endif]-->
-<!--[if (IE 7)&(!IEMobile)]><html class="lt-ie9 lt-ie8"  lang="en" dir="ltr"><![endif]-->
-<!--[if IE 8]><html class="lt-ie9"  lang="en" dir="ltr"><![endif]-->
-<!--[if (gte IE 9)|(gt IEMobile 7)]><!--><html  lang="en" dir="ltr"><!--<![endif]-->
 <head>
 <meta charset="utf-8" />
 <!--<base href="/igc2-presentations" />-->
@@ -18,23 +13,12 @@
 <title>The 2nd GEOS-Chem Meeting</title>
 <meta http-equiv="x-ua-compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<link type="text/css" rel="stylesheet" href="css/css_xE-rWrJf-fncB6ztZfd2huxqgxu4WO-qwma6Xer30m4%EF%B9%96m=1675397288.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_1kR8T1_c-l5pBT6ZwbDT7BFda-4fyqW9Jjum29_2IY8%EF%B9%96m=1675397312.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_YnlUIvHP13qgpYEqubzE8JyDwlSxUnVibfnVkSoSDb0%EF%B9%96m=1675397273.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_Ku-3OcT9qU9h7dnGig5e23q6EVryY8orK4wzVDxsweE%EF%B9%96m=1675397367.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_vprtFTrWyg23GbY50_zJZHWGYMNfS8vsrRS26i4-ISk%EF%B9%96m=1675397406.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_dW-aNNrctRhQNc-KECjtQd0PxuW-h19IEum-TX2MeEk%EF%B9%96m=1675397301.css" media="print" />
-<link type="text/css" rel="stylesheet" href="css/css_SH2Lx3Qprh0GZo_9xRp85U9NsWfkSXn_Bi-rJoMY1sw%EF%B9%96m=1675397273.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_uaIDKcYMUK5osSQXuirpr3ZleXtnnpBN-eiECm7N0M0%EF%B9%96m=1675397395.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/responsive.blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/geos-chem.css" media="all"/>
 <script type="text/javascript" src="dropdown-menu.js"></script>
-<!--[if lte IE 8]>
-<script type="text/javascript">
-  var os_c = document.createElement;os_c('header');os_c('nav');os_c('section');os_c('article');os_c('aside');os_c('footer');os_c('hgroup');os_c('figure');
-</script>
-<![endif]-->
 </head>
 
 <body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-1585687 node-type-page og-context og-context-node og-context-node-1585652 navbar-on">
@@ -45,19 +29,19 @@
 <div id="page_wrap" class="page_wrap">
 <div id="page" class="container page header-main content-top footer-none">
 <div id="page-wrapper">
-		
+
 <!--header regions beg-->
 <header id="header" class="clearfix" role="banner">
 <div id="header-container">
 <div id="header-panels" class="at-panel gpanel panel-display three-col clearfix">
 <div class="region region-header-second"><div class="region-inner clearfix">
 <section id="block-boxes-1630413211" class="block block-boxes block-boxes-os_boxes_html"  module="boxes" delta="1630413211">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <h2 class="block-title" ng-non-bindable="">Site-Logo</h2>
 <div class="block-content content" ng-non-bindable="">
 <div id='boxes-box-1630413211' class='boxes-box'>
 <div class="boxes-box-content">
-<img height="551" width="1101" style="float: right; width: 350px; height: 175px; margin-bottom: 1.5em;" alt="gca2 logo" class="media-element file-default file-os-files-xxlarge" src="https://static.projects.iq.harvard.edu/files/styles/os_files_xxlarge/public/acmg-geos/files/img-logo-igc10.png?m=1617306663&amp;itok=ghgvQrVn" title="" />
+<img height="551" width="1101" style="float: right; width: 350px; height: 175px; margin-bottom: 1.5em;" alt="ig logo" class="media-element file-default file-os-files-xxlarge" src="img/igc-early-logo.png" title="" />
 <h2 class="css-brand--css-geos-meetings-header-h2-xxxlarge">
   The 2nd GEOS-Chem Scientific and Users' Meeting (IGC2)<br />April 4-6 2005
 </h2>
@@ -76,15 +60,16 @@
 
 <!--main menu region beg-->
 <div id="menu-bar" class="nav region-menu-bar clearfix">
-<nav id="block-os-igc2-menu" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="igc2_menu">  
-<ul class="nice-menu nice-menu-down nice-menu-igc2_menu" id="nice-menu-igc2_menu">
-  <li class="menu-861158 menu-path-node-1587331  first   odd  "><a href="igc2.html"  class="active">Home</a></li>
-  <li class="menu-861168 menu-path-node-1587334   even   last "><a href="igc2-presentations.html" >Presentations</a></li>
+<nav id="block-os-igc2-menu" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="igc2_menu">
+<ul class="nice-menu nice-menu-down">
+  <li><a href="igc2.html" class="active">IGC2 Home</a></li>
+  <li><a href="igc2-presentations.html">Presentations and Posters</a></li>
+  <li><a href="index.html">GEOS-Chem Home</a></li>
 </ul>
 </nav>
 </div>
 <!--main menu region end-->
-		
+
 <div id="columns" class="clearfix">
 <div class="hg-container">
 <div id="content-column" role="main">
@@ -93,14 +78,14 @@
 <header id="main-content-header">
 <a name="main-content"></a>
 <h1 id="page-title" ng-non-bindable="">Presentations</h1>
-</header> 
-														
+</header>
+
 <!--front panel regions beg-->
 <div id="content-panels" class="at-panel gpanel panel-display content clearfix">
 <div class="region region-content-top">
 <div class="region-inner clearfix">
 <div id="block-os-pages-main-content" class="block block-os-pages no-title"  module="os_pages" delta="main_content">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <div class="block-content content" ng-non-bindable="">
 <article id="node-1585687" class="node node-page article clearfix" role="article">
 <div class="node-content" ng-non-bindable="">
@@ -109,300 +94,300 @@
 <div class="field-item even">
 
 <p>
-	<strong>Mon Apr 4</strong>:  <a href="#overview">Model Overview</a> | <a href="#gtc">Global Trop. Chemistry</a> | <a href="#aerosols">Global Aerosols</a> | <a href="#it">Intercontinental Transport</a>
+ <strong>Mon Apr 4</strong>:  <a href="#overview">Model Overview</a> | <a href="#gtc">Global Trop. Chemistry</a> | <a href="#aerosols">Global Aerosols</a> | <a href="#it">Intercontinental Transport</a>
 </p>
 
 <p>
-	<strong>Tue Apr 5</strong>:  <a href="#coco2">CO, CO2, Black Carbon</a> | <a href="#noxvoc">NOx and VOC's</a> | <a href="#exp">Expanding Model Capabilities</a> | <a href="#aq">Regional Air Quality</a>
+ <strong>Tue Apr 5</strong>:  <a href="#coco2">CO, CO2, Black Carbon</a> | <a href="#noxvoc">NOx and VOC's</a> | <a href="#exp">Expanding Model Capabilities</a> | <a href="#aq">Regional Air Quality</a>
 </p>
 
 <p>
-	<strong>Wed Apr 6</strong>:  <a href="#gcb">Global Chemical Budgets</a> | <a href="#issues">Model Issues &amp; Model Future</a>
+ <strong>Wed Apr 6</strong>:  <a href="#gcb">Global Chemical Budgets</a> | <a href="#issues">Model Issues &amp; Model Future</a>
 </p>
 
 <h2>
-	Monday, April 4 2005
+ Monday, April 4 2005
 </h2>
 
 <h3>
-	<a name="overview" id="overview"></a>Model Overview (Daniel Jacob, chair)
+ <a name="overview" id="overview"></a>Model Overview (Daniel Jacob, chair)
 </h3>
 
 <ul>
-	<li>
-		Welcome, Daniel Jacob, Harvard University
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1nY34xTSyeuYrrVWFDCidJ1LOJNqcohRK/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">The GEOS-Chem model: present state, future directions</a>, Daniel Jacob, Harvard University
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1X6S0plcdc8t0RchQN4H66TqWeyyGkEvI/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">GEOS-Chem code management and benchmarking</a>, Bob Yantosca, Harvard University
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1YTxb-ilFXp92x2AAubsWpshEC6C-MvXX/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Data distribution and model performance</a>, Jack Yatteau, Harvard University
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/186kpww-XCzw6li0ERlF5pnWOXGfZf_vJ/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">GEOS-Chem near-real-time simulation</a>, Solene Turquety, Harvard University
-	</li>
+ <li>
+  Welcome, Daniel Jacob, Harvard University
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1nY34xTSyeuYrrVWFDCidJ1LOJNqcohRK/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">The GEOS-Chem model: present state, future directions</a>, Daniel Jacob, Harvard University
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1X6S0plcdc8t0RchQN4H66TqWeyyGkEvI/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">GEOS-Chem code management and benchmarking</a>, Bob Yantosca, Harvard University
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1YTxb-ilFXp92x2AAubsWpshEC6C-MvXX/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Data distribution and model performance</a>, Jack Yatteau, Harvard University
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/186kpww-XCzw6li0ERlF5pnWOXGfZf_vJ/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">GEOS-Chem near-real-time simulation</a>, Solene Turquety, Harvard University
+ </li>
 </ul>
 
 <h3>
-	<a name="gtc" id="gtc"></a>Global Tropospheric Chemistry (Qinbin Li, chair)
+ <a name="gtc" id="gtc"></a>Global Tropospheric Chemistry (Qinbin Li, chair)
 </h3>
 
 <ul>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1PrccK34alvf8-vFVdSh0k3IO_mweXRfm/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">IPCC AR4 results</a>, Jerome Drevet, EPFL
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1rKuD0AOJ6p-Vu_zCo8znKfiLqhQqX58a/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Evolving simulation of OH and ozone in GEOS-Chem</a>, Jennifer Logan, Harvard University
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1WCvA0uORDM5FFx8iOnfAM7Mmw3ZSW6CD/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Radiative effects of clouds on tropospheric chemistry</a>, Hongyu Liu, NASA/LaRC
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1e371pu5PCgOBgllfM6JMMKsdYcN8Mhus/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Comparison of GEOS-Chem with OH observations</a>, Mat Evans, University of Leeds
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1QFqPKdQVuKqpZcmNT4AS84I3h9w7j7iT/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Evaluation of GEOS-Chem with GOME tropospheric ozone columns</a>, Xiong Liu, CfA
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1kJq1O34pvboxEDwgf9j7WQs79QUn-iVj/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Comparison of TES ozone with GEOS-Chem and global budget of methanol</a>, Daniel Jacob, Harvard University
-	</li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1PrccK34alvf8-vFVdSh0k3IO_mweXRfm/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">IPCC AR4 results</a>, Jerome Drevet, EPFL
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1rKuD0AOJ6p-Vu_zCo8znKfiLqhQqX58a/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Evolving simulation of OH and ozone in GEOS-Chem</a>, Jennifer Logan, Harvard University
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1WCvA0uORDM5FFx8iOnfAM7Mmw3ZSW6CD/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Radiative effects of clouds on tropospheric chemistry</a>, Hongyu Liu, NASA/LaRC
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1e371pu5PCgOBgllfM6JMMKsdYcN8Mhus/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Comparison of GEOS-Chem with OH observations</a>, Mat Evans, University of Leeds
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1QFqPKdQVuKqpZcmNT4AS84I3h9w7j7iT/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Evaluation of GEOS-Chem with GOME tropospheric ozone columns</a>, Xiong Liu, CfA
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1kJq1O34pvboxEDwgf9j7WQs79QUn-iVj/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Comparison of TES ozone with GEOS-Chem and global budget of methanol</a>, Daniel Jacob, Harvard University
+ </li>
 </ul>
 
 <h3>
-	<a name="aerosols" id="aerosols"></a>Global Aerosols (Randall Martin, chair)
+ <a name="aerosols" id="aerosols"></a>Global Aerosols (Randall Martin, chair)
 </h3>
 
 <ul>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1fWT9MyLpvv7SeFR8TsT0cWSqDy69V_t3/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Background aerosols in North America</a>, Rokjin Park, Harvard University
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1jjh51mrtXQNj3GhdqctJWloCGe3WmI_5/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Sea salt chemistry and sulfate formation pathways</a>, Becky Alexander, Harvard University
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1ViTw2GBHxGAd9xSGQ_mAgZs-hREOeW4y/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Global simulation of secondary organic carbon aerosols</a>, Hong Liao, Caltech
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1apVWulliunudlypEaeFjpyiU6Men6gXy/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Global dust modeling</a>, Duncan Fairlie, NASA/LaRC and Harvard University
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1-n8aAQV8gBrdEHmwFldaIBpBxIXkf4yQ/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Evaluation of GEOS-Chem AOTs: comparisons to satellite data</a> (POLDER, MODIS), Sylvia Generoso, EPFL
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1tHWlfsz1OPESWR9Ynl2qB6PmGcGiMpFp/view?usp=drive_link" target="_blank">Aerosol phase transitions and radiative implications</a>, Scot Martin, Harvard University
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1RDIV6WZsksYwJWNK7bvSMAi45zkZuHQk/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Use of GEOS-Chem backscattered radiances for comparison to MODIS</a>, Easan Drury, Harvard University
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1vYozHGp-Ivw2-y4R-UUGrfpikPYgF3w7/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Aerosol microphysics simulation</a>, Win Trivitayanurak, Carnegie-Mellon University
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1BXb1A_VGUBr5OAPZnJEDg9EYE6BgYUH_/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Size-resolved carbonaceous and dust aerosols</a>, Peter Adams, Carnegie-Mellon University
-	</li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1fWT9MyLpvv7SeFR8TsT0cWSqDy69V_t3/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Background aerosols in North America</a>, Rokjin Park, Harvard University
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1jjh51mrtXQNj3GhdqctJWloCGe3WmI_5/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Sea salt chemistry and sulfate formation pathways</a>, Becky Alexander, Harvard University
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1ViTw2GBHxGAd9xSGQ_mAgZs-hREOeW4y/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Global simulation of secondary organic carbon aerosols</a>, Hong Liao, Caltech
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1apVWulliunudlypEaeFjpyiU6Men6gXy/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Global dust modeling</a>, Duncan Fairlie, NASA/LaRC and Harvard University
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1-n8aAQV8gBrdEHmwFldaIBpBxIXkf4yQ/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Evaluation of GEOS-Chem AOTs: comparisons to satellite data</a> (POLDER, MODIS), Sylvia Generoso, EPFL
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1tHWlfsz1OPESWR9Ynl2qB6PmGcGiMpFp/view?usp=drive_link" target="_blank">Aerosol phase transitions and radiative implications</a>, Scot Martin, Harvard University
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1RDIV6WZsksYwJWNK7bvSMAi45zkZuHQk/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Use of GEOS-Chem backscattered radiances for comparison to MODIS</a>, Easan Drury, Harvard University
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1vYozHGp-Ivw2-y4R-UUGrfpikPYgF3w7/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Aerosol microphysics simulation</a>, Win Trivitayanurak, Carnegie-Mellon University
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1BXb1A_VGUBr5OAPZnJEDg9EYE6BgYUH_/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Size-resolved carbonaceous and dust aerosols</a>, Peter Adams, Carnegie-Mellon University
+ </li>
 </ul>
 
 <h3>
-	<a name="it" id="it"></a>Intercontinental Transport (Prasad Kasibhatla, chair)
+ <a name="it" id="it"></a>Intercontinental Transport (Prasad Kasibhatla, chair)
 </h3>
 
 <ul>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1SqdkfXzJjBTf6VndZHjjNHnIjMBywlcy/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Transpacific transport of Asian pollution aerosols and effects on U.S. air quality</a>, Colette Heald, Harvard University
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1-VEm0Bk1BmDnJ4_yFZa8SbFohsB74Rv2/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Meteorological indices for transpacific transport of Asian pollution</a>, Qing Liang, University of Washington
-	</li>
-	<li>
-		Trapping of convective outflow by upper-level anticyclones, Qinbin Li, JPL
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1TKYk3TE9Jp0AGjxLsOvjxmLW0Z2iRirT/view?usp=drive_link" target="_blank">Export of North American ozone and NOy constrained from ICARTT</a> observations, Rynda Hudman, Harvard University
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/16_6pDkaRKcH0HG6rAyGnrBKmC-pw05Jl/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Evaluation of ozone production and loss rates using aircraft observations</a>, Marion Auvray, EPFL
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1c8wYQ2ytKrV5gwVYCWQaR-WldduHAEYQ/view?usp=drive_link" target="_blank">Transatlantic transport of tropospheric ozone and its precursors</a>, Guerguana Guerova, EPFL
-	</li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1SqdkfXzJjBTf6VndZHjjNHnIjMBywlcy/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Transpacific transport of Asian pollution aerosols and effects on U.S. air quality</a>, Colette Heald, Harvard University
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1-VEm0Bk1BmDnJ4_yFZa8SbFohsB74Rv2/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Meteorological indices for transpacific transport of Asian pollution</a>, Qing Liang, University of Washington
+ </li>
+ <li>
+  Trapping of convective outflow by upper-level anticyclones, Qinbin Li, JPL
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1TKYk3TE9Jp0AGjxLsOvjxmLW0Z2iRirT/view?usp=drive_link" target="_blank">Export of North American ozone and NOy constrained from ICARTT</a> observations, Rynda Hudman, Harvard University
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/16_6pDkaRKcH0HG6rAyGnrBKmC-pw05Jl/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Evaluation of ozone production and loss rates using aircraft observations</a>, Marion Auvray, EPFL
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1c8wYQ2ytKrV5gwVYCWQaR-WldduHAEYQ/view?usp=drive_link" target="_blank">Transatlantic transport of tropospheric ozone and its precursors</a>, Guerguana Guerova, EPFL
+ </li>
 </ul>
 
 <h2>
-	Tuesday, April 5, 2005
+ Tuesday, April 5, 2005
 </h2>
 
 <h3>
-	<a name="coco2" id="coco2"></a>Inverse modeling of emissions: CO, CO2, black carbon (Jennifer Logan, chair)
+ <a name="coco2" id="coco2"></a>Inverse modeling of emissions: CO, CO2, black carbon (Jennifer Logan, chair)
 </h3>
 
 <ul>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1uON-fQ-ZuoHaVHZC0CQR6hg_gQS46n0f/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">CO inverse modeling</a>, Avelino Arellano, Duke
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1vDwqu4_6zEELzNuu2uzaPaUad-g1YYJA/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Effect of boreal forest fires on CO</a>, Fok-Yan Leung, Harvard University
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1zgx-ENlhZJsX-OVMJuoxtRSbwWhI_Ocw/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Inverse modeling of North American CO sources during ICARTT</a>, Solene Turquety, Harvard University
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1tV8OGz4E4N0L7Rtt0DKhBK3N1F9MIujR/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Inverse modeling of Asian CO and NOx emissions</a>, Yuxuan Wang, Harvard University
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1pfzBGnfC-ObBgpKO6BISHgyFWj3EwuCI/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Constraints on Asian carbon sources from a coupled CO-CO2 inversion</a>, Paul Palmer, Harvard University
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1AfAalxaWvvBMggVNGo4CactZ_tjhp6se/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Chemical pump effect on atmospheric CO2 inversions</a>, Parvadha Suntharalingam, Harvard University
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1C_lM6P-1qD3qJEfQ-LJxJ-qe-uWhPAMG/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Exploiting satellite observations of tropospheric trace gases</a>, Dylan Jones, University of Toronto
-	</li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1uON-fQ-ZuoHaVHZC0CQR6hg_gQS46n0f/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">CO inverse modeling</a>, Avelino Arellano, Duke
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1vDwqu4_6zEELzNuu2uzaPaUad-g1YYJA/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Effect of boreal forest fires on CO</a>, Fok-Yan Leung, Harvard University
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1zgx-ENlhZJsX-OVMJuoxtRSbwWhI_Ocw/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Inverse modeling of North American CO sources during ICARTT</a>, Solene Turquety, Harvard University
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1tV8OGz4E4N0L7Rtt0DKhBK3N1F9MIujR/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Inverse modeling of Asian CO and NOx emissions</a>, Yuxuan Wang, Harvard University
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1pfzBGnfC-ObBgpKO6BISHgyFWj3EwuCI/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Constraints on Asian carbon sources from a coupled CO-CO2 inversion</a>, Paul Palmer, Harvard University
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1AfAalxaWvvBMggVNGo4CactZ_tjhp6se/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Chemical pump effect on atmospheric CO2 inversions</a>, Parvadha Suntharalingam, Harvard University
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1C_lM6P-1qD3qJEfQ-LJxJ-qe-uWhPAMG/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Exploiting satellite observations of tropospheric trace gases</a>, Dylan Jones, University of Toronto
+ </li>
 </ul>
 
 <h3>
-	<a name="noxvoc" id="noxvoc"></a>Inverse modeling of emissions: NOx and VOCs (Yuhang Wang, chair)
+ <a name="noxvoc" id="noxvoc"></a>Inverse modeling of emissions: NOx and VOCs (Yuhang Wang, chair)
 </h3>
 
 <ul><li>
-		<a href="https://docs.google.com/presentation/d/1ed_a9OdKPV7FT5JHRLcuHNBlD6pHqGja/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Global partitioning of NOx emissions using satellite observations</a>, Lyatt Jaeglé, University of Washington
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1vss9Yh67BV2E0752b67yzxhntEewvC83/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">North American NOx emission inventory</a>, Randall Martin, Dalhousie University
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1cgrz4PxUREFwRV-U7Jn7y8lowRRg1c7O/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Modeling oxygen isotopes of nitrate with GEOS-Chem</a>, Meredith Hastings, University of Washington
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/10H9RqhMjoVdZ6m2UUoh5K6ToB16rVVGF/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Constraints from GOME HCHO on global isoprene emission</a>, Changshub Shim, Georgia Tech
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1UQLW4lI2yw7ghrw-0hMo7czk37BMrZwg/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Constraints on Asian VOC sources from GOME HCHO observations</a>, May Fu, Harvard University
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1E4osp9Gg34WbQRnJ8godcTybi_hHdSyR/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">HCHO columns over Europe as proxy for biogenic emissions</a>, Gabriele Curci, University of L'Aquila
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1osQL5R9WsPQb9cRkaZvpaajxzIwU_54P/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Variability of HCHO during ICARTT: implications for GOME/OMI interpretation</a>, Dylan Millet, Harvard University
-	</li>
+  <a href="https://docs.google.com/presentation/d/1ed_a9OdKPV7FT5JHRLcuHNBlD6pHqGja/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Global partitioning of NOx emissions using satellite observations</a>, Lyatt Jaeglé, University of Washington
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1vss9Yh67BV2E0752b67yzxhntEewvC83/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">North American NOx emission inventory</a>, Randall Martin, Dalhousie University
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1cgrz4PxUREFwRV-U7Jn7y8lowRRg1c7O/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Modeling oxygen isotopes of nitrate with GEOS-Chem</a>, Meredith Hastings, University of Washington
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/10H9RqhMjoVdZ6m2UUoh5K6ToB16rVVGF/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Constraints from GOME HCHO on global isoprene emission</a>, Changshub Shim, Georgia Tech
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1UQLW4lI2yw7ghrw-0hMo7czk37BMrZwg/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Constraints on Asian VOC sources from GOME HCHO observations</a>, May Fu, Harvard University
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1E4osp9Gg34WbQRnJ8godcTybi_hHdSyR/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">HCHO columns over Europe as proxy for biogenic emissions</a>, Gabriele Curci, University of L'Aquila
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1osQL5R9WsPQb9cRkaZvpaajxzIwU_54P/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Variability of HCHO during ICARTT: implications for GOME/OMI interpretation</a>, Dylan Millet, Harvard University
+ </li>
 </ul>
 
 <h3>
-	<a name="exp" id="exp"></a>Expanding model capabilities (Dylan Jones, chair)
+ <a name="exp" id="exp"></a>Expanding model capabilities (Dylan Jones, chair)
 </h3>
 
 <ul>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1z0Y8_xthxjZFcoPXnfUMrs9cLlVZVK-U/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Linking GEOS-Chem with CMAQ: consistency in meteorology and chemistry</a>, Daewon Byun, University of Houston
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1voMLXiq_lRHcQSRExKIkvcPXBXIU179h/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Evaluation of the GEOS-Chem/CMAQ interface over China and US</a>, Zuopan Li, University of Tennessee
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1XjhjLhYuXJU8epZjZ1-uHM4tl3Oc1CDP/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Running GEOS-Chem with GISS GCM fields</a>, Loretta Mickley, Harvard University
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1FV3QmTpFeit4krrTByVMhUCoCDncct4s/view?usp=drive_link" target="_blank">Parallelization of GEOS-Chem on a 1024-node Linux cluster based on MPI</a>, Kevin Bowman, JPL
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1BWbmfk-S58zUEMo_K19N_cGTjGt9gzde/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">GEOS-Chem adjoint development using TAF</a>, Monika Kopacz, Harvard University
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1oIxqVy0hcSvxK2ezxciWYVX44e6IvL21/view?usp=drive_link" target="_blank">Constructing an adjoint for GEOS-Chem</a>, Daven Henze, Caltech
-	</li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1z0Y8_xthxjZFcoPXnfUMrs9cLlVZVK-U/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Linking GEOS-Chem with CMAQ: consistency in meteorology and chemistry</a>, Daewon Byun, University of Houston
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1voMLXiq_lRHcQSRExKIkvcPXBXIU179h/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Evaluation of the GEOS-Chem/CMAQ interface over China and US</a>, Zuopan Li, University of Tennessee
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1XjhjLhYuXJU8epZjZ1-uHM4tl3Oc1CDP/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Running GEOS-Chem with GISS GCM fields</a>, Loretta Mickley, Harvard University
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1FV3QmTpFeit4krrTByVMhUCoCDncct4s/view?usp=drive_link" target="_blank">Parallelization of GEOS-Chem on a 1024-node Linux cluster based on MPI</a>, Kevin Bowman, JPL
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1BWbmfk-S58zUEMo_K19N_cGTjGt9gzde/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">GEOS-Chem adjoint development using TAF</a>, Monika Kopacz, Harvard University
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1oIxqVy0hcSvxK2ezxciWYVX44e6IvL21/view?usp=drive_link" target="_blank">Constructing an adjoint for GEOS-Chem</a>, Daven Henze, Caltech
+ </li>
 </ul>
 
 <h3>
-	<a name="aq" id="aq"></a>Regional air quality (Daewon Byun, chair)
+ <a name="aq" id="aq"></a>Regional air quality (Daewon Byun, chair)
 </h3>
 
 <ul>
-	<li>
-		<a href="https://docs.google.com/presentation/d/14AJvvqGJfmzCbAf_bRlsglin3ChQ14c6/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Sensitivity of surface ozone in the U.S. to isoprene emissions and chemistry</a>, Arlene Fiore, GFDL
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1ck4PsT4A04TgWnZDJvhn45UXdmcTB3gm/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Aerosol simulation over North America</a>, Aaron Van Donkelaar, Dalhousie University
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1vkPTf1sNN64J1JDK2NSF-lvM4SSYVvT8/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Impact of trans-boundary transport of aerosols on regional air quality</a>, Heejin In, University of Houston
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1WGJPwTX34PBptIudeHBdDmvXlXGFW9DR/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Nesting GEOS-Chem with a regional air pollution model for Greece</a>, Maria Tombrou-Tzella, Athens
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1ilqsvXn1qjLnXSqwk1FMZiXFVF5B8dwe/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Origin and distribution of ozone for the Eastern Mediterranean region</a>, Christos Giannakopoulos, Athens
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1RHeyJZjbmZlKHJaVVcCvnnvT67UUa2U_/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Effects of climate change on air quality</a>, Shiliang Wu, Harvard University
-	</li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/14AJvvqGJfmzCbAf_bRlsglin3ChQ14c6/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Sensitivity of surface ozone in the U.S. to isoprene emissions and chemistry</a>, Arlene Fiore, GFDL
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1ck4PsT4A04TgWnZDJvhn45UXdmcTB3gm/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Aerosol simulation over North America</a>, Aaron Van Donkelaar, Dalhousie University
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1vkPTf1sNN64J1JDK2NSF-lvM4SSYVvT8/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Impact of trans-boundary transport of aerosols on regional air quality</a>, Heejin In, University of Houston
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1WGJPwTX34PBptIudeHBdDmvXlXGFW9DR/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Nesting GEOS-Chem with a regional air pollution model for Greece</a>, Maria Tombrou-Tzella, Athens
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1ilqsvXn1qjLnXSqwk1FMZiXFVF5B8dwe/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Origin and distribution of ozone for the Eastern Mediterranean region</a>, Christos Giannakopoulos, Athens
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1RHeyJZjbmZlKHJaVVcCvnnvT67UUa2U_/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Effects of climate change on air quality</a>, Shiliang Wu, Harvard University
+ </li>
 </ul>
 
 <h2>
-	Wednesday, April 6, 2005
+ Wednesday, April 6, 2005
 </h2>
 
 <h3>
-	<a name="gcb" id="gcb"></a>Global chemical budgets (Lyatt Jaeglé, chair)
+ <a name="gcb" id="gcb"></a>Global chemical budgets (Lyatt Jaeglé, chair)
 </h3>
 
 <ul>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1w8rTlFmgxBmdRyUHme4v8oyPf1_6W7y4/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Role of ocean emissions in the mercury budget</a>, Sarah Strode, University of Washington
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1fpfOr9_ocEo7KGprcUo57ZCO-HcurCaM/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Global mercury modeling</a>, Noelle Eckley Selin, Harvard University
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/18W672MP5zP4ZQy_ggIQXbVSqpddAtXUT/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Global simulation of H2 and HD with GEOS-Chem</a>, Heather Price, University of Washington
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1_Ibk_7yqWynRYJpJUgwFo_gw_NUsolbD/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Coupled simulations of CO-ethane-HCN-acetylene</a>, Yaping Xiao, Harvard University
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/12yt314eO-pnDhgBCBlg84ERBoKn4bQbT/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Global sources and distributions of CH3Cl</a>, Yasuko Yoshida, Georgia Tech
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/12SQxCcgQgMEeba5SbywRx-EvwrL3fG3c/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Tracer correlation of ethane and propane</a>, Yuhang Wang, Georgia Tech
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1TWAX1HpkhqQXeGZzS6axUHGfinHnFIRx/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Global 3-D simulation of reactive bromine chemistry</a>, Tim Canty, JPL
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1-H4iF9cWvjqajF6C8Zn60CxSmBrI-zgc/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Modeling persistent organic pollutants (POPs) with GEOS-Chem</a>, Jordi Dachs, CSIC - Barcelona
-	</li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1w8rTlFmgxBmdRyUHme4v8oyPf1_6W7y4/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Role of ocean emissions in the mercury budget</a>, Sarah Strode, University of Washington
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1fpfOr9_ocEo7KGprcUo57ZCO-HcurCaM/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Global mercury modeling</a>, Noelle Eckley Selin, Harvard University
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/18W672MP5zP4ZQy_ggIQXbVSqpddAtXUT/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Global simulation of H2 and HD with GEOS-Chem</a>, Heather Price, University of Washington
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1_Ibk_7yqWynRYJpJUgwFo_gw_NUsolbD/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Coupled simulations of CO-ethane-HCN-acetylene</a>, Yaping Xiao, Harvard University
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/12yt314eO-pnDhgBCBlg84ERBoKn4bQbT/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Global sources and distributions of CH3Cl</a>, Yasuko Yoshida, Georgia Tech
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/12SQxCcgQgMEeba5SbywRx-EvwrL3fG3c/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Tracer correlation of ethane and propane</a>, Yuhang Wang, Georgia Tech
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1TWAX1HpkhqQXeGZzS6axUHGfinHnFIRx/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Global 3-D simulation of reactive bromine chemistry</a>, Tim Canty, JPL
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1-H4iF9cWvjqajF6C8Zn60CxSmBrI-zgc/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Modeling persistent organic pollutants (POPs) with GEOS-Chem</a>, Jordi Dachs, CSIC - Barcelona
+ </li>
 </ul>
 
 <h3>
-	<a name="issues" id="issues"></a>Model Issues, Model Future (Daniel Jacob, chair)
+ <a name="issues" id="issues"></a>Model Issues, Model Future (Daniel Jacob, chair)
 </h3>
 
 <ul>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1gAd6XkV3xD6cHGO461NL00nOW-vnImFS/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Emissions</a> (Jennifer Logan, discussion leader)
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1dvztkgS1oYamqDbK1iW_W8I9mhdSXfNR/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Aerosols</a> (Peter Adams, discussion leader)
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1-V8xiZ6B8beUjaSBiKN9dSKnX7pggc2Z/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true"" target="_blank">Chemistry</a> (Mat Evans, discussion leader)
-	</li>
-	<li>
-		Multimedia modeling (Lyatt Jaeglé, discussion leader)
-	</li>
-	<li>
-		Transport (Prasad Kasibhatla, discussion leader)
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/13zEC6-iShz7HIyFH1N8094SoJ5SLF4iE/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Nesting with regional models</a> (Daewon Byun, discussion leader)
-	</li>
-	<li>
-		Data assimilation (Dylan Jones, discussion leader)
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1qR3QkbbeL2bFoFOpE7y6XpXWrrqfzOdC/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Hardware/software issues</a> (Bob Yantosca, discussion leader)
-	</li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1gAd6XkV3xD6cHGO461NL00nOW-vnImFS/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Emissions</a> (Jennifer Logan, discussion leader)
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1dvztkgS1oYamqDbK1iW_W8I9mhdSXfNR/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Aerosols</a> (Peter Adams, discussion leader)
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1-V8xiZ6B8beUjaSBiKN9dSKnX7pggc2Z/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Chemistry</a> (Mat Evans, discussion leader)
+ </li>
+ <li>
+  Multimedia modeling (Lyatt Jaeglé, discussion leader)
+ </li>
+ <li>
+  Transport (Prasad Kasibhatla, discussion leader)
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/13zEC6-iShz7HIyFH1N8094SoJ5SLF4iE/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Nesting with regional models</a> (Daewon Byun, discussion leader)
+ </li>
+ <li>
+  Data assimilation (Dylan Jones, discussion leader)
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1qR3QkbbeL2bFoFOpE7y6XpXWrrqfzOdC/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Hardware/software issues</a> (Bob Yantosca, discussion leader)
+ </li>
 </ul>
 
 </div>
@@ -423,64 +408,16 @@
 </div>
 </div>
 
-<!--footer region beg-->
+<!--footer-->
 <footer id="footer" class="clearfix" role="contentinfo">
-
-<!-- Three column 3x33 Gpanel -->
-<div class="at-panel gpanel panel-display footer clearfix">
-<div class="region region-footer">
-<div class="region-inner clearfix">
-<div id="block-boxes-1617037690" class="block block-boxes block-boxes-os_boxes_html no-title"  module="boxes" delta="1617037690">
-<div class="block-inner clearfix">  
-<div class="block-content content" ng-non-bindable="">  
-<div id='boxes-box-1617037690' class='boxes-box'>  
 <div class="boxes-box-content">
   <p style="text-align:center">
-    Copyright © 2023 by the International GEOS-Chem Community. All rights reserved.
+    Copyright © 2026 by the International GEOS-Chem Community. All rights reserved.
   </p>
 </div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-<div class="region region-footer-bottom">  
-<div class="region-inner clearfix">  
-<div id="block-boxes-1616879798" class="block block-boxes block-boxes-os_boxes_media no-title"  module="boxes" delta="1616879798">  
-<div class="block-inner clearfix">  
-<div class="block-content content"> 
-<div id='boxes-box-1616879798' class='boxes-box'> 
-<div class="boxes-box-content"> 
-<div id="file-3900146" class="file file-html file-html-embed">
-<h2 class="element-invisible"><a href="">css-brand</a></h2>
-<div class="content">
-<div class="file-info">
-</div>
-<div class="field field-name-field-html-code field-type-text-long field-label-hidden view-mode-full">
-<div class="field-items">
-<div class="field-item even">
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-
-<!--footer region end-->
 </footer>
-</div>
-</div>
 
-<!--page area ends-->
-<div id="extradiv"></div>
+</div>
 </div>
 
 </body>

--- a/igc2-presentations.html
+++ b/igc2-presentations.html
@@ -41,10 +41,8 @@
 <div class="block-content content" ng-non-bindable="">
 <div id='boxes-box-1630413211' class='boxes-box'>
 <div class="boxes-box-content">
-<img height="551" width="1101" style="float: right; width: 350px; height: 175px; margin-bottom: 1.5em;" alt="ig logo" class="media-element file-default file-os-files-xxlarge" src="img/igc-early-logo.png" title="" />
-<h2 class="css-brand--css-geos-meetings-header-h2-xxxlarge">
-  The 2nd GEOS-Chem Scientific and Users' Meeting (IGC2)<br />April 4-6 2005
-</h2>
+<a href="https://geoschem.github.io/"><img height="600" width="1034" style="float: right; width: 350px; height: 203px;" class="media-element file-default file-os-files-xxlarge" src="img/GEOS-Chem_Logo_Square_Light_Background_Orig.png" alt="" title="" /></a>
+<h2 class="css-brand--css-geos-meetings-header-h2-xxxlarge">The 2nd GEOS-Chem Scientific and Users' Meeting (IGC2)<br />April 4-6 2005</h2>
 </div>
 </div>
 </div>
@@ -93,301 +91,270 @@
 <div class="field-items">
 <div class="field-item even">
 
-<p>
- <strong>Mon Apr 4</strong>:  <a href="#overview">Model Overview</a> | <a href="#gtc">Global Trop. Chemistry</a> | <a href="#aerosols">Global Aerosols</a> | <a href="#it">Intercontinental Transport</a>
-</p>
+<p><strong>Mon Apr 4</strong>:  <a href="#overview">Model Overview</a> | <a href="#gtc">Global Trop. Chemistry</a> | <a href="#aerosols">Global Aerosols</a> | <a href="#it">Intercontinental Transport</a></p>
 
-<p>
- <strong>Tue Apr 5</strong>:  <a href="#coco2">CO, CO2, Black Carbon</a> | <a href="#noxvoc">NOx and VOC's</a> | <a href="#exp">Expanding Model Capabilities</a> | <a href="#aq">Regional Air Quality</a>
-</p>
+<p> <strong>Tue Apr 5</strong>:  <a href="#coco2">CO, CO2, Black Carbon</a> | <a href="#noxvoc">NOx and VOC's</a> | <a href="#exp">Expanding Model Capabilities</a> | <a href="#aq">Regional Air Quality</a></p>
 
-<p>
- <strong>Wed Apr 6</strong>:  <a href="#gcb">Global Chemical Budgets</a> | <a href="#issues">Model Issues &amp; Model Future</a>
-</p>
+<p> <strong>Wed Apr 6</strong>:  <a href="#gcb">Global Chemical Budgets</a> | <a href="#issues">Model Issues &amp; Model Future</a></p>
 
-<h2>
- Monday, April 4 2005
-</h2>
+<h2>Monday, April 4 2005</h2>
 
-<h3>
- <a name="overview" id="overview"></a>Model Overview (Daniel Jacob, chair)
-</h3>
+<h3><a name="overview" id="overview"></a>Model Overview (Daniel Jacob, chair)</h3>
 
 <ul>
- <li>
-  Welcome, Daniel Jacob, Harvard University
+  <li>
+    Welcome, Daniel Jacob, Harvard University
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1nY34xTSyeuYrrVWFDCidJ1LOJNqcohRK/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">The GEOS-Chem model: present state, future directions</a>, Daniel Jacob, Harvard University
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1X6S0plcdc8t0RchQN4H66TqWeyyGkEvI/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">GEOS-Chem code management and benchmarking</a>, Bob Yantosca, Harvard University
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1YTxb-ilFXp92x2AAubsWpshEC6C-MvXX/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Data distribution and model performance</a>, Jack Yatteau, Harvard University
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/186kpww-XCzw6li0ERlF5pnWOXGfZf_vJ/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">GEOS-Chem near-real-time simulation</a>, Solene Turquety, Harvard University
+  </li>
+</ul>
+
+<h3><a name="gtc" id="gtc"></a>Global Tropospheric Chemistry (Qinbin Li, chair)</h3>
+
+<ul>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1PrccK34alvf8-vFVdSh0k3IO_mweXRfm/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">IPCC AR4 results</a>, Jerome Drevet, EPFL
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1rKuD0AOJ6p-Vu_zCo8znKfiLqhQqX58a/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Evolving simulation of OH and ozone in GEOS-Chem</a>, Jennifer Logan, Harvard University
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1WCvA0uORDM5FFx8iOnfAM7Mmw3ZSW6CD/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Radiative effects of clouds on tropospheric chemistry</a>, Hongyu Liu, NASA/LaRC
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1e371pu5PCgOBgllfM6JMMKsdYcN8Mhus/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Comparison of GEOS-Chem with OH observations</a>, Mat Evans, University of Leeds
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1QFqPKdQVuKqpZcmNT4AS84I3h9w7j7iT/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Evaluation of GEOS-Chem with GOME tropospheric ozone columns</a>, Xiong Liu, CfA
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1kJq1O34pvboxEDwgf9j7WQs79QUn-iVj/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Comparison of TES ozone with GEOS-Chem and global budget of methanol</a>, Daniel Jacob, Harvard University
+  </li>
+</ul>
+
+<h3><a name="aerosols" id="aerosols"></a>Global Aerosols (Randall Martin, chair)</h3>
+
+<ul>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1fWT9MyLpvv7SeFR8TsT0cWSqDy69V_t3/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Background aerosols in North America</a>, Rokjin Park, Harvard University
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1jjh51mrtXQNj3GhdqctJWloCGe3WmI_5/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Sea salt chemistry and sulfate formation pathways</a>, Becky Alexander, Harvard University
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1ViTw2GBHxGAd9xSGQ_mAgZs-hREOeW4y/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Global simulation of secondary organic carbon aerosols</a>, Hong Liao, Caltech
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1apVWulliunudlypEaeFjpyiU6Men6gXy/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Global dust modeling</a>, Duncan Fairlie, NASA/LaRC and Harvard University
+  </li>
+  <li>
+   <a href="https://docs.google.com/presentation/d/1-n8aAQV8gBrdEHmwFldaIBpBxIXkf4yQ/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Evaluation of GEOS-Chem AOTs: comparisons to satellite data</a> (POLDER, MODIS), Sylvia Generoso, EPFL
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1tHWlfsz1OPESWR9Ynl2qB6PmGcGiMpFp/view?usp=drive_link" target="_blank">Aerosol phase transitions and radiative implications</a>, Scot Martin, Harvard University
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1RDIV6WZsksYwJWNK7bvSMAi45zkZuHQk/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Use of GEOS-Chem backscattered radiances for comparison to MODIS</a>, Easan Drury, Harvard University
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1vYozHGp-Ivw2-y4R-UUGrfpikPYgF3w7/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Aerosol microphysics simulation</a>, Win Trivitayanurak, Carnegie-Mellon University
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1BXb1A_VGUBr5OAPZnJEDg9EYE6BgYUH_/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Size-resolved carbonaceous and dust aerosols</a>, Peter Adams, Carnegie-Mellon University
+  </li>
+</ul>
+
+<h3><a name="it" id="it"></a>Intercontinental Transport (Prasad Kasibhatla, chair)</h3>
+
+<ul>
+  <li>
+   <a href="https://docs.google.com/presentation/d/1SqdkfXzJjBTf6VndZHjjNHnIjMBywlcy/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Transpacific transport of Asian pollution aerosols and effects on U.S. air quality</a>, Colette Heald, Harvard University
  </li>
  <li>
-  <a href="https://docs.google.com/presentation/d/1nY34xTSyeuYrrVWFDCidJ1LOJNqcohRK/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">The GEOS-Chem model: present state, future directions</a>, Daniel Jacob, Harvard University
+   <a href="https://docs.google.com/presentation/d/1-VEm0Bk1BmDnJ4_yFZa8SbFohsB74Rv2/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Meteorological indices for transpacific transport of Asian pollution</a>, Qing Liang, University of Washington
  </li>
  <li>
-  <a href="https://docs.google.com/presentation/d/1X6S0plcdc8t0RchQN4H66TqWeyyGkEvI/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">GEOS-Chem code management and benchmarking</a>, Bob Yantosca, Harvard University
+   Trapping of convective outflow by upper-level anticyclones, Qinbin Li, JPL
  </li>
  <li>
-  <a href="https://docs.google.com/presentation/d/1YTxb-ilFXp92x2AAubsWpshEC6C-MvXX/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Data distribution and model performance</a>, Jack Yatteau, Harvard University
+   <a href="https://drive.google.com/file/d/1TKYk3TE9Jp0AGjxLsOvjxmLW0Z2iRirT/view?usp=drive_link" target="_blank">Export of North American ozone and NOy constrained from ICARTT</a> observations, Rynda Hudman, Harvard University
  </li>
  <li>
-  <a href="https://docs.google.com/presentation/d/186kpww-XCzw6li0ERlF5pnWOXGfZf_vJ/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">GEOS-Chem near-real-time simulation</a>, Solene Turquety, Harvard University
+   <a href="https://docs.google.com/presentation/d/16_6pDkaRKcH0HG6rAyGnrBKmC-pw05Jl/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Evaluation of ozone production and loss rates using aircraft observations</a>, Marion Auvray, EPFL
+ </li>
+ <li>
+   <a href="https://drive.google.com/file/d/1c8wYQ2ytKrV5gwVYCWQaR-WldduHAEYQ/view?usp=drive_link" target="_blank">Transatlantic transport of tropospheric ozone and its precursors</a>, Guerguana Guerova, EPFL
  </li>
 </ul>
 
-<h3>
- <a name="gtc" id="gtc"></a>Global Tropospheric Chemistry (Qinbin Li, chair)
-</h3>
+<h2>Tuesday, April 5, 2005</h2>
+
+<h3><a name="coco2" id="coco2"></a>Inverse modeling of emissions: CO, CO2, black carbon (Jennifer Logan, chair)</h3>
 
 <ul>
- <li>
-  <a href="https://docs.google.com/presentation/d/1PrccK34alvf8-vFVdSh0k3IO_mweXRfm/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">IPCC AR4 results</a>, Jerome Drevet, EPFL
+  <li>
+    <a href="https://docs.google.com/presentation/d/1uON-fQ-ZuoHaVHZC0CQR6hg_gQS46n0f/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">CO inverse modeling</a>, Avelino Arellano, Duke
  </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1rKuD0AOJ6p-Vu_zCo8znKfiLqhQqX58a/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Evolving simulation of OH and ozone in GEOS-Chem</a>, Jennifer Logan, Harvard University
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1WCvA0uORDM5FFx8iOnfAM7Mmw3ZSW6CD/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Radiative effects of clouds on tropospheric chemistry</a>, Hongyu Liu, NASA/LaRC
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1e371pu5PCgOBgllfM6JMMKsdYcN8Mhus/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Comparison of GEOS-Chem with OH observations</a>, Mat Evans, University of Leeds
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1QFqPKdQVuKqpZcmNT4AS84I3h9w7j7iT/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Evaluation of GEOS-Chem with GOME tropospheric ozone columns</a>, Xiong Liu, CfA
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1kJq1O34pvboxEDwgf9j7WQs79QUn-iVj/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Comparison of TES ozone with GEOS-Chem and global budget of methanol</a>, Daniel Jacob, Harvard University
- </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1vDwqu4_6zEELzNuu2uzaPaUad-g1YYJA/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Effect of boreal forest fires on CO</a>, Fok-Yan Leung, Harvard University
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1zgx-ENlhZJsX-OVMJuoxtRSbwWhI_Ocw/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Inverse modeling of North American CO sources during ICARTT</a>, Solene Turquety, Harvard University
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1tV8OGz4E4N0L7Rtt0DKhBK3N1F9MIujR/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Inverse modeling of Asian CO and NOx emissions</a>, Yuxuan Wang, Harvard University
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1pfzBGnfC-ObBgpKO6BISHgyFWj3EwuCI/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Constraints on Asian carbon sources from a coupled CO-CO2 inversion</a>, Paul Palmer, Harvard University
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1AfAalxaWvvBMggVNGo4CactZ_tjhp6se/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Chemical pump effect on atmospheric CO2 inversions</a>, Parvadha Suntharalingam, Harvard University
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1C_lM6P-1qD3qJEfQ-LJxJ-qe-uWhPAMG/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Exploiting satellite observations of tropospheric trace gases</a>, Dylan Jones, University of Toronto
+  </li>
 </ul>
 
-<h3>
- <a name="aerosols" id="aerosols"></a>Global Aerosols (Randall Martin, chair)
-</h3>
+<h3><a name="noxvoc" id="noxvoc"></a>Inverse modeling of emissions: NOx and VOCs (Yuhang Wang, chair)</h3>
 
 <ul>
- <li>
-  <a href="https://docs.google.com/presentation/d/1fWT9MyLpvv7SeFR8TsT0cWSqDy69V_t3/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Background aerosols in North America</a>, Rokjin Park, Harvard University
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1jjh51mrtXQNj3GhdqctJWloCGe3WmI_5/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Sea salt chemistry and sulfate formation pathways</a>, Becky Alexander, Harvard University
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1ViTw2GBHxGAd9xSGQ_mAgZs-hREOeW4y/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Global simulation of secondary organic carbon aerosols</a>, Hong Liao, Caltech
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1apVWulliunudlypEaeFjpyiU6Men6gXy/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Global dust modeling</a>, Duncan Fairlie, NASA/LaRC and Harvard University
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1-n8aAQV8gBrdEHmwFldaIBpBxIXkf4yQ/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Evaluation of GEOS-Chem AOTs: comparisons to satellite data</a> (POLDER, MODIS), Sylvia Generoso, EPFL
- </li>
- <li>
-  <a href="https://drive.google.com/file/d/1tHWlfsz1OPESWR9Ynl2qB6PmGcGiMpFp/view?usp=drive_link" target="_blank">Aerosol phase transitions and radiative implications</a>, Scot Martin, Harvard University
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1RDIV6WZsksYwJWNK7bvSMAi45zkZuHQk/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Use of GEOS-Chem backscattered radiances for comparison to MODIS</a>, Easan Drury, Harvard University
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1vYozHGp-Ivw2-y4R-UUGrfpikPYgF3w7/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Aerosol microphysics simulation</a>, Win Trivitayanurak, Carnegie-Mellon University
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1BXb1A_VGUBr5OAPZnJEDg9EYE6BgYUH_/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Size-resolved carbonaceous and dust aerosols</a>, Peter Adams, Carnegie-Mellon University
- </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1ed_a9OdKPV7FT5JHRLcuHNBlD6pHqGja/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Global partitioning of NOx emissions using satellite observations</a>, Lyatt Jaeglé, University of Washington
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1vss9Yh67BV2E0752b67yzxhntEewvC83/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">North American NOx emission inventory</a>, Randall Martin, Dalhousie University
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1cgrz4PxUREFwRV-U7Jn7y8lowRRg1c7O/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Modeling oxygen isotopes of nitrate with GEOS-Chem</a>, Meredith Hastings, University of Washington
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/10H9RqhMjoVdZ6m2UUoh5K6ToB16rVVGF/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Constraints from GOME HCHO on global isoprene emission</a>, Changshub Shim, Georgia Tech
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1UQLW4lI2yw7ghrw-0hMo7czk37BMrZwg/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Constraints on Asian VOC sources from GOME HCHO observations</a>, May Fu, Harvard University
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1E4osp9Gg34WbQRnJ8godcTybi_hHdSyR/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">HCHO columns over Europe as proxy for biogenic emissions</a>, Gabriele Curci, University of L'Aquila
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1osQL5R9WsPQb9cRkaZvpaajxzIwU_54P/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Variability of HCHO during ICARTT: implications for GOME/OMI interpretation</a>, Dylan Millet, Harvard University
+  </li>
 </ul>
 
-<h3>
- <a name="it" id="it"></a>Intercontinental Transport (Prasad Kasibhatla, chair)
-</h3>
+<h3><a name="exp" id="exp"></a>Expanding model capabilities (Dylan Jones, chair)</h3>
 
 <ul>
- <li>
-  <a href="https://docs.google.com/presentation/d/1SqdkfXzJjBTf6VndZHjjNHnIjMBywlcy/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Transpacific transport of Asian pollution aerosols and effects on U.S. air quality</a>, Colette Heald, Harvard University
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1-VEm0Bk1BmDnJ4_yFZa8SbFohsB74Rv2/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Meteorological indices for transpacific transport of Asian pollution</a>, Qing Liang, University of Washington
- </li>
- <li>
-  Trapping of convective outflow by upper-level anticyclones, Qinbin Li, JPL
- </li>
- <li>
-  <a href="https://drive.google.com/file/d/1TKYk3TE9Jp0AGjxLsOvjxmLW0Z2iRirT/view?usp=drive_link" target="_blank">Export of North American ozone and NOy constrained from ICARTT</a> observations, Rynda Hudman, Harvard University
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/16_6pDkaRKcH0HG6rAyGnrBKmC-pw05Jl/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Evaluation of ozone production and loss rates using aircraft observations</a>, Marion Auvray, EPFL
- </li>
- <li>
-  <a href="https://drive.google.com/file/d/1c8wYQ2ytKrV5gwVYCWQaR-WldduHAEYQ/view?usp=drive_link" target="_blank">Transatlantic transport of tropospheric ozone and its precursors</a>, Guerguana Guerova, EPFL
- </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1z0Y8_xthxjZFcoPXnfUMrs9cLlVZVK-U/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Linking GEOS-Chem with CMAQ: consistency in meteorology and chemistry</a>, Daewon Byun, University of Houston
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1voMLXiq_lRHcQSRExKIkvcPXBXIU179h/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Evaluation of the GEOS-Chem/CMAQ interface over China and US</a>, Zuopan Li, University of Tennessee
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1XjhjLhYuXJU8epZjZ1-uHM4tl3Oc1CDP/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Running GEOS-Chem with GISS GCM fields</a>, Loretta Mickley, Harvard University
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1FV3QmTpFeit4krrTByVMhUCoCDncct4s/view?usp=drive_link" target="_blank">Parallelization of GEOS-Chem on a 1024-node Linux cluster based on MPI</a>, Kevin Bowman, JPL
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1BWbmfk-S58zUEMo_K19N_cGTjGt9gzde/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">GEOS-Chem adjoint development using TAF</a>, Monika Kopacz, Harvard University
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1oIxqVy0hcSvxK2ezxciWYVX44e6IvL21/view?usp=drive_link" target="_blank">Constructing an adjoint for GEOS-Chem</a>, Daven Henze, Caltech
+  </li>
 </ul>
 
-<h2>
- Tuesday, April 5, 2005
-</h2>
-
-<h3>
- <a name="coco2" id="coco2"></a>Inverse modeling of emissions: CO, CO2, black carbon (Jennifer Logan, chair)
-</h3>
+<h3><a name="aq" id="aq"></a>Regional air quality (Daewon Byun, chair)</h3>
 
 <ul>
- <li>
-  <a href="https://docs.google.com/presentation/d/1uON-fQ-ZuoHaVHZC0CQR6hg_gQS46n0f/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">CO inverse modeling</a>, Avelino Arellano, Duke
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1vDwqu4_6zEELzNuu2uzaPaUad-g1YYJA/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Effect of boreal forest fires on CO</a>, Fok-Yan Leung, Harvard University
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1zgx-ENlhZJsX-OVMJuoxtRSbwWhI_Ocw/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Inverse modeling of North American CO sources during ICARTT</a>, Solene Turquety, Harvard University
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1tV8OGz4E4N0L7Rtt0DKhBK3N1F9MIujR/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Inverse modeling of Asian CO and NOx emissions</a>, Yuxuan Wang, Harvard University
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1pfzBGnfC-ObBgpKO6BISHgyFWj3EwuCI/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Constraints on Asian carbon sources from a coupled CO-CO2 inversion</a>, Paul Palmer, Harvard University
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1AfAalxaWvvBMggVNGo4CactZ_tjhp6se/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Chemical pump effect on atmospheric CO2 inversions</a>, Parvadha Suntharalingam, Harvard University
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1C_lM6P-1qD3qJEfQ-LJxJ-qe-uWhPAMG/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Exploiting satellite observations of tropospheric trace gases</a>, Dylan Jones, University of Toronto
- </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/14AJvvqGJfmzCbAf_bRlsglin3ChQ14c6/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Sensitivity of surface ozone in the U.S. to isoprene emissions and chemistry</a>, Arlene Fiore, GFDL
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1ck4PsT4A04TgWnZDJvhn45UXdmcTB3gm/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Aerosol simulation over North America</a>, Aaron Van Donkelaar, Dalhousie University
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1vkPTf1sNN64J1JDK2NSF-lvM4SSYVvT8/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Impact of trans-boundary transport of aerosols on regional air quality</a>, Heejin In, University of Houston
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1WGJPwTX34PBptIudeHBdDmvXlXGFW9DR/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Nesting GEOS-Chem with a regional air pollution model for Greece</a>, Maria Tombrou-Tzella, Athens
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1ilqsvXn1qjLnXSqwk1FMZiXFVF5B8dwe/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Origin and distribution of ozone for the Eastern Mediterranean region</a>, Christos Giannakopoulos, Athens
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1RHeyJZjbmZlKHJaVVcCvnnvT67UUa2U_/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Effects of climate change on air quality</a>, Shiliang Wu, Harvard University
+  </li>
 </ul>
 
-<h3>
- <a name="noxvoc" id="noxvoc"></a>Inverse modeling of emissions: NOx and VOCs (Yuhang Wang, chair)
-</h3>
+<h2>Wednesday, April 6, 2005</h2>
 
-<ul><li>
-  <a href="https://docs.google.com/presentation/d/1ed_a9OdKPV7FT5JHRLcuHNBlD6pHqGja/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Global partitioning of NOx emissions using satellite observations</a>, Lyatt Jaeglé, University of Washington
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1vss9Yh67BV2E0752b67yzxhntEewvC83/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">North American NOx emission inventory</a>, Randall Martin, Dalhousie University
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1cgrz4PxUREFwRV-U7Jn7y8lowRRg1c7O/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Modeling oxygen isotopes of nitrate with GEOS-Chem</a>, Meredith Hastings, University of Washington
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/10H9RqhMjoVdZ6m2UUoh5K6ToB16rVVGF/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Constraints from GOME HCHO on global isoprene emission</a>, Changshub Shim, Georgia Tech
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1UQLW4lI2yw7ghrw-0hMo7czk37BMrZwg/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Constraints on Asian VOC sources from GOME HCHO observations</a>, May Fu, Harvard University
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1E4osp9Gg34WbQRnJ8godcTybi_hHdSyR/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">HCHO columns over Europe as proxy for biogenic emissions</a>, Gabriele Curci, University of L'Aquila
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1osQL5R9WsPQb9cRkaZvpaajxzIwU_54P/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Variability of HCHO during ICARTT: implications for GOME/OMI interpretation</a>, Dylan Millet, Harvard University
- </li>
-</ul>
-
-<h3>
- <a name="exp" id="exp"></a>Expanding model capabilities (Dylan Jones, chair)
-</h3>
+<h3><a name="gcb" id="gcb"></a>Global chemical budgets (Lyatt Jaeglé, chair)</h3>
 
 <ul>
- <li>
-  <a href="https://docs.google.com/presentation/d/1z0Y8_xthxjZFcoPXnfUMrs9cLlVZVK-U/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Linking GEOS-Chem with CMAQ: consistency in meteorology and chemistry</a>, Daewon Byun, University of Houston
+  <li>
+    <a href="https://docs.google.com/presentation/d/1w8rTlFmgxBmdRyUHme4v8oyPf1_6W7y4/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Role of ocean emissions in the mercury budget</a>, Sarah Strode, University of Washington
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1fpfOr9_ocEo7KGprcUo57ZCO-HcurCaM/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Global mercury modeling</a>, Noelle Eckley Selin, Harvard University
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/18W672MP5zP4ZQy_ggIQXbVSqpddAtXUT/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Global simulation of H2 and HD with GEOS-Chem</a>, Heather Price, University of Washington
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1_Ibk_7yqWynRYJpJUgwFo_gw_NUsolbD/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Coupled simulations of CO-ethane-HCN-acetylene</a>, Yaping Xiao, Harvard University
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/12yt314eO-pnDhgBCBlg84ERBoKn4bQbT/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Global sources and distributions of CH3Cl</a>, Yasuko Yoshida, Georgia Tech
  </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1voMLXiq_lRHcQSRExKIkvcPXBXIU179h/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Evaluation of the GEOS-Chem/CMAQ interface over China and US</a>, Zuopan Li, University of Tennessee
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1XjhjLhYuXJU8epZjZ1-uHM4tl3Oc1CDP/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Running GEOS-Chem with GISS GCM fields</a>, Loretta Mickley, Harvard University
- </li>
- <li>
-  <a href="https://drive.google.com/file/d/1FV3QmTpFeit4krrTByVMhUCoCDncct4s/view?usp=drive_link" target="_blank">Parallelization of GEOS-Chem on a 1024-node Linux cluster based on MPI</a>, Kevin Bowman, JPL
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1BWbmfk-S58zUEMo_K19N_cGTjGt9gzde/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">GEOS-Chem adjoint development using TAF</a>, Monika Kopacz, Harvard University
- </li>
- <li>
-  <a href="https://drive.google.com/file/d/1oIxqVy0hcSvxK2ezxciWYVX44e6IvL21/view?usp=drive_link" target="_blank">Constructing an adjoint for GEOS-Chem</a>, Daven Henze, Caltech
- </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/12SQxCcgQgMEeba5SbywRx-EvwrL3fG3c/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Tracer correlation of ethane and propane</a>, Yuhang Wang, Georgia Tech
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1TWAX1HpkhqQXeGZzS6axUHGfinHnFIRx/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Global 3-D simulation of reactive bromine chemistry</a>, Tim Canty, JPL
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1-H4iF9cWvjqajF6C8Zn60CxSmBrI-zgc/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Modeling persistent organic pollutants (POPs) with GEOS-Chem</a>, Jordi Dachs, CSIC - Barcelona
+  </li>
 </ul>
 
-<h3>
- <a name="aq" id="aq"></a>Regional air quality (Daewon Byun, chair)
-</h3>
+<h3><a name="issues" id="issues"></a>Model Issues, Model Future (Daniel Jacob, chair)</h3>
 
 <ul>
- <li>
-  <a href="https://docs.google.com/presentation/d/14AJvvqGJfmzCbAf_bRlsglin3ChQ14c6/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Sensitivity of surface ozone in the U.S. to isoprene emissions and chemistry</a>, Arlene Fiore, GFDL
+  <li>
+    <a href="https://docs.google.com/presentation/d/1gAd6XkV3xD6cHGO461NL00nOW-vnImFS/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Emissions</a> (Jennifer Logan, discussion leader)
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1dvztkgS1oYamqDbK1iW_W8I9mhdSXfNR/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Aerosols</a> (Peter Adams, discussion leader)
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1-V8xiZ6B8beUjaSBiKN9dSKnX7pggc2Z/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Chemistry</a> (Mat Evans, discussion leader)
+  </li>
+  <li>
+    Multimedia modeling (Lyatt Jaeglé, discussion leader)
+  </li>
+  <li>
+    Transport (Prasad Kasibhatla, discussion leader)
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/13zEC6-iShz7HIyFH1N8094SoJ5SLF4iE/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Nesting with regional models</a> (Daewon Byun, discussion leader)
+  </li>
+  <li>
+    Data assimilation (Dylan Jones, discussion leader)
  </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1ck4PsT4A04TgWnZDJvhn45UXdmcTB3gm/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Aerosol simulation over North America</a>, Aaron Van Donkelaar, Dalhousie University
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1vkPTf1sNN64J1JDK2NSF-lvM4SSYVvT8/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Impact of trans-boundary transport of aerosols on regional air quality</a>, Heejin In, University of Houston
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1WGJPwTX34PBptIudeHBdDmvXlXGFW9DR/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Nesting GEOS-Chem with a regional air pollution model for Greece</a>, Maria Tombrou-Tzella, Athens
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1ilqsvXn1qjLnXSqwk1FMZiXFVF5B8dwe/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Origin and distribution of ozone for the Eastern Mediterranean region</a>, Christos Giannakopoulos, Athens
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1RHeyJZjbmZlKHJaVVcCvnnvT67UUa2U_/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Effects of climate change on air quality</a>, Shiliang Wu, Harvard University
- </li>
-</ul>
-
-<h2>
- Wednesday, April 6, 2005
-</h2>
-
-<h3>
- <a name="gcb" id="gcb"></a>Global chemical budgets (Lyatt Jaeglé, chair)
-</h3>
-
-<ul>
- <li>
-  <a href="https://docs.google.com/presentation/d/1w8rTlFmgxBmdRyUHme4v8oyPf1_6W7y4/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Role of ocean emissions in the mercury budget</a>, Sarah Strode, University of Washington
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1fpfOr9_ocEo7KGprcUo57ZCO-HcurCaM/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Global mercury modeling</a>, Noelle Eckley Selin, Harvard University
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/18W672MP5zP4ZQy_ggIQXbVSqpddAtXUT/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Global simulation of H2 and HD with GEOS-Chem</a>, Heather Price, University of Washington
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1_Ibk_7yqWynRYJpJUgwFo_gw_NUsolbD/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Coupled simulations of CO-ethane-HCN-acetylene</a>, Yaping Xiao, Harvard University
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/12yt314eO-pnDhgBCBlg84ERBoKn4bQbT/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Global sources and distributions of CH3Cl</a>, Yasuko Yoshida, Georgia Tech
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/12SQxCcgQgMEeba5SbywRx-EvwrL3fG3c/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Tracer correlation of ethane and propane</a>, Yuhang Wang, Georgia Tech
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1TWAX1HpkhqQXeGZzS6axUHGfinHnFIRx/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Global 3-D simulation of reactive bromine chemistry</a>, Tim Canty, JPL
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1-H4iF9cWvjqajF6C8Zn60CxSmBrI-zgc/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Modeling persistent organic pollutants (POPs) with GEOS-Chem</a>, Jordi Dachs, CSIC - Barcelona
- </li>
-</ul>
-
-<h3>
- <a name="issues" id="issues"></a>Model Issues, Model Future (Daniel Jacob, chair)
-</h3>
-
-<ul>
- <li>
-  <a href="https://docs.google.com/presentation/d/1gAd6XkV3xD6cHGO461NL00nOW-vnImFS/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Emissions</a> (Jennifer Logan, discussion leader)
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1dvztkgS1oYamqDbK1iW_W8I9mhdSXfNR/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Aerosols</a> (Peter Adams, discussion leader)
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1-V8xiZ6B8beUjaSBiKN9dSKnX7pggc2Z/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Chemistry</a> (Mat Evans, discussion leader)
- </li>
- <li>
-  Multimedia modeling (Lyatt Jaeglé, discussion leader)
- </li>
- <li>
-  Transport (Prasad Kasibhatla, discussion leader)
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/13zEC6-iShz7HIyFH1N8094SoJ5SLF4iE/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Nesting with regional models</a> (Daewon Byun, discussion leader)
- </li>
- <li>
-  Data assimilation (Dylan Jones, discussion leader)
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1qR3QkbbeL2bFoFOpE7y6XpXWrrqfzOdC/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Hardware/software issues</a> (Bob Yantosca, discussion leader)
- </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1qR3QkbbeL2bFoFOpE7y6XpXWrrqfzOdC/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Hardware/software issues</a> (Bob Yantosca, discussion leader)
+  </li>
 </ul>
 
 </div>

--- a/igc2.html
+++ b/igc2.html
@@ -1,9 +1,4 @@
 <!DOCTYPE html>
-<!--[if IEMobile 7]><html class="iem7"  lang="en" dir="ltr"><![endif]-->
-<!--[if lte IE 6]><html class="lt-ie9 lt-ie8 lt-ie7"  lang="en" dir="ltr"><![endif]-->
-<!--[if (IE 7)&(!IEMobile)]><html class="lt-ie9 lt-ie8"  lang="en" dir="ltr"><![endif]-->
-<!--[if IE 8]><html class="lt-ie9"  lang="en" dir="ltr"><![endif]-->
-<!--[if (gte IE 9)|(gt IEMobile 7)]><!--><html  lang="en" dir="ltr"><!--<![endif]-->
 <head>
 <meta charset="utf-8" />
 <!--<base href="/igc2" />-->
@@ -18,23 +13,12 @@
 <title>The 2nd GEOS-Chem Meeting</title>
 <meta http-equiv="x-ua-compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<link type="text/css" rel="stylesheet" href="css/css_xE-rWrJf-fncB6ztZfd2huxqgxu4WO-qwma6Xer30m4%EF%B9%96m=1675397288.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_1kR8T1_c-l5pBT6ZwbDT7BFda-4fyqW9Jjum29_2IY8%EF%B9%96m=1675397312.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_YnlUIvHP13qgpYEqubzE8JyDwlSxUnVibfnVkSoSDb0%EF%B9%96m=1675397273.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_Ku-3OcT9qU9h7dnGig5e23q6EVryY8orK4wzVDxsweE%EF%B9%96m=1675397367.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_vprtFTrWyg23GbY50_zJZHWGYMNfS8vsrRS26i4-ISk%EF%B9%96m=1675397406.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_dW-aNNrctRhQNc-KECjtQd0PxuW-h19IEum-TX2MeEk%EF%B9%96m=1675397301.css" media="print" />
-<link type="text/css" rel="stylesheet" href="css/css_SH2Lx3Qprh0GZo_9xRp85U9NsWfkSXn_Bi-rJoMY1sw%EF%B9%96m=1675397273.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_uaIDKcYMUK5osSQXuirpr3ZleXtnnpBN-eiECm7N0M0%EF%B9%96m=1675397395.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/responsive.blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/geos-chem.css" media="all"/>
 <script type="text/javascript" src="dropdown-menu.js"></script>
-<!--[if lte IE 8]>
-<script type="text/javascript">
-  var os_c = document.createElement;os_c('header');os_c('nav');os_c('section');os_c('article');os_c('aside');os_c('footer');os_c('hgroup');os_c('figure');
-</script>
-<![endif]-->
 </head>
 
 <body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-1585687 node-type-page og-context og-context-node og-context-node-1585652 navbar-on">
@@ -45,7 +29,7 @@
 <div id="page_wrap" class="page_wrap">
 <div id="page" class="container page header-main content-top footer-none">
 <div id="page-wrapper">
-		
+  
 <!--header regions beg-->
 <header id="header" class="clearfix" role="banner">
 <div id="header-container">
@@ -57,7 +41,7 @@
 <div class="block-content content" ng-non-bindable="">
 <div id='boxes-box-1630413211' class='boxes-box'>
 <div class="boxes-box-content">
-<img height="551" width="1101" style="float: right; width: 350px; height: 175px; margin-bottom: 1.5em;" alt="gca2 logo" class="media-element file-default file-os-files-xxlarge" src="img/igc-early-logo.png" title="" />
+<img height="551" width="1101" style="float: right; width: 350px; height: 175px; margin-bottom: 1.5em;" alt="ig logo" class="media-element file-default file-os-files-xxlarge" src="img/igc-early-logo.png" title="" />
 <h2 class="css-brand--css-geos-meetings-header-h2-xxxlarge">
   The 2nd GEOS-Chem Scientific and Users' Meeting (IGC2)<br />April 4-6 2005
 </h2>
@@ -76,15 +60,16 @@
 
 <!--main menu region beg-->
 <div id="menu-bar" class="nav region-menu-bar clearfix">
-<nav id="block-os-igc2-menu" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="igc2_menu">  
-<ul class="nice-menu nice-menu-down nice-menu-igc2_menu" id="nice-menu-igc2_menu">
-  <li class="menu-861158 menu-path-node-1587331  first   odd  "><a href="igc2.html"  class="active">Home</a></li>
-  <li class="menu-861168 menu-path-node-1587334   even   last "><a href="igc2-presentations.html" >Presentations</a></li>
+<nav id="block-os-igc2-menu" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="igc2_menu">
+<ul class="nice-menu nice-menu-down">
+  <li><a href="igc2.html" class="active">IGC2 Home</a></li>
+  <li><a href="igc2-presentations.html">Presentations and Posters</a></li>
+  <li><a href="index.html">GEOS-Chem Home</a></li>
 </ul>
 </nav>
 </div>
 <!--main menu region end-->
-		
+  
 <div id="columns" class="clearfix">
 <div class="hg-container">
 <div id="content-column" role="main">
@@ -94,7 +79,7 @@
 <a name="main-content"></a>
 <h1 id="page-title" ng-non-bindable="">Overview</h1>
 </header>
-														
+              
 <!--front panel regions beg-->
 <div id="content-panels" class="at-panel gpanel panel-display content clearfix">
 <div class="region region-content-top">
@@ -113,12 +98,12 @@
 </p>
 
 <ul>
-	<li>
-		<a href="https://drive.google.com/file/d/1SyX4OrvkVd6yMS6HyCQOxpi7R9SbxI4I/view?usp=drive_link">View the list of GEOS-Chem meeting attendees</a>
-	</li>
-	<li>
-		<a href="https://drive.google.com/drive/folders/1fro01ieHTuJQ0FqUl-T0uJJHRvBy6bmi?usp=drive_link">View photos from the GEOS-Chem meeting</a> (Photographer: Becky Alexander)
-	</li>
+ <li>
+  <a href="https://drive.google.com/file/d/1SyX4OrvkVd6yMS6HyCQOxpi7R9SbxI4I/view?usp=drive_link">View the list of GEOS-Chem meeting attendees</a>
+ </li>
+ <li>
+  <a href="https://drive.google.com/drive/folders/1fro01ieHTuJQ0FqUl-T0uJJHRvBy6bmi?usp=drive_link">View photos from the GEOS-Chem meeting</a> (Photographer: Becky Alexander)
+ </li>
 </ul>
 
 </div>
@@ -139,64 +124,16 @@
 </div>
 </div>
 
-<!--footer region beg-->
+<!--footer-->
 <footer id="footer" class="clearfix" role="contentinfo">
-
-<!-- Three column 3x33 Gpanel -->
-<div class="at-panel gpanel panel-display footer clearfix">
-<div class="region region-footer">
-<div class="region-inner clearfix">
-<div id="block-boxes-1617037690" class="block block-boxes block-boxes-os_boxes_html no-title"  module="boxes" delta="1617037690">
-<div class="block-inner clearfix">  
-<div class="block-content content" ng-non-bindable="">  
-<div id='boxes-box-1617037690' class='boxes-box'>  
 <div class="boxes-box-content">
   <p style="text-align:center">
-    Copyright © 2023 by the International GEOS-Chem Community. All rights reserved.
+    Copyright © 2026 by the International GEOS-Chem Community. All rights reserved.
   </p>
 </div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-<div class="region region-footer-bottom">  
-<div class="region-inner clearfix">  
-<div id="block-boxes-1616879798" class="block block-boxes block-boxes-os_boxes_media no-title"  module="boxes" delta="1616879798">  
-<div class="block-inner clearfix">  
-<div class="block-content content"> 
-<div id='boxes-box-1616879798' class='boxes-box'> 
-<div class="boxes-box-content"> 
-<div id="file-3900146" class="file file-html file-html-embed">
-<h2 class="element-invisible"><a href="">css-brand</a></h2>
-<div class="content">
-<div class="file-info">
-</div>
-<div class="field field-name-field-html-code field-type-text-long field-label-hidden view-mode-full">
-<div class="field-items">
-<div class="field-item even">
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-
-<!--footer region end-->
 </footer>
-</div>
-</div>
 
-<!--page area ends-->
-<div id="extradiv"></div>
+</div>
 </div>
 
 </body>

--- a/igc2.html
+++ b/igc2.html
@@ -29,22 +29,20 @@
 <div id="page_wrap" class="page_wrap">
 <div id="page" class="container page header-main content-top footer-none">
 <div id="page-wrapper">
-  
+
 <!--header regions beg-->
 <header id="header" class="clearfix" role="banner">
 <div id="header-container">
 <div id="header-panels" class="at-panel gpanel panel-display three-col clearfix">
 <div class="region region-header-second"><div class="region-inner clearfix">
 <section id="block-boxes-1630413211" class="block block-boxes block-boxes-os_boxes_html"  module="boxes" delta="1630413211">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <h2 class="block-title" ng-non-bindable="">Site-Logo</h2>
 <div class="block-content content" ng-non-bindable="">
 <div id='boxes-box-1630413211' class='boxes-box'>
 <div class="boxes-box-content">
-<img height="551" width="1101" style="float: right; width: 350px; height: 175px; margin-bottom: 1.5em;" alt="ig logo" class="media-element file-default file-os-files-xxlarge" src="img/igc-early-logo.png" title="" />
-<h2 class="css-brand--css-geos-meetings-header-h2-xxxlarge">
-  The 2nd GEOS-Chem Scientific and Users' Meeting (IGC2)<br />April 4-6 2005
-</h2>
+<a href="https://geoschem.github.io/"><img height="600" width="1034" style="float: right; width: 350px; height: 203px;" class="media-element file-default file-os-files-xxlarge" src="img/GEOS-Chem_Logo_Square_Light_Background_Orig.png" alt="" title="" /></a>
+<h2 class="css-brand--css-geos-meetings-header-h2-xxxlarge">The 2nd GEOS-Chem Scientific and Users' Meeting (IGC2)<br />April 4-6 2005</h2>
 </div>
 </div>
 </div>
@@ -69,7 +67,7 @@
 </nav>
 </div>
 <!--main menu region end-->
-  
+
 <div id="columns" class="clearfix">
 <div class="hg-container">
 <div id="content-column" role="main">
@@ -79,13 +77,13 @@
 <a name="main-content"></a>
 <h1 id="page-title" ng-non-bindable="">Overview</h1>
 </header>
-              
+
 <!--front panel regions beg-->
 <div id="content-panels" class="at-panel gpanel panel-display content clearfix">
 <div class="region region-content-top">
 <div class="region-inner clearfix">
 <div id="block-os-pages-main-content" class="block block-os-pages no-title"  module="os_pages" delta="main_content">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <div class="block-content content" ng-non-bindable="">
 <article id="node-1585687" class="node node-page article clearfix" role="article">
 <div class="node-content" ng-non-bindable="">
@@ -98,12 +96,12 @@
 </p>
 
 <ul>
- <li>
-  <a href="https://drive.google.com/file/d/1SyX4OrvkVd6yMS6HyCQOxpi7R9SbxI4I/view?usp=drive_link">View the list of GEOS-Chem meeting attendees</a>
- </li>
- <li>
-  <a href="https://drive.google.com/drive/folders/1fro01ieHTuJQ0FqUl-T0uJJHRvBy6bmi?usp=drive_link">View photos from the GEOS-Chem meeting</a> (Photographer: Becky Alexander)
- </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1SyX4OrvkVd6yMS6HyCQOxpi7R9SbxI4I/view?usp=drive_link">View the list of GEOS-Chem meeting attendees</a>
+  </li>
+  <li>
+    <a href="https://drive.google.com/drive/folders/1fro01ieHTuJQ0FqUl-T0uJJHRvBy6bmi?usp=drive_link">View photos from the GEOS-Chem meeting</a> (Photographer: Becky Alexander)
+  </li>
 </ul>
 
 </div>

--- a/igc3-presentations.html
+++ b/igc3-presentations.html
@@ -29,22 +29,20 @@
 <div id="page_wrap" class="page_wrap">
 <div id="page" class="container page header-main content-top footer-none">
 <div id="page-wrapper">
-		
+
 <!--header regions beg-->
 <header id="header" class="clearfix" role="banner">
 <div id="header-container">
 <div id="header-panels" class="at-panel gpanel panel-display three-col clearfix">
 <div class="region region-header-second"><div class="region-inner clearfix">
 <section id="block-boxes-1630413211" class="block block-boxes block-boxes-os_boxes_html"  module="boxes" delta="1630413211">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <h2 class="block-title" ng-non-bindable="">Site-Logo</h2>
 <div class="block-content content" ng-non-bindable="">
 <div id='boxes-box-1630413211' class='boxes-box'>
 <div class="boxes-box-content">
-<img height="551" width="1101" style="float: right; width: 350px; height: 175px; margin-bottom: 1.5em;" alt="ig logo" class="media-element file-default file-os-files-xxlarge" src="img/igc-early-logo.png" title="" />
-<h2 class="css-brand--css-geos-meetings-header-h2-xxxlarge">
-  The 3rd GEOS-Chem Scientific and Users' Meeting (IGC3)<br />April 11-13 2007
-</h2>
+<a href="https://geoschem.github.io/"><img height="600" width="1034" style="float: right; width: 350px; height: 203px;" class="media-element file-default file-os-files-xxlarge" src="img/GEOS-Chem_Logo_Square_Light_Background_Orig.png" alt="" title="" /></a>
+<h2 class="css-brand--css-geos-meetings-header-h2-xxxlarge">The 3rd GEOS-Chem Scientific and Users' Meeting (IGC3)<br />April 11-13 2007</h2>
 </div>
 </div>
 </div>
@@ -69,7 +67,7 @@
 </nav>
 </div>
 <!--main menu region end-->
-  
+
 <div id="columns" class="clearfix">
 <div class="hg-container">
 <div id="content-column" role="main">
@@ -79,13 +77,13 @@
 <a name="main-content"></a>
 <h1 id="page-title" ng-non-bindable="">Presentations</h1>
 </header>
-              
+
 <!--front panel regions beg-->
 <div id="content-panels" class="at-panel gpanel panel-display content clearfix">
 <div class="region region-content-top">
 <div class="region-inner clearfix">
 <div id="block-os-pages-main-content" class="block block-os-pages no-title"  module="os_pages" delta="main_content">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <div class="block-content content" ng-non-bindable="">
 <article id="node-1585687" class="node node-page article clearfix" role="article">
 <div class="node-content" ng-non-bindable="">
@@ -96,167 +94,167 @@
 <p class="size14"><i>Wed Apr 11:  </i><a href="#model_overview">Model Overview</a>  | <a href="#glob_trop_chem">Global Tropopsheric Chemistry</a>,  | <a href="#aerosols_1">Aerosols I</a>  | <a href="#aerosols_2">Aerosols II</a>  | <a href="#posters">Posters</a> </p>
 <p class="size14"><i>Thu Apr 12:  </i><a href="#biomass">Biomass Burning</a>  | <a href="#voc">VOC Emissions &amp; C Fluxes</a>  | <a href="#nox">NOx Emiss &amp; Chem</a>  | <a href="#mercury">Mercury</a> </p>
 <p class="size14"><i>Fri Apr 13:  </i><a href="#aq">Regional Air Quality</a>  | <a href="#transport">Intercontinental Transport</a>  | <a href="#wgs">Working Group Reports</a> </p>
-  
+
 <h2>Wednesday April 11, 2007</h2>
 
 <h3><a name="model_overview" id="model_overview"></a>Model Overview (Daniel Jacob, chair)</h3>
 
 <ul class="disc">
- <li>
-  Welcome,  <i>Daniel Jacob, Harvard University</i>
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1JllkiD2knhXV2lQOuTCu-6gIOGUO25tG/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">GEOS-Chem model: present state, future directions</a>,  <i>Daniel Jacob, Harvard University</i>
- </li>
-    <li>
-     <a href="https://docs.google.com/presentation/d/1SdTAI4xIP6Zy6lEgvelxlQrsIgQw3abU/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">GEOS-Chem code: new developments</a>, <i>Bob Yantosca, Harvard University</i>
-    </li>
-    <li>
-     <a href="https://docs.google.com/presentation/d/1CZWbAJgRYTQOrtbQzp-k_1MRUzb6U9ZD/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">GEOS-5 meteorological data, tracer transport</a>, <i>Max Suarez and Steven Pawson, NASA/GMAO</i>
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1KrlLuVr3mTWxVs_JZ5R9I6-sZYp6P4Df/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">GEOS-Chem adjoint construction and long-term maintainability</a>, <i>Adrian Sandu, Virginia Tech</i>
- </li>
+  <li>
+    Welcome,  <i>Daniel Jacob, Harvard University</i>
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1JllkiD2knhXV2lQOuTCu-6gIOGUO25tG/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">GEOS-Chem model: present state, future directions</a>,  <i>Daniel Jacob, Harvard University</i>
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1SdTAI4xIP6Zy6lEgvelxlQrsIgQw3abU/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">GEOS-Chem code: new developments</a>, <i>Bob Yantosca, Harvard University</i>
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1CZWbAJgRYTQOrtbQzp-k_1MRUzb6U9ZD/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">GEOS-5 meteorological data, tracer transport</a>, <i>Max Suarez and Steven Pawson, NASA/GMAO</i>
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1KrlLuVr3mTWxVs_JZ5R9I6-sZYp6P4Df/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">GEOS-Chem adjoint construction and long-term maintainability</a>, <i>Adrian Sandu, Virginia Tech</i>
+  </li>
 </ul>
 
 <h3><a name="glob_trop_chem" id="glob_trop_chem"></a>Global Tropospheric Chemistry (Dylan Jones, chair)</h3>
 
 <ul class="disc">
- <li>
-  <a href="https://docs.google.com/presentation/d/1CyHPbOMuX_zOCOR0I0L1YO71w0uUkv5X/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Status of global ozone and CO simulations</a>, <i>Jennifer Logan, Harvard University</i>
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/14bW416FcbBGYctTbvZx6zMkjEOpicLOh/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Year-to-year variations in global OH radicals over the last 20-year period</a>, <i>Isabelle Bey, EPFL</i>
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1UXmTQCi2PW8ZPt3f2EIh35KX_erYzy9X/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Cross evaluation of OMI, TES, and GEOS-Chem tropospheric ozone</a>, <i>Xiong Liu, CFA</i>
- </li>
-    <li>
-     <a href="https://docs.google.com/presentation/d/189eldIHRWu-K8fOHelQRRUFGhijhzk0b/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Simulation of TES ozone</a>,  <i>Ray Nassar, Harvard University</i>
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1Lf1_RhLn4rEIfNx28w1GJfWkQcKPBrk-/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Assimilation of TES observations</a>, <i>Mark Parrington, University of Toronto</i>
- </li>
-    <li>
-     <a href="https://docs.google.com/presentation/d/19lbZC7H74bzIzlbePjpYH9iK7H8keOt8/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Variability of upper tropospheric ozone and CO</a>,  <i>Chenxia Cai, JPL</i>
-    </li>
-    <li>
-     <a href="https://docs.google.com/presentation/d/1PIDIqymnceHh8saIR6OrWUxZFAJ93bmk/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Impact of seasonal variations in long-range transport on tropospheric ozone</a>, <i>Jane Liu, University of Toronto</i>
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1S3siOdvmUuws6L_ZhSB3N1jPHwKEdZLW/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Dynamic tropopause and spatial reduction mechanism</a>, <i>Philippe LeSager and Yevgenii Rastigeyev, Harvard University</i>
- </li>
-    <li>
-     <a href="https://docs.google.com/presentation/d/1GbzKgU_Kc_wWya0I6FOU31KKQTRtA0xT/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Adapting GEOS-Chem to Mars photochemistry</a>, <i>Huiqun Wang, CFA</i>
- </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1CyHPbOMuX_zOCOR0I0L1YO71w0uUkv5X/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Status of global ozone and CO simulations</a>, <i>Jennifer Logan, Harvard University</i>
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/14bW416FcbBGYctTbvZx6zMkjEOpicLOh/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Year-to-year variations in global OH radicals over the last 20-year period</a>, <i>Isabelle Bey, EPFL</i>
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1UXmTQCi2PW8ZPt3f2EIh35KX_erYzy9X/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Cross evaluation of OMI, TES, and GEOS-Chem tropospheric ozone</a>, <i>Xiong Liu, CFA</i>
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/189eldIHRWu-K8fOHelQRRUFGhijhzk0b/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Simulation of TES ozone</a>,  <i>Ray Nassar, Harvard University</i>
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1Lf1_RhLn4rEIfNx28w1GJfWkQcKPBrk-/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Assimilation of TES observations</a>, <i>Mark Parrington, University of Toronto</i>
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/19lbZC7H74bzIzlbePjpYH9iK7H8keOt8/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Variability of upper tropospheric ozone and CO</a>,  <i>Chenxia Cai, JPL</i>
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1PIDIqymnceHh8saIR6OrWUxZFAJ93bmk/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Impact of seasonal variations in long-range transport on tropospheric ozone</a>, <i>Jane Liu, University of Toronto</i>
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1S3siOdvmUuws6L_ZhSB3N1jPHwKEdZLW/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Dynamic tropopause and spatial reduction mechanism</a>, <i>Philippe LeSager and Yevgenii Rastigeyev, Harvard University</i>
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1GbzKgU_Kc_wWya0I6FOU31KKQTRtA0xT/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Adapting GEOS-Chem to Mars photochemistry</a>, <i>Huiqun Wang, CFA</i>
+  </li>
 </ul>
 
 <h3><a name="aerosols_1" id="aerosols_1"></a>Aerosols I (Qinbin Li, chair)</h3>
 
 <ul class="disc">
- <li>
-  <a href="https://docs.google.com/presentation/d/138i5sY1SGmbtwF-XJxhIKHItp7G5KC5O/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Global simulation of SO2 concentrations with updated emission inventory</a>, <i>Gan Luo, SUNY Albany</i>
+  <li>
+    <a href="https://docs.google.com/presentation/d/138i5sY1SGmbtwF-XJxhIKHItp7G5KC5O/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Global simulation of SO2 concentrations with updated emission inventory</a>, <i>Gan Luo, SUNY Albany</i>
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1eajy9t8cZBq0AOjsa8LjLeqJZKQBFq6O/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Coupling of sulfate aerosol with gas-phase precursors</a>, <i>Daven Henze, Caltech</i>
  </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1eajy9t8cZBq0AOjsa8LjLeqJZKQBFq6O/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Coupling of sulfate aerosol with gas-phase precursors</a>, <i>Daven Henze, Caltech</i>
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/14V_n1WUrbnSjZnINQKlOp44QKaMfegfA/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Updates to fossil-fuel emissions and long-range transport of sulfur to Canada</a>, <i>Aaron van Donkelaar, Dalhousie University</i>
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1Eh8Eb7QHAhf-ENxElIJcfOjgYwlfy0_y/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Sensitivity of sulfate direct climate forcing to particle phase transitions</a>, <i>Jun Wang, Harvard University</i>
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1wLA7ha7DiHf4tEANLk7lkUXnx3y1lAjy/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Organic carbon aerosol: insight from recent field campaigns</a>, <i>Colette Heald, UC Berkeley</i>
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/18TRaDnKFl_zBVDqKx1XP5H1G2mhhahH3/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Global budget of glyoxal and methylglyoxal, and implication for SOA</a>, <i>May Fu, Harvard University</i>
- </li>
- <li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/14V_n1WUrbnSjZnINQKlOp44QKaMfegfA/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Updates to fossil-fuel emissions and long-range transport of sulfur to Canada</a>, <i>Aaron van Donkelaar, Dalhousie University</i>
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1Eh8Eb7QHAhf-ENxElIJcfOjgYwlfy0_y/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Sensitivity of sulfate direct climate forcing to particle phase transitions</a>, <i>Jun Wang, Harvard University</i>
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1wLA7ha7DiHf4tEANLk7lkUXnx3y1lAjy/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Organic carbon aerosol: insight from recent field campaigns</a>, <i>Colette Heald, UC Berkeley</i>
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/18TRaDnKFl_zBVDqKx1XP5H1G2mhhahH3/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Global budget of glyoxal and methylglyoxal, and implication for SOA</a>, <i>May Fu, Harvard University</i>
+  </li>
+  <li>
   <a href="https://docs.google.com/presentation/d/1E3Vx8BnF-yvr0-o5ujGRwSvr-oVJIhw0/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">The effect of climate on secondary organic aerosols</a>, <i>Havala Pye, Caltech</i>
- </li>
+  </li>
 </ul>
 
 <h3><a name="aerosols_2" id="aerosols_2"></a>Aerosols II (Randall Martin, chair)</h3>
 
 <ul>
- <li>
-  <a href="https://docs.google.com/presentation/d/1dSzkjWcbz9FDlpj0ReiagTJ9-KwWAZNs/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Dust modeling and preliminary analysis of INTEX-B data</a>, <i>Duncan Fairlie, NASA LaRC</i>
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1QLdwTIwfI4Fey1nyxgTn9asaTPnMqU-h/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Modeling of soluble iron formation, transport and deposition to the Pacific</a>, <i>Fabien Solmon, UC Santa Cruz</i>
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/12SPipjChAj3BF_17421zaGXiNJjTCUUO/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Deriving PM2.5 speciation information using MISR data coupled with GEOS-Chem </a>, <i>Yang Liu, Harvard School of Public Health</i>
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1u2lzl3W8ieS3xdpGCP3h6Dz64J5_wcsE/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Deriving AODs from MODIS radiances</a>, <i>Easan Drury, Harvard University</i>
- </li>
- <li>
-  New particle formation in the global atmosphere<i>Fangqun Yu, SUNY Albany</i>
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1wuXQwqmh4Q7V-7_QxunVtz09zNzeTZ1B/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Implementation of sulfate and sea-salt aerosol microphysics into GEOS-Chem</a>, <i>Win Trivitayanurak, Carnegie-Mellon University</i>
- </li>
- <li>
-  <a href="https://drive.google.com/file/d/1oEgWGxIvZeDy0DTzHZYdKio_oisa6FQw/view?usp=drive_link" target="_blank">Comparisons of Ozone and Aerosols in US and East Asia between 2001 and 2002</a>,  <i>Joshua Fu, University of Tennessee</i>
- </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1dSzkjWcbz9FDlpj0ReiagTJ9-KwWAZNs/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Dust modeling and preliminary analysis of INTEX-B data</a>, <i>Duncan Fairlie, NASA LaRC</i>
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1QLdwTIwfI4Fey1nyxgTn9asaTPnMqU-h/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Modeling of soluble iron formation, transport and deposition to the Pacific</a>, <i>Fabien Solmon, UC Santa Cruz</i>
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/12SPipjChAj3BF_17421zaGXiNJjTCUUO/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Deriving PM2.5 speciation information using MISR data coupled with GEOS-Chem </a>, <i>Yang Liu, Harvard School of Public Health</i>
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1u2lzl3W8ieS3xdpGCP3h6Dz64J5_wcsE/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Deriving AODs from MODIS radiances</a>, <i>Easan Drury, Harvard University</i>
+  </li>
+  <li>
+    New particle formation in the global atmosphere<i>Fangqun Yu, SUNY Albany</i>
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1wuXQwqmh4Q7V-7_QxunVtz09zNzeTZ1B/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Implementation of sulfate and sea-salt aerosol microphysics into GEOS-Chem</a>, <i>Win Trivitayanurak, Carnegie-Mellon University</i>
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1oEgWGxIvZeDy0DTzHZYdKio_oisa6FQw/view?usp=drive_link" target="_blank">Comparisons of Ozone and Aerosols in US and East Asia between 2001 and 2002</a>,  <i>Joshua Fu, University of Tennessee</i>
+  </li>
 </ul>
 
 <h3><a name="posters" id="posters"></a>Poster Session</h3>
 
 <ul class="disc">
+  <li>
+    Evaluating the global health impact of intercontinental transport of fine aerosols <i>Junfeng Liu, Princeton University</i>
+  </li>
+  <li>
+    A regional aerosol modeling perspective on global models <i>Scott Spak, University of Wisconsin</i>
+  </li>
+  <li>
+    A model study of ozone over Europe during the August 2003 heat wave <i>Guergana Guerova, University of Wollongong</i>
+  </li>
  <li>
-  Evaluating the global health impact of intercontinental transport of fine aerosols <i>Junfeng Liu, Princeton University</i>
+   Long range transport of ammonia from sugarcane cropping <i>Guergana Guerova, University of Wollongong</i>
  </li>
- <li>
-  A regional aerosol modeling perspective on global models <i>Scott Spak, University of Wisconsin</i>
- </li>
- <li>
-  A model study of ozone over Europe during the August 2003 heat wave <i>Guergana Guerova, University of Wollongong</i>
- </li>
- <li>
-  Long range transport of ammonia from sugarcane cropping <i>Guergana Guerova, University of Wollongong</i>
- </li>
- <li>
-  Air pollution radiative forcing from emission sectors: prototype for a new IPCC bar chart <i>Nadine Unger, NASA/GISS</i>
- </li>
- <li>
+  <li>
+    Air pollution radiative forcing from emission sectors: prototype for a new IPCC bar chart <i>Nadine Unger, NASA/GISS</i>
+  </li>
+  <li>
   Future trends in ozone exceedances over the Northeast United States <i>Loretta Mickley, Harvard University</i>
- </li>
- <li>
-  Air quality degradation in future climate due to decreased cyclone frequency <i>Eric Leibensperger, Harvard University</i>
- </li>
- <li>
-  Evaluation of GMI Combo model simulations with TES ozone data: indirect TES validation <i>Jennifer Logan, Harvard University</i>
- </li>
- <li>
+  </li>
+  <li>
+    Air quality degradation in future climate due to decreased cyclone frequency <i>Eric Leibensperger, Harvard University</i>
+  </li>
+  <li>
+   Evaluation of GMI Combo model simulations with TES ozone data: indirect TES validation <i>Jennifer Logan, Harvard University</i>
+  </li>
+  <li>
   Evaluating model contributions to tropospheric ozone with aircraft datain factor-projected space <i>Changsub Shim, JPL</i>
- </li>
-    <li>
-     CMAQ modeling of China's regional air quality <i>Dan Chen, Tsinghua University</i>
- </li>
- <li>
-  Evaluation of Tropospheric Aerosol Microphysics Simulations Using Observations <i>Win Trivitayanurak, Carnegie-Mellon University</i>
- </li>
- <li>
-  Sea-salt aerosols: impact on air pollution of the Attica Peninsula Greece <i>E. Athanasopoulou, National Observatory of Athens</i>
- </li>
- <li>
-  Influence of the city of Athens in the evolution of the sea-breeze front <i>A. Dandou, National Observatory of Athens</i>
- </li>
- <li>
-  Influence of different PBL schemes on ozone predictions over the GAA <i>E. Bossioli, National Observatory of Athens</i>
- </li>
- <li>
-  Comparison of the GMI Combo CTM with observations from the Aura period <i>Duncan, Yoshida, Rodriguez, NASA/GSFC</i>
- </li>
- <li>
-  Source-receptor relationship of trans-Pacific transport of East Asian sulfate <i>Junfeng Liu, Princeton University</i>
- </li>
- <li>
-  Processes driving ozone in the tropics and in the South Atlantic <i>Bastien Sauvage, Dalhousie University</i>
- </li>
+  </li>
+  <li>
+    CMAQ modeling of China's regional air quality <i>Dan Chen, Tsinghua University</i>
+  </li>
+  <li>
+    Evaluation of Tropospheric Aerosol Microphysics Simulations Using Observations <i>Win Trivitayanurak, Carnegie-Mellon University</i>
+  </li>
+  <li>
+    Sea-salt aerosols: impact on air pollution of the Attica Peninsula Greece <i>E. Athanasopoulou, National Observatory of Athens</i>
+  </li>
+  <li>
+    Influence of the city of Athens in the evolution of the sea-breeze front <i>A. Dandou, National Observatory of Athens</i>
+  </li>
+  <li>
+    Influence of different PBL schemes on ozone predictions over the GAA <i>E. Bossioli, National Observatory of Athens</i>
+  </li>
+  <li>
+    Comparison of the GMI Combo CTM with observations from the Aura period <i>Duncan, Yoshida, Rodriguez, NASA/GSFC</i>
+  </li>
+  <li>
+    Source-receptor relationship of trans-Pacific transport of East Asian sulfate <i>Junfeng Liu, Princeton University</i>
+  </li>
+  <li>
+    Processes driving ozone in the tropics and in the South Atlantic <i>Bastien Sauvage, Dalhousie University</i>
+  </li>
 </ul>
 
 <h2>Thursday, April 12, 2007</h2>
@@ -264,102 +262,102 @@
 <h3><a name="biomass" id="biomass"></a>Biomass Burning (Jennifer Logan, chair)</h3>
 
 <ul class="disc">
- <li>
-  <a href="https://docs.google.com/presentation/d/1L-N-L_nIOPEPMf_nLp0B06aMn-K-JGUq/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Climate change, fires, and carbon aerosol over N. America</a>, <i>Dominick Spracklen and Loretta Mickley, Harvard University</i>
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1KGeMyV52wLCvj-_qLKFSCBrQzj_1wWLB/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Simulation of Australian bushfire season 2002/2003</a>, <i>Guergana Guerova, University of Wollongong</i>
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1UpS5jLi72YDpe_pNYSmc1sLb_EBxjFBv/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Evaluation of aerosol and CO vertical distributions from wild fires</a>, <i>Sylvia Generoso, EPFL</i>
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1-vwa2Psit-YNCnEfm_q3iI5vbkMzoBra/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Dealing with injection height for biomass burning emissions</a>, <i>Fok-Yan Leung, Harvard University</i>
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1xYDjxyd9fEVmdCjkYTo3EU0TVo6Rpj0E/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Fire-driven interannual variability in CO, and SH seasonality of CO</a>, <i>Prasad Kasibhatla, Duke University</i>
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1KYEMk9u-h_VWUgJ424YfRLdUhekTNW-o/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Global transport and radiative forcing of biomass burning aerosols</a>, <i>Yang Chen, JPL</i>
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1lYwzu8mHnvTNirLYlruT_skLst6txP9M/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Assimilation of TES data for biomass burning influence on tropospheric ozone</a>, <i>Dylan Jones, University of Toronto</i>
- </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1L-N-L_nIOPEPMf_nLp0B06aMn-K-JGUq/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Climate change, fires, and carbon aerosol over N. America</a>, <i>Dominick Spracklen and Loretta Mickley, Harvard University</i>
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1KGeMyV52wLCvj-_qLKFSCBrQzj_1wWLB/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Simulation of Australian bushfire season 2002/2003</a>, <i>Guergana Guerova, University of Wollongong</i>
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1UpS5jLi72YDpe_pNYSmc1sLb_EBxjFBv/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Evaluation of aerosol and CO vertical distributions from wild fires</a>, <i>Sylvia Generoso, EPFL</i>
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1-vwa2Psit-YNCnEfm_q3iI5vbkMzoBra/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Dealing with injection height for biomass burning emissions</a>, <i>Fok-Yan Leung, Harvard University</i>
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1xYDjxyd9fEVmdCjkYTo3EU0TVo6Rpj0E/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Fire-driven interannual variability in CO, and SH seasonality of CO</a>, <i>Prasad Kasibhatla, Duke University</i>
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1KYEMk9u-h_VWUgJ424YfRLdUhekTNW-o/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Global transport and radiative forcing of biomass burning aerosols</a>, <i>Yang Chen, JPL</i>
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1lYwzu8mHnvTNirLYlruT_skLst6txP9M/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Assimilation of TES data for biomass burning influence on tropospheric ozone</a>, <i>Dylan Jones, University of Toronto</i>
+  </li>
 </ul>
 
 <h3><a name="voc" id="voc"></a>VOC Emissions and Carbon Fluxes (Prasad Kasibhatla, chair)</h3>
 
 <ul class="disc">
- <li>
-  <a href="https://docs.google.com/presentation/d/1-Lc_r-yP_32DD1_F49LaeId2P4Yk9u_I/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Biogenic emissions from tropical ecosystems</a>, <i>Michael Barkley, University of Edinburgh</i>
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1lOWPjSbV5E-aCCR-0Prv5FCswSO7ZA6i/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Biogenic emissions and VOC oxidation</a>, <i>Gabriele Curci, University of L'Aquila</i>
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1g98vxA7LGyhpjjm_xVIpkFcgedhrcLMg/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">OMI HCHO measurements to test isoprene emissions and land cover</a>, <i>Dylan Millet, Harvard University</i>
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1eRhnpzuXFheK3B11yZBiAK9865G9iPvH/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Evolution of methane concentrations over the last 20 years</a>, <i>Jerome Drevet, EPFL</i>
- </li>
- <li>
-  Analysis of AIRS CO2 and ozone retrievals. <i>Xun Jiang, JPL</i>
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1JTFoyGhbT41npp908XlZzIZihj4hqDCJ/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Improving estimates of CO2 fluxes through a joint CO-CO2 adjoint inversion</a>, <i>Monika Kopacz, Harvard University</i>
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/14EVVljB8ciqMVtjbDDZ4Igm3vo9IBKRJ/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Factors governing the seasonal variability of atmospheric carbonyl sulfide</a>, <i>Parvadha Suntharalingam, Harvard University</i>
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1pxhGxeoA7-owrY6SSYjTBYaAbLKLZ_oK/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Acetylene-CO relationship and U.S. sources of ethane</a>, <i>Yaping Xiao, University of New Hampshire</i>
- </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1-Lc_r-yP_32DD1_F49LaeId2P4Yk9u_I/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Biogenic emissions from tropical ecosystems</a>, <i>Michael Barkley, University of Edinburgh</i>
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1lOWPjSbV5E-aCCR-0Prv5FCswSO7ZA6i/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Biogenic emissions and VOC oxidation</a>, <i>Gabriele Curci, University of L'Aquila</i>
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1g98vxA7LGyhpjjm_xVIpkFcgedhrcLMg/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">OMI HCHO measurements to test isoprene emissions and land cover</a>, <i>Dylan Millet, Harvard University</i>
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1eRhnpzuXFheK3B11yZBiAK9865G9iPvH/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Evolution of methane concentrations over the last 20 years</a>, <i>Jerome Drevet, EPFL</i>
+  </li>
+  <li>
+    Analysis of AIRS CO2 and ozone retrievals. <i>Xun Jiang, JPL</i>
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1JTFoyGhbT41npp908XlZzIZihj4hqDCJ/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Improving estimates of CO2 fluxes through a joint CO-CO2 adjoint inversion</a>, <i>Monika Kopacz, Harvard University</i>
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/14EVVljB8ciqMVtjbDDZ4Igm3vo9IBKRJ/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Factors governing the seasonal variability of atmospheric carbonyl sulfide</a>, <i>Parvadha Suntharalingam, Harvard University</i>
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1pxhGxeoA7-owrY6SSYjTBYaAbLKLZ_oK/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Acetylene-CO relationship and U.S. sources of ethane</a>, <i>Yaping Xiao, University of New Hampshire</i>
+  </li>
 </ul>
 
 <h3><a name="nox" id="nox"></a>NOx Emissions and Chemistry (Isabelle Bey, chair)</h3>
 
 <ul class="disc">
- <li>
-  <a href="https://docs.google.com/presentation/d/1TeTBsE09EivfUXMNbojDvIUC090PKU-r/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Constraining the magnitude and diurnal variation of NOx sources from space</a>, <i>Folkert Boersma, Harvard University</i>
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1EgkwA83JcB1o8uvSSIMpfiB6z1KoXdpw/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Surface nitrogen dioxide concentrations inferred from OMI</a>, <i>Lok Lamsal, Dalhousie University</i>
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1yWb_jUn78gPQeppmUX0Oodve2qPF_ftV/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Development of the bottom-up soil NOx inventory</a>, <i>Neil Moore, Dalhousie University</i>
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/16KnDy5dHdyOfgpNskPjQn81CGCXO6yXZ/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true">Constraints on lightning NOx emissions inferred from satellite observations</a>, <i>Randall Martin, Dalhousie University</i>
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/17Yg_YJ2RwgHWSjoa5pxx0MdWyHKjAzq3/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Lightning NOx source emissions in GEOS-Chem</a>, <i>Lee Murray, Harvard University</i>
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1IOZn6nQln3ptGEAr1Ayf_Fk5gwie8riQ/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Year-to-year variations in ozone and in satellite-derived NOx emissions</a>, <i>Simos Koumoutsaris, EPFL</i>
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1IXfmhZPVJNwCCyD9vdzJfYdi8Dj78Vqm/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">U.S. influence on tropospheric ozone and the effects of recent emission reductions</a>, <i>Rynda Hudman, Harvard University</i>
- </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1TeTBsE09EivfUXMNbojDvIUC090PKU-r/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Constraining the magnitude and diurnal variation of NOx sources from space</a>, <i>Folkert Boersma, Harvard University</i>
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1EgkwA83JcB1o8uvSSIMpfiB6z1KoXdpw/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Surface nitrogen dioxide concentrations inferred from OMI</a>, <i>Lok Lamsal, Dalhousie University</i>
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1yWb_jUn78gPQeppmUX0Oodve2qPF_ftV/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Development of the bottom-up soil NOx inventory</a>, <i>Neil Moore, Dalhousie University</i>
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/16KnDy5dHdyOfgpNskPjQn81CGCXO6yXZ/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true">Constraints on lightning NOx emissions inferred from satellite observations</a>, <i>Randall Martin, Dalhousie University</i>
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/17Yg_YJ2RwgHWSjoa5pxx0MdWyHKjAzq3/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Lightning NOx source emissions in GEOS-Chem</a>, <i>Lee Murray, Harvard University</i>
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1IOZn6nQln3ptGEAr1Ayf_Fk5gwie8riQ/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Year-to-year variations in ozone and in satellite-derived NOx emissions</a>, <i>Simos Koumoutsaris, EPFL</i>
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1IXfmhZPVJNwCCyD9vdzJfYdi8Dj78Vqm/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">U.S. influence on tropospheric ozone and the effects of recent emission reductions</a>, <i>Rynda Hudman, Harvard University</i>
+  </li>
 </ul>
 
 <h3><a name="mercury" id="mercury"></a>Mercury (Lyatt Jaegle, chair)</h3>
 
 <ul class="disc">
- <li>
-  <a href="https://docs.google.com/presentation/d/1yT6al5aZu_hwFbZ5VVBsCQh9Zg_OXQrq/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">A biogeochemical model for mercury in GEOS-Chem</a>, <i>Noelle Selin, Harvard University</i>
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1dzvcJaJ3jEtwEmG9udUmyMXjSamD-oGy/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Transpacific transport of mercury</a>, <i>Sarah Strode, University of Washington</i>
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1LvjKboA7EdrAj5pL-bTWfnq4dsnoEyqg/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Discerning mercury-halogen chemistry</a>, <i>Chris Holmes, Harvard University</i>
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1mnnamZTRv_-4T6_XTFdklYMNFN4kxSHu/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Incorporating a land surface model of terrestrial mercury storage</a>, <i>Nicole Downey, Harvard University</i>
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1oNLhjuPIk_1G7eFaDROo7ZojbnzRpRRS/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Ocean-atmosphere model linkages</a>, <i>Elsie Sunderland, EPA</i>
- </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1yT6al5aZu_hwFbZ5VVBsCQh9Zg_OXQrq/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">A biogeochemical model for mercury in GEOS-Chem</a>, <i>Noelle Selin, Harvard University</i>
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1dzvcJaJ3jEtwEmG9udUmyMXjSamD-oGy/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Transpacific transport of mercury</a>, <i>Sarah Strode, University of Washington</i>
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1LvjKboA7EdrAj5pL-bTWfnq4dsnoEyqg/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Discerning mercury-halogen chemistry</a>, <i>Chris Holmes, Harvard University</i>
+  </li>
+  <li>
+    <a <href="https://docs.google.com/presentation/d/1mnnamZTRv_-4T6_XTFdklYMNFN4kxSHu/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Incorporating a land surface model of terrestrial mercury storage</a>, <i>Nicole Downey, Harvard University</i>
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1oNLhjuPIk_1G7eFaDROo7ZojbnzRpRRS/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Ocean-atmosphere model linkages</a>, <i>Elsie Sunderland, EPA</i>
+  </li>
 </ul>
 
 <h2><i>Friday, April 13, 2007</i></h2>
@@ -367,75 +365,75 @@
 <h3><a name="aq" id="aq"></a>Regional Air Quality (Rokjin Park, chair)</h3>
 
 <ul class="disc">
- <li>
-  <a href="https://docs.google.com/presentation/d/1omEHhwkGCB-c3Nos_UwrJJVQ0UUFdu9G/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Nested grid application of GC over Europe</a>, <i>A. Protonotariou, National Observatory of Athens</i>
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1jHL7R4yRFv1BA8MYD4Oxh4N3BQMp_Xsk/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Coupling GEOS-Chem with a regional air pollution model for Greece</a>, <i>E. Bossioli, National Observatory of Athens</i>
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1CgyrqO26swOUHBcOjwleVbHPtxDCUgBG/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Simulation of air pollutants over China</a>, <i>Hong Liao, Chinese Academy of Sciences</i>
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1jcULRSH_6OJsi_QG7tzB-ym1NIWGamTw/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true">Sources of NOx and tropospheric O3 chemistry over Beijing</a>, <i>Yuxuan Wang, Harvard University</i>
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1rPukJLB0B-5Ai5HE8PGgI1jHbxb95evw/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Sensitivity of surface O3 to soil NOx emissions</a>, <i>Lyatt Jaegle, University of Washington</i>
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1uIPdH8eYsNSojjjnPPvDi-Z5gJM5FTBg/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Effects of 2000-2050 global change on ozone air quality in the United States</a>, <i>Shiliang Wu, Harvard University</i>
- </li>
- <li>
-  Coupling of global-regional models for impact of climate change on air quality, <i>Daewon Byun, University of Houston</i>
- </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1omEHhwkGCB-c3Nos_UwrJJVQ0UUFdu9G/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Nested grid application of GC over Europe</a>, <i>A. Protonotariou, National Observatory of Athens</i>
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1jHL7R4yRFv1BA8MYD4Oxh4N3BQMp_Xsk/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Coupling GEOS-Chem with a regional air pollution model for Greece</a>, <i>E. Bossioli, National Observatory of Athens</i>
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1CgyrqO26swOUHBcOjwleVbHPtxDCUgBG/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Simulation of air pollutants over China</a>, <i>Hong Liao, Chinese Academy of Sciences</i>
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1jcULRSH_6OJsi_QG7tzB-ym1NIWGamTw/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true">Sources of NOx and tropospheric O3 chemistry over Beijing</a>, <i>Yuxuan Wang, Harvard University</i>
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1rPukJLB0B-5Ai5HE8PGgI1jHbxb95evw/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Sensitivity of surface O3 to soil NOx emissions</a>, <i>Lyatt Jaegle, University of Washington</i>
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1uIPdH8eYsNSojjjnPPvDi-Z5gJM5FTBg/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Effects of 2000-2050 global change on ozone air quality in the United States</a>, <i>Shiliang Wu, Harvard University</i>
+  </li>
+  <li>
+    Coupling of global-regional models for impact of climate change on air quality, <i>Daewon Byun, University of Houston</i>
+  </li>
 </ul>
 
 <h3><a name="transport" id="transport"></a>Intercontinental Transport (Daewon Byun, chair)</h3>
 
 <ul class="disc">
- <li>
-  <a href="https://docs.google.com/presentation/d/18tJSwXq2DY2KJQmooox4-vStoQmei5uf/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Testable sensitivities of CTM simulations to meteorological fields</a>, <i>Yuhang Wang, Georgia Tech</i>
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1YhtCkUR4Uc9FVVgF9gtRjcWXl9ky5jGN/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">HTAP multi-model assessment of ozone source-receptor relationships</a>, <i>Arlene Fiore, NOAA/GFDL</i>
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1nvqZfSEewyGY1NRl9XuaUqFQUVwQlAXn/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Intercontinental transport of air pollution</a>, <i>Rokjin Park, Seoul National University</i>
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1SZoggXP7CiSYimG0KDc19RPKlecBbpgM/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Long-range transport of NOy and ozone from Asia</a>, <i>Thomas Walker, Dalhousie University</i>
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1dRc6q2AAdNB3fc1tiUE6X2FTDIC5v1QM/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Analysis of MILAGRO/INTEX-B data</a>, <i>Changshub Shim, JPL</i>
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/18At7zjw6ReisvsN9ineVL0Er3KkCOuSC/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Transpacific transport of ozone pollution during INTEX-B</a>, <i>Lin Zhang, Harvard University</i>
- </li>
- <li>
-  <a href="https://docs.google.com/presentation/d/1hvab1xUOMbr8RyHJSUT6s3yuS5CaJUM_/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Long-range transport of black carbon to northern highlatitudes</a>, <i>Qinbin Li, JPL</i>
- </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/18tJSwXq2DY2KJQmooox4-vStoQmei5uf/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Testable sensitivities of CTM simulations to meteorological fields</a>, <i>Yuhang Wang, Georgia Tech</i>
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1YhtCkUR4Uc9FVVgF9gtRjcWXl9ky5jGN/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">HTAP multi-model assessment of ozone source-receptor relationships</a>, <i>Arlene Fiore, NOAA/GFDL</i>
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1nvqZfSEewyGY1NRl9XuaUqFQUVwQlAXn/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Intercontinental transport of air pollution</a>, <i>Rokjin Park, Seoul National University</i>
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1SZoggXP7CiSYimG0KDc19RPKlecBbpgM/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Long-range transport of NOy and ozone from Asia</a>, <i>Thomas Walker, Dalhousie University</i>
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1dRc6q2AAdNB3fc1tiUE6X2FTDIC5v1QM/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Analysis of MILAGRO/INTEX-B data</a>, <i>Changshub Shim, JPL</i>
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/18At7zjw6ReisvsN9ineVL0Er3KkCOuSC/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Transpacific transport of ozone pollution during INTEX-B</a>, <i>Lin Zhang, Harvard University</i>
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1hvab1xUOMbr8RyHJSUT6s3yuS5CaJUM_/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Long-range transport of black carbon to northern highlatitudes</a>, <i>Qinbin Li, JPL</i>
+  </li>
 </ul>
 
 <h3><a name="wgs" id="wgs"></a>Working Group Summaries</h3>
 
 <ul class="disc">
- <li>
-  Emissions <i>(Prasad Kasibhatla and Jennifer Logan, leads)</i>
+  <li>
+    Emissions <i>(Prasad Kasibhatla and Jennifer Logan, leads)</i>
+ </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/1Mc7ZKK1dQrrBCI0GEnlaXVJQHCZspCGz/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Chemistry</a>,  <i>(Isabelle Bey and Yuhang Wang, leads)</i>
+ </li>
+  <li>
+    Aerosols <i>(Rokjin Park and Fangqun Yu, leads)</i>
  </li>
  <li>
-  <a href="https://docs.google.com/presentation/d/1Mc7ZKK1dQrrBCI0GEnlaXVJQHCZspCGz/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Chemistry</a>,  <i>(Isabelle Bey and Yuhang Wang, leads)</i>
+   Regional Air Quality <i>(Daewon Byun and Yuxuan Wang, leads)</i>
  </li>
  <li>
-  Aerosols <i>(Rokjin Park and Fangqun Yu, leads)</i>
+   Inverse Modeling and Data Assimilation <i>(Dylan Jones and Qinbin Li, leads)</i>
  </li>
  <li>
-  Regional Air Quality <i>(Daewon Byun and Yuxuan Wang, leads)</i>
- </li>
- <li>
-  Inverse Modeling and Data Assimilation <i>(Dylan Jones and Qinbin Li, leads)</i>
- </li>
- <li>
-  Mercury and Biogeochemistry <i>(Lyatt Jaegle and Parv Suntharalingam, leads)</i>
+   Mercury and Biogeochemistry <i>(Lyatt Jaegle and Parv Suntharalingam, leads)</i>
  </li>
 </ul>
 

--- a/igc3-presentations.html
+++ b/igc3-presentations.html
@@ -1,9 +1,4 @@
 <!DOCTYPE html>
-<!--[if IEMobile 7]><html class="iem7"  lang="en" dir="ltr"><![endif]-->
-<!--[if lte IE 6]><html class="lt-ie9 lt-ie8 lt-ie7"  lang="en" dir="ltr"><![endif]-->
-<!--[if (IE 7)&(!IEMobile)]><html class="lt-ie9 lt-ie8"  lang="en" dir="ltr"><![endif]-->
-<!--[if IE 8]><html class="lt-ie9"  lang="en" dir="ltr"><![endif]-->
-<!--[if (gte IE 9)|(gt IEMobile 7)]><!--><html  lang="en" dir="ltr"><!--<![endif]-->
 <head>
 <meta charset="utf-8" />
 <!--<base href="/igc3-presentations" />-->
@@ -18,23 +13,12 @@
 <title>The 3rd GEOS-Chem Meeting</title>
 <meta http-equiv="x-ua-compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<link type="text/css" rel="stylesheet" href="css/css_xE-rWrJf-fncB6ztZfd2huxqgxu4WO-qwma6Xer30m4%EF%B9%96m=1675397288.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_1kR8T1_c-l5pBT6ZwbDT7BFda-4fyqW9Jjum29_2IY8%EF%B9%96m=1675397312.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_YnlUIvHP13qgpYEqubzE8JyDwlSxUnVibfnVkSoSDb0%EF%B9%96m=1675397273.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_Ku-3OcT9qU9h7dnGig5e23q6EVryY8orK4wzVDxsweE%EF%B9%96m=1675397367.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_vprtFTrWyg23GbY50_zJZHWGYMNfS8vsrRS26i4-ISk%EF%B9%96m=1675397406.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_dW-aNNrctRhQNc-KECjtQd0PxuW-h19IEum-TX2MeEk%EF%B9%96m=1675397301.css" media="print" />
-<link type="text/css" rel="stylesheet" href="css/css_SH2Lx3Qprh0GZo_9xRp85U9NsWfkSXn_Bi-rJoMY1sw%EF%B9%96m=1675397273.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_uaIDKcYMUK5osSQXuirpr3ZleXtnnpBN-eiECm7N0M0%EF%B9%96m=1675397395.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/responsive.blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/geos-chem.css" media="all"/>
 <script type="text/javascript" src="dropdown-menu.js"></script>
-<!--[if lte IE 8]>
-<script type="text/javascript">
-  var os_c = document.createElement;os_c('header');os_c('nav');os_c('section');os_c('article');os_c('aside');os_c('footer');os_c('hgroup');os_c('figure');
-</script>
-<![endif]-->
 </head>
 
 <body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-1585687 node-type-page og-context og-context-node og-context-node-1585652 navbar-on">
@@ -57,7 +41,7 @@
 <div class="block-content content" ng-non-bindable="">
 <div id='boxes-box-1630413211' class='boxes-box'>
 <div class="boxes-box-content">
-<img height="551" width="1101" style="float: right; width: 350px; height: 175px; margin-bottom: 1.5em;" alt="gca2 logo" class="media-element file-default file-os-files-xxlarge" src="img/igc-early-logo.png" title="" />
+<img height="551" width="1101" style="float: right; width: 350px; height: 175px; margin-bottom: 1.5em;" alt="ig logo" class="media-element file-default file-os-files-xxlarge" src="img/igc-early-logo.png" title="" />
 <h2 class="css-brand--css-geos-meetings-header-h2-xxxlarge">
   The 3rd GEOS-Chem Scientific and Users' Meeting (IGC3)<br />April 11-13 2007
 </h2>
@@ -76,15 +60,16 @@
 
 <!--main menu region beg-->
 <div id="menu-bar" class="nav region-menu-bar clearfix">
-<nav id="block-os-igc3-menu" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="igc3_menu">  
-<ul class="nice-menu nice-menu-down nice-menu-igc3_menu" id="nice-menu-igc3_menu">
-  <li class="menu-860313 menu-path-node-1587125  first   odd  "><a href="igc3.html"  class="active">Home</a></li>
-  <li class="menu-860317 menu-path-node-1587126   even   last "><a href="igc3-presentations.html" >Presentations</a></li>
+<nav id="block-os-igc3-menu" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="igc3_menu">
+<ul class="nice-menu nice-menu-down">
+  <li><a href="igc3.html" class="active">IGC3 Home</a></li>
+  <li><a href="igc3-presentations.html">Presentations and Posters</a></li>
+  <li><a href="index.html">GEOS-Chem Home</a></li>
 </ul>
 </nav>
 </div>
 <!--main menu region end-->
-		
+  
 <div id="columns" class="clearfix">
 <div class="hg-container">
 <div id="content-column" role="main">
@@ -94,7 +79,7 @@
 <a name="main-content"></a>
 <h1 id="page-title" ng-non-bindable="">Presentations</h1>
 </header>
-														
+              
 <!--front panel regions beg-->
 <div id="content-panels" class="at-panel gpanel panel-display content clearfix">
 <div class="region region-content-top">
@@ -117,161 +102,161 @@
 <h3><a name="model_overview" id="model_overview"></a>Model Overview (Daniel Jacob, chair)</h3>
 
 <ul class="disc">
-	<li>
-		Welcome,  <i>Daniel Jacob, Harvard University</i>
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1JllkiD2knhXV2lQOuTCu-6gIOGUO25tG/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">GEOS-Chem model: present state, future directions</a>,  <i>Daniel Jacob, Harvard University</i>
-	</li>
+ <li>
+  Welcome,  <i>Daniel Jacob, Harvard University</i>
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1JllkiD2knhXV2lQOuTCu-6gIOGUO25tG/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">GEOS-Chem model: present state, future directions</a>,  <i>Daniel Jacob, Harvard University</i>
+ </li>
     <li>
-    	<a href="https://docs.google.com/presentation/d/1SdTAI4xIP6Zy6lEgvelxlQrsIgQw3abU/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">GEOS-Chem code: new developments</a>, <i>Bob Yantosca, Harvard University</i>
+     <a href="https://docs.google.com/presentation/d/1SdTAI4xIP6Zy6lEgvelxlQrsIgQw3abU/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">GEOS-Chem code: new developments</a>, <i>Bob Yantosca, Harvard University</i>
     </li>
     <li>
-    	<a href="https://docs.google.com/presentation/d/1CZWbAJgRYTQOrtbQzp-k_1MRUzb6U9ZD/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">GEOS-5 meteorological data, tracer transport</a>, <i>Max Suarez and Steven Pawson, NASA/GMAO</i>
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1KrlLuVr3mTWxVs_JZ5R9I6-sZYp6P4Df/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">GEOS-Chem adjoint construction and long-term maintainability</a>, <i>Adrian Sandu, Virginia Tech</i>
-	</li>
+     <a href="https://docs.google.com/presentation/d/1CZWbAJgRYTQOrtbQzp-k_1MRUzb6U9ZD/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">GEOS-5 meteorological data, tracer transport</a>, <i>Max Suarez and Steven Pawson, NASA/GMAO</i>
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1KrlLuVr3mTWxVs_JZ5R9I6-sZYp6P4Df/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">GEOS-Chem adjoint construction and long-term maintainability</a>, <i>Adrian Sandu, Virginia Tech</i>
+ </li>
 </ul>
 
 <h3><a name="glob_trop_chem" id="glob_trop_chem"></a>Global Tropospheric Chemistry (Dylan Jones, chair)</h3>
 
 <ul class="disc">
-	<li>
-		<a href="https://docs.google.com/presentation/d/1CyHPbOMuX_zOCOR0I0L1YO71w0uUkv5X/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Status of global ozone and CO simulations</a>, <i>Jennifer Logan, Harvard University</i>
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/14bW416FcbBGYctTbvZx6zMkjEOpicLOh/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Year-to-year variations in global OH radicals over the last 20-year period</a>, <i>Isabelle Bey, EPFL</i>
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1UXmTQCi2PW8ZPt3f2EIh35KX_erYzy9X/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Cross evaluation of OMI, TES, and GEOS-Chem tropospheric ozone</a>, <i>Xiong Liu, CFA</i>
-	</li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1CyHPbOMuX_zOCOR0I0L1YO71w0uUkv5X/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Status of global ozone and CO simulations</a>, <i>Jennifer Logan, Harvard University</i>
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/14bW416FcbBGYctTbvZx6zMkjEOpicLOh/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Year-to-year variations in global OH radicals over the last 20-year period</a>, <i>Isabelle Bey, EPFL</i>
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1UXmTQCi2PW8ZPt3f2EIh35KX_erYzy9X/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Cross evaluation of OMI, TES, and GEOS-Chem tropospheric ozone</a>, <i>Xiong Liu, CFA</i>
+ </li>
     <li>
-    	<a href="https://docs.google.com/presentation/d/189eldIHRWu-K8fOHelQRRUFGhijhzk0b/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Simulation of TES ozone</a>,  <i>Ray Nassar, Harvard University</i>
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1Lf1_RhLn4rEIfNx28w1GJfWkQcKPBrk-/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Assimilation of TES observations</a>, <i>Mark Parrington, University of Toronto</i>
-	</li>
+     <a href="https://docs.google.com/presentation/d/189eldIHRWu-K8fOHelQRRUFGhijhzk0b/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Simulation of TES ozone</a>,  <i>Ray Nassar, Harvard University</i>
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1Lf1_RhLn4rEIfNx28w1GJfWkQcKPBrk-/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Assimilation of TES observations</a>, <i>Mark Parrington, University of Toronto</i>
+ </li>
     <li>
-    	<a href="https://docs.google.com/presentation/d/19lbZC7H74bzIzlbePjpYH9iK7H8keOt8/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Variability of upper tropospheric ozone and CO</a>,  <i>Chenxia Cai, JPL</i>
+     <a href="https://docs.google.com/presentation/d/19lbZC7H74bzIzlbePjpYH9iK7H8keOt8/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Variability of upper tropospheric ozone and CO</a>,  <i>Chenxia Cai, JPL</i>
     </li>
     <li>
-    	<a href="https://docs.google.com/presentation/d/1PIDIqymnceHh8saIR6OrWUxZFAJ93bmk/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Impact of seasonal variations in long-range transport on tropospheric ozone</a>, <i>Jane Liu, University of Toronto</i>
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1S3siOdvmUuws6L_ZhSB3N1jPHwKEdZLW/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Dynamic tropopause and spatial reduction mechanism</a>, <i>Philippe LeSager and Yevgenii Rastigeyev, Harvard University</i>
-	</li>
+     <a href="https://docs.google.com/presentation/d/1PIDIqymnceHh8saIR6OrWUxZFAJ93bmk/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Impact of seasonal variations in long-range transport on tropospheric ozone</a>, <i>Jane Liu, University of Toronto</i>
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1S3siOdvmUuws6L_ZhSB3N1jPHwKEdZLW/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Dynamic tropopause and spatial reduction mechanism</a>, <i>Philippe LeSager and Yevgenii Rastigeyev, Harvard University</i>
+ </li>
     <li>
-    	<a href="https://docs.google.com/presentation/d/1GbzKgU_Kc_wWya0I6FOU31KKQTRtA0xT/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Adapting GEOS-Chem to Mars photochemistry</a>, <i>Huiqun Wang, CFA</i>
-	</li>
+     <a href="https://docs.google.com/presentation/d/1GbzKgU_Kc_wWya0I6FOU31KKQTRtA0xT/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Adapting GEOS-Chem to Mars photochemistry</a>, <i>Huiqun Wang, CFA</i>
+ </li>
 </ul>
 
 <h3><a name="aerosols_1" id="aerosols_1"></a>Aerosols I (Qinbin Li, chair)</h3>
 
 <ul class="disc">
-	<li>
-		<a href="https://docs.google.com/presentation/d/138i5sY1SGmbtwF-XJxhIKHItp7G5KC5O/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Global simulation of SO2 concentrations with updated emission inventory</a>, <i>Gan Luo, SUNY Albany</i>
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1eajy9t8cZBq0AOjsa8LjLeqJZKQBFq6O/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Coupling of sulfate aerosol with gas-phase precursors</a>, <i>Daven Henze, Caltech</i>
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/14V_n1WUrbnSjZnINQKlOp44QKaMfegfA/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Updates to fossil-fuel emissions and long-range transport of sulfur to Canada</a>, <i>Aaron van Donkelaar, Dalhousie University</i>
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1Eh8Eb7QHAhf-ENxElIJcfOjgYwlfy0_y/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Sensitivity of sulfate direct climate forcing to particle phase transitions</a>, <i>Jun Wang, Harvard University</i>
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1wLA7ha7DiHf4tEANLk7lkUXnx3y1lAjy/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Organic carbon aerosol: insight from recent field campaigns</a>, <i>Colette Heald, UC Berkeley</i>
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/18TRaDnKFl_zBVDqKx1XP5H1G2mhhahH3/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Global budget of glyoxal and methylglyoxal, and implication for SOA</a>, <i>May Fu, Harvard University</i>
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1E3Vx8BnF-yvr0-o5ujGRwSvr-oVJIhw0/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">The effect of climate on secondary organic aerosols</a>, <i>Havala Pye, Caltech</i>
-	</li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/138i5sY1SGmbtwF-XJxhIKHItp7G5KC5O/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Global simulation of SO2 concentrations with updated emission inventory</a>, <i>Gan Luo, SUNY Albany</i>
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1eajy9t8cZBq0AOjsa8LjLeqJZKQBFq6O/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Coupling of sulfate aerosol with gas-phase precursors</a>, <i>Daven Henze, Caltech</i>
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/14V_n1WUrbnSjZnINQKlOp44QKaMfegfA/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Updates to fossil-fuel emissions and long-range transport of sulfur to Canada</a>, <i>Aaron van Donkelaar, Dalhousie University</i>
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1Eh8Eb7QHAhf-ENxElIJcfOjgYwlfy0_y/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Sensitivity of sulfate direct climate forcing to particle phase transitions</a>, <i>Jun Wang, Harvard University</i>
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1wLA7ha7DiHf4tEANLk7lkUXnx3y1lAjy/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Organic carbon aerosol: insight from recent field campaigns</a>, <i>Colette Heald, UC Berkeley</i>
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/18TRaDnKFl_zBVDqKx1XP5H1G2mhhahH3/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Global budget of glyoxal and methylglyoxal, and implication for SOA</a>, <i>May Fu, Harvard University</i>
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1E3Vx8BnF-yvr0-o5ujGRwSvr-oVJIhw0/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">The effect of climate on secondary organic aerosols</a>, <i>Havala Pye, Caltech</i>
+ </li>
 </ul>
 
 <h3><a name="aerosols_2" id="aerosols_2"></a>Aerosols II (Randall Martin, chair)</h3>
 
 <ul>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1dSzkjWcbz9FDlpj0ReiagTJ9-KwWAZNs/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Dust modeling and preliminary analysis of INTEX-B data</a>, <i>Duncan Fairlie, NASA LaRC</i>
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1QLdwTIwfI4Fey1nyxgTn9asaTPnMqU-h/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Modeling of soluble iron formation, transport and deposition to the Pacific</a>, <i>Fabien Solmon, UC Santa Cruz</i>
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/12SPipjChAj3BF_17421zaGXiNJjTCUUO/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Deriving PM2.5 speciation information using MISR data coupled with GEOS-Chem </a>, <i>Yang Liu, Harvard School of Public Health</i>
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1u2lzl3W8ieS3xdpGCP3h6Dz64J5_wcsE/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Deriving AODs from MODIS radiances</a>, <i>Easan Drury, Harvard University</i>
-	</li>
-	<li>
-		New particle formation in the global atmosphere<i>Fangqun Yu, SUNY Albany</i>
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1wuXQwqmh4Q7V-7_QxunVtz09zNzeTZ1B/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Implementation of sulfate and sea-salt aerosol microphysics into GEOS-Chem</a>, <i>Win Trivitayanurak, Carnegie-Mellon University</i>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1oEgWGxIvZeDy0DTzHZYdKio_oisa6FQw/view?usp=drive_link" target="_blank">Comparisons of Ozone and Aerosols in US and East Asia between 2001 and 2002</a>,  <i>Joshua Fu, University of Tennessee</i>
-	</li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1dSzkjWcbz9FDlpj0ReiagTJ9-KwWAZNs/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Dust modeling and preliminary analysis of INTEX-B data</a>, <i>Duncan Fairlie, NASA LaRC</i>
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1QLdwTIwfI4Fey1nyxgTn9asaTPnMqU-h/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Modeling of soluble iron formation, transport and deposition to the Pacific</a>, <i>Fabien Solmon, UC Santa Cruz</i>
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/12SPipjChAj3BF_17421zaGXiNJjTCUUO/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Deriving PM2.5 speciation information using MISR data coupled with GEOS-Chem </a>, <i>Yang Liu, Harvard School of Public Health</i>
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1u2lzl3W8ieS3xdpGCP3h6Dz64J5_wcsE/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Deriving AODs from MODIS radiances</a>, <i>Easan Drury, Harvard University</i>
+ </li>
+ <li>
+  New particle formation in the global atmosphere<i>Fangqun Yu, SUNY Albany</i>
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1wuXQwqmh4Q7V-7_QxunVtz09zNzeTZ1B/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Implementation of sulfate and sea-salt aerosol microphysics into GEOS-Chem</a>, <i>Win Trivitayanurak, Carnegie-Mellon University</i>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1oEgWGxIvZeDy0DTzHZYdKio_oisa6FQw/view?usp=drive_link" target="_blank">Comparisons of Ozone and Aerosols in US and East Asia between 2001 and 2002</a>,  <i>Joshua Fu, University of Tennessee</i>
+ </li>
 </ul>
 
 <h3><a name="posters" id="posters"></a>Poster Session</h3>
 
 <ul class="disc">
-	<li>
-		Evaluating the global health impact of intercontinental transport of fine aerosols <i>Junfeng Liu, Princeton University</i>
-	</li>
-	<li>
-		A regional aerosol modeling perspective on global models <i>Scott Spak, University of Wisconsin</i>
-	</li>
-	<li>
-		A model study of ozone over Europe during the August 2003 heat wave <i>Guergana Guerova, University of Wollongong</i>
-	</li>
-	<li>
-		Long range transport of ammonia from sugarcane cropping <i>Guergana Guerova, University of Wollongong</i>
-	</li>
-	<li>
-		Air pollution radiative forcing from emission sectors: prototype for a new IPCC bar chart <i>Nadine Unger, NASA/GISS</i>
-	</li>
-	<li>
-		Future trends in ozone exceedances over the Northeast United States <i>Loretta Mickley, Harvard University</i>
-	</li>
-	<li>
-		Air quality degradation in future climate due to decreased cyclone frequency <i>Eric Leibensperger, Harvard University</i>
-	</li>
-	<li>
-		Evaluation of GMI Combo model simulations with TES ozone data: indirect TES validation <i>Jennifer Logan, Harvard University</i>
-	</li>
-	<li>
-		Evaluating model contributions to tropospheric ozone with aircraft datain factor-projected space <i>Changsub Shim, JPL</i>
-	</li>
-   	<li>
-   		CMAQ modeling of China's regional air quality <i>Dan Chen, Tsinghua University</i>
-	</li>
-	<li>
-		Evaluation of Tropospheric Aerosol Microphysics Simulations Using Observations <i>Win Trivitayanurak, Carnegie-Mellon University</i>
-	</li>
-	<li>
-		Sea-salt aerosols: impact on air pollution of the Attica Peninsula Greece <i>E. Athanasopoulou, National Observatory of Athens</i>
-	</li>
-	<li>
-		Influence of the city of Athens in the evolution of the sea-breeze front <i>A. Dandou, National Observatory of Athens</i>
-	</li>
-	<li>
-		Influence of different PBL schemes on ozone predictions over the GAA <i>E. Bossioli, National Observatory of Athens</i>
-	</li>
-	<li>
-		Comparison of the GMI Combo CTM with observations from the Aura period <i>Duncan, Yoshida, Rodriguez, NASA/GSFC</i>
-	</li>
-	<li>
-		Source-receptor relationship of trans-Pacific transport of East Asian sulfate <i>Junfeng Liu, Princeton University</i>
-	</li>
-	<li>
-		Processes driving ozone in the tropics and in the South Atlantic <i>Bastien Sauvage, Dalhousie University</i>
-	</li>
+ <li>
+  Evaluating the global health impact of intercontinental transport of fine aerosols <i>Junfeng Liu, Princeton University</i>
+ </li>
+ <li>
+  A regional aerosol modeling perspective on global models <i>Scott Spak, University of Wisconsin</i>
+ </li>
+ <li>
+  A model study of ozone over Europe during the August 2003 heat wave <i>Guergana Guerova, University of Wollongong</i>
+ </li>
+ <li>
+  Long range transport of ammonia from sugarcane cropping <i>Guergana Guerova, University of Wollongong</i>
+ </li>
+ <li>
+  Air pollution radiative forcing from emission sectors: prototype for a new IPCC bar chart <i>Nadine Unger, NASA/GISS</i>
+ </li>
+ <li>
+  Future trends in ozone exceedances over the Northeast United States <i>Loretta Mickley, Harvard University</i>
+ </li>
+ <li>
+  Air quality degradation in future climate due to decreased cyclone frequency <i>Eric Leibensperger, Harvard University</i>
+ </li>
+ <li>
+  Evaluation of GMI Combo model simulations with TES ozone data: indirect TES validation <i>Jennifer Logan, Harvard University</i>
+ </li>
+ <li>
+  Evaluating model contributions to tropospheric ozone with aircraft datain factor-projected space <i>Changsub Shim, JPL</i>
+ </li>
+    <li>
+     CMAQ modeling of China's regional air quality <i>Dan Chen, Tsinghua University</i>
+ </li>
+ <li>
+  Evaluation of Tropospheric Aerosol Microphysics Simulations Using Observations <i>Win Trivitayanurak, Carnegie-Mellon University</i>
+ </li>
+ <li>
+  Sea-salt aerosols: impact on air pollution of the Attica Peninsula Greece <i>E. Athanasopoulou, National Observatory of Athens</i>
+ </li>
+ <li>
+  Influence of the city of Athens in the evolution of the sea-breeze front <i>A. Dandou, National Observatory of Athens</i>
+ </li>
+ <li>
+  Influence of different PBL schemes on ozone predictions over the GAA <i>E. Bossioli, National Observatory of Athens</i>
+ </li>
+ <li>
+  Comparison of the GMI Combo CTM with observations from the Aura period <i>Duncan, Yoshida, Rodriguez, NASA/GSFC</i>
+ </li>
+ <li>
+  Source-receptor relationship of trans-Pacific transport of East Asian sulfate <i>Junfeng Liu, Princeton University</i>
+ </li>
+ <li>
+  Processes driving ozone in the tropics and in the South Atlantic <i>Bastien Sauvage, Dalhousie University</i>
+ </li>
 </ul>
 
 <h2>Thursday, April 12, 2007</h2>
@@ -279,102 +264,102 @@
 <h3><a name="biomass" id="biomass"></a>Biomass Burning (Jennifer Logan, chair)</h3>
 
 <ul class="disc">
-	<li>
-		<a href="https://docs.google.com/presentation/d/1L-N-L_nIOPEPMf_nLp0B06aMn-K-JGUq/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Climate change, fires, and carbon aerosol over N. America</a>, <i>Dominick Spracklen and Loretta Mickley, Harvard University</i>
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1KGeMyV52wLCvj-_qLKFSCBrQzj_1wWLB/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Simulation of Australian bushfire season 2002/2003</a>, <i>Guergana Guerova, University of Wollongong</i>
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1UpS5jLi72YDpe_pNYSmc1sLb_EBxjFBv/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Evaluation of aerosol and CO vertical distributions from wild fires</a>, <i>Sylvia Generoso, EPFL</i>
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1-vwa2Psit-YNCnEfm_q3iI5vbkMzoBra/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Dealing with injection height for biomass burning emissions</a>, <i>Fok-Yan Leung, Harvard University</i>
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1xYDjxyd9fEVmdCjkYTo3EU0TVo6Rpj0E/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Fire-driven interannual variability in CO, and SH seasonality of CO</a>, <i>Prasad Kasibhatla, Duke University</i>
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1KYEMk9u-h_VWUgJ424YfRLdUhekTNW-o/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Global transport and radiative forcing of biomass burning aerosols</a>, <i>Yang Chen, JPL</i>
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1lYwzu8mHnvTNirLYlruT_skLst6txP9M/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Assimilation of TES data for biomass burning influence on tropospheric ozone</a>, <i>Dylan Jones, University of Toronto</i>
-	</li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1L-N-L_nIOPEPMf_nLp0B06aMn-K-JGUq/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Climate change, fires, and carbon aerosol over N. America</a>, <i>Dominick Spracklen and Loretta Mickley, Harvard University</i>
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1KGeMyV52wLCvj-_qLKFSCBrQzj_1wWLB/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Simulation of Australian bushfire season 2002/2003</a>, <i>Guergana Guerova, University of Wollongong</i>
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1UpS5jLi72YDpe_pNYSmc1sLb_EBxjFBv/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Evaluation of aerosol and CO vertical distributions from wild fires</a>, <i>Sylvia Generoso, EPFL</i>
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1-vwa2Psit-YNCnEfm_q3iI5vbkMzoBra/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Dealing with injection height for biomass burning emissions</a>, <i>Fok-Yan Leung, Harvard University</i>
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1xYDjxyd9fEVmdCjkYTo3EU0TVo6Rpj0E/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Fire-driven interannual variability in CO, and SH seasonality of CO</a>, <i>Prasad Kasibhatla, Duke University</i>
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1KYEMk9u-h_VWUgJ424YfRLdUhekTNW-o/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Global transport and radiative forcing of biomass burning aerosols</a>, <i>Yang Chen, JPL</i>
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1lYwzu8mHnvTNirLYlruT_skLst6txP9M/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Assimilation of TES data for biomass burning influence on tropospheric ozone</a>, <i>Dylan Jones, University of Toronto</i>
+ </li>
 </ul>
 
 <h3><a name="voc" id="voc"></a>VOC Emissions and Carbon Fluxes (Prasad Kasibhatla, chair)</h3>
 
 <ul class="disc">
-	<li>
-		<a href="https://docs.google.com/presentation/d/1-Lc_r-yP_32DD1_F49LaeId2P4Yk9u_I/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Biogenic emissions from tropical ecosystems</a>, <i>Michael Barkley, University of Edinburgh</i>
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1lOWPjSbV5E-aCCR-0Prv5FCswSO7ZA6i/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Biogenic emissions and VOC oxidation</a>, <i>Gabriele Curci, University of L'Aquila</i>
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1g98vxA7LGyhpjjm_xVIpkFcgedhrcLMg/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">OMI HCHO measurements to test isoprene emissions and land cover</a>, <i>Dylan Millet, Harvard University</i>
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1eRhnpzuXFheK3B11yZBiAK9865G9iPvH/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Evolution of methane concentrations over the last 20 years</a>, <i>Jerome Drevet, EPFL</i>
-	</li>
-	<li>
-		Analysis of AIRS CO2 and ozone retrievals. <i>Xun Jiang, JPL</i>
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1JTFoyGhbT41npp908XlZzIZihj4hqDCJ/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Improving estimates of CO2 fluxes through a joint CO-CO2 adjoint inversion</a>, <i>Monika Kopacz, Harvard University</i>
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/14EVVljB8ciqMVtjbDDZ4Igm3vo9IBKRJ/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Factors governing the seasonal variability of atmospheric carbonyl sulfide</a>, <i>Parvadha Suntharalingam, Harvard University</i>
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1pxhGxeoA7-owrY6SSYjTBYaAbLKLZ_oK/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Acetylene-CO relationship and U.S. sources of ethane</a>, <i>Yaping Xiao, University of New Hampshire</i>
-	</li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1-Lc_r-yP_32DD1_F49LaeId2P4Yk9u_I/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Biogenic emissions from tropical ecosystems</a>, <i>Michael Barkley, University of Edinburgh</i>
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1lOWPjSbV5E-aCCR-0Prv5FCswSO7ZA6i/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Biogenic emissions and VOC oxidation</a>, <i>Gabriele Curci, University of L'Aquila</i>
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1g98vxA7LGyhpjjm_xVIpkFcgedhrcLMg/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">OMI HCHO measurements to test isoprene emissions and land cover</a>, <i>Dylan Millet, Harvard University</i>
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1eRhnpzuXFheK3B11yZBiAK9865G9iPvH/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Evolution of methane concentrations over the last 20 years</a>, <i>Jerome Drevet, EPFL</i>
+ </li>
+ <li>
+  Analysis of AIRS CO2 and ozone retrievals. <i>Xun Jiang, JPL</i>
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1JTFoyGhbT41npp908XlZzIZihj4hqDCJ/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Improving estimates of CO2 fluxes through a joint CO-CO2 adjoint inversion</a>, <i>Monika Kopacz, Harvard University</i>
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/14EVVljB8ciqMVtjbDDZ4Igm3vo9IBKRJ/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Factors governing the seasonal variability of atmospheric carbonyl sulfide</a>, <i>Parvadha Suntharalingam, Harvard University</i>
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1pxhGxeoA7-owrY6SSYjTBYaAbLKLZ_oK/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Acetylene-CO relationship and U.S. sources of ethane</a>, <i>Yaping Xiao, University of New Hampshire</i>
+ </li>
 </ul>
 
 <h3><a name="nox" id="nox"></a>NOx Emissions and Chemistry (Isabelle Bey, chair)</h3>
 
 <ul class="disc">
-	<li>
-		<a href="https://docs.google.com/presentation/d/1TeTBsE09EivfUXMNbojDvIUC090PKU-r/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Constraining the magnitude and diurnal variation of NOx sources from space</a>, <i>Folkert Boersma, Harvard University</i>
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1EgkwA83JcB1o8uvSSIMpfiB6z1KoXdpw/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Surface nitrogen dioxide concentrations inferred from OMI</a>, <i>Lok Lamsal, Dalhousie University</i>
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1yWb_jUn78gPQeppmUX0Oodve2qPF_ftV/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Development of the bottom-up soil NOx inventory</a>, <i>Neil Moore, Dalhousie University</i>
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/16KnDy5dHdyOfgpNskPjQn81CGCXO6yXZ/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true">Constraints on lightning NOx emissions inferred from satellite observations</a>, <i>Randall Martin, Dalhousie University</i>
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/17Yg_YJ2RwgHWSjoa5pxx0MdWyHKjAzq3/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Lightning NOx source emissions in GEOS-Chem</a>, <i>Lee Murray, Harvard University</i>
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1IOZn6nQln3ptGEAr1Ayf_Fk5gwie8riQ/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Year-to-year variations in ozone and in satellite-derived NOx emissions</a>, <i>Simos Koumoutsaris, EPFL</i>
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1IXfmhZPVJNwCCyD9vdzJfYdi8Dj78Vqm/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">U.S. influence on tropospheric ozone and the effects of recent emission reductions</a>, <i>Rynda Hudman, Harvard University</i>
-	</li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1TeTBsE09EivfUXMNbojDvIUC090PKU-r/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Constraining the magnitude and diurnal variation of NOx sources from space</a>, <i>Folkert Boersma, Harvard University</i>
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1EgkwA83JcB1o8uvSSIMpfiB6z1KoXdpw/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Surface nitrogen dioxide concentrations inferred from OMI</a>, <i>Lok Lamsal, Dalhousie University</i>
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1yWb_jUn78gPQeppmUX0Oodve2qPF_ftV/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Development of the bottom-up soil NOx inventory</a>, <i>Neil Moore, Dalhousie University</i>
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/16KnDy5dHdyOfgpNskPjQn81CGCXO6yXZ/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true">Constraints on lightning NOx emissions inferred from satellite observations</a>, <i>Randall Martin, Dalhousie University</i>
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/17Yg_YJ2RwgHWSjoa5pxx0MdWyHKjAzq3/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Lightning NOx source emissions in GEOS-Chem</a>, <i>Lee Murray, Harvard University</i>
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1IOZn6nQln3ptGEAr1Ayf_Fk5gwie8riQ/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Year-to-year variations in ozone and in satellite-derived NOx emissions</a>, <i>Simos Koumoutsaris, EPFL</i>
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1IXfmhZPVJNwCCyD9vdzJfYdi8Dj78Vqm/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">U.S. influence on tropospheric ozone and the effects of recent emission reductions</a>, <i>Rynda Hudman, Harvard University</i>
+ </li>
 </ul>
 
 <h3><a name="mercury" id="mercury"></a>Mercury (Lyatt Jaegle, chair)</h3>
 
 <ul class="disc">
-	<li>
-		<a href="https://docs.google.com/presentation/d/1yT6al5aZu_hwFbZ5VVBsCQh9Zg_OXQrq/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">A biogeochemical model for mercury in GEOS-Chem</a>, <i>Noelle Selin, Harvard University</i>
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1dzvcJaJ3jEtwEmG9udUmyMXjSamD-oGy/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Transpacific transport of mercury</a>, <i>Sarah Strode, University of Washington</i>
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1LvjKboA7EdrAj5pL-bTWfnq4dsnoEyqg/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Discerning mercury-halogen chemistry</a>, <i>Chris Holmes, Harvard University</i>
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1mnnamZTRv_-4T6_XTFdklYMNFN4kxSHu/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Incorporating a land surface model of terrestrial mercury storage</a>, <i>Nicole Downey, Harvard University</i>
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1oNLhjuPIk_1G7eFaDROo7ZojbnzRpRRS/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Ocean-atmosphere model linkages</a>, <i>Elsie Sunderland, EPA</i>
-	</li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1yT6al5aZu_hwFbZ5VVBsCQh9Zg_OXQrq/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">A biogeochemical model for mercury in GEOS-Chem</a>, <i>Noelle Selin, Harvard University</i>
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1dzvcJaJ3jEtwEmG9udUmyMXjSamD-oGy/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Transpacific transport of mercury</a>, <i>Sarah Strode, University of Washington</i>
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1LvjKboA7EdrAj5pL-bTWfnq4dsnoEyqg/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Discerning mercury-halogen chemistry</a>, <i>Chris Holmes, Harvard University</i>
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1mnnamZTRv_-4T6_XTFdklYMNFN4kxSHu/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Incorporating a land surface model of terrestrial mercury storage</a>, <i>Nicole Downey, Harvard University</i>
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1oNLhjuPIk_1G7eFaDROo7ZojbnzRpRRS/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Ocean-atmosphere model linkages</a>, <i>Elsie Sunderland, EPA</i>
+ </li>
 </ul>
 
 <h2><i>Friday, April 13, 2007</i></h2>
@@ -382,76 +367,76 @@
 <h3><a name="aq" id="aq"></a>Regional Air Quality (Rokjin Park, chair)</h3>
 
 <ul class="disc">
-	<li>
-		<a href="https://docs.google.com/presentation/d/1omEHhwkGCB-c3Nos_UwrJJVQ0UUFdu9G/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Nested grid application of GC over Europe</a>, <i>A. Protonotariou, National Observatory of Athens</i>
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1jHL7R4yRFv1BA8MYD4Oxh4N3BQMp_Xsk/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Coupling GEOS-Chem with a regional air pollution model for Greece</a>, <i>E. Bossioli, National Observatory of Athens</i>
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1CgyrqO26swOUHBcOjwleVbHPtxDCUgBG/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Simulation of air pollutants over China</a>, <i>Hong Liao, Chinese Academy of Sciences</i>
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1jcULRSH_6OJsi_QG7tzB-ym1NIWGamTw/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true">Sources of NOx and tropospheric O3 chemistry over Beijing</a>, <i>Yuxuan Wang, Harvard University</i>
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1rPukJLB0B-5Ai5HE8PGgI1jHbxb95evw/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Sensitivity of surface O3 to soil NOx emissions</a>, <i>Lyatt Jaegle, University of Washington</i>
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1uIPdH8eYsNSojjjnPPvDi-Z5gJM5FTBg/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Effects of 2000-2050 global change on ozone air quality in the United States</a>, <i>Shiliang Wu, Harvard University</i>
-	</li>
-	<li>
-		Coupling of global-regional models for impact of climate change on air quality, <i>Daewon Byun, University of Houston</i>
-	</li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1omEHhwkGCB-c3Nos_UwrJJVQ0UUFdu9G/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Nested grid application of GC over Europe</a>, <i>A. Protonotariou, National Observatory of Athens</i>
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1jHL7R4yRFv1BA8MYD4Oxh4N3BQMp_Xsk/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Coupling GEOS-Chem with a regional air pollution model for Greece</a>, <i>E. Bossioli, National Observatory of Athens</i>
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1CgyrqO26swOUHBcOjwleVbHPtxDCUgBG/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Simulation of air pollutants over China</a>, <i>Hong Liao, Chinese Academy of Sciences</i>
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1jcULRSH_6OJsi_QG7tzB-ym1NIWGamTw/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true">Sources of NOx and tropospheric O3 chemistry over Beijing</a>, <i>Yuxuan Wang, Harvard University</i>
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1rPukJLB0B-5Ai5HE8PGgI1jHbxb95evw/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Sensitivity of surface O3 to soil NOx emissions</a>, <i>Lyatt Jaegle, University of Washington</i>
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1uIPdH8eYsNSojjjnPPvDi-Z5gJM5FTBg/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Effects of 2000-2050 global change on ozone air quality in the United States</a>, <i>Shiliang Wu, Harvard University</i>
+ </li>
+ <li>
+  Coupling of global-regional models for impact of climate change on air quality, <i>Daewon Byun, University of Houston</i>
+ </li>
 </ul>
 
 <h3><a name="transport" id="transport"></a>Intercontinental Transport (Daewon Byun, chair)</h3>
 
 <ul class="disc">
-	<li>
-		<a href="https://docs.google.com/presentation/d/18tJSwXq2DY2KJQmooox4-vStoQmei5uf/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Testable sensitivities of CTM simulations to meteorological fields</a>, <i>Yuhang Wang, Georgia Tech</i>
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1YhtCkUR4Uc9FVVgF9gtRjcWXl9ky5jGN/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">HTAP multi-model assessment of ozone source-receptor relationships</a>, <i>Arlene Fiore, NOAA/GFDL</i>
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1nvqZfSEewyGY1NRl9XuaUqFQUVwQlAXn/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Intercontinental transport of air pollution</a>, <i>Rokjin Park, Seoul National University</i>
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1SZoggXP7CiSYimG0KDc19RPKlecBbpgM/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Long-range transport of NOy and ozone from Asia</a>, <i>Thomas Walker, Dalhousie University</i>
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1dRc6q2AAdNB3fc1tiUE6X2FTDIC5v1QM/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Analysis of MILAGRO/INTEX-B data</a>, <i>Changshub Shim, JPL</i>
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/18At7zjw6ReisvsN9ineVL0Er3KkCOuSC/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Transpacific transport of ozone pollution during INTEX-B</a>, <i>Lin Zhang, Harvard University</i>
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1hvab1xUOMbr8RyHJSUT6s3yuS5CaJUM_/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Long-range transport of black carbon to northern highlatitudes</a>, <i>Qinbin Li, JPL</i>
-	</li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/18tJSwXq2DY2KJQmooox4-vStoQmei5uf/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Testable sensitivities of CTM simulations to meteorological fields</a>, <i>Yuhang Wang, Georgia Tech</i>
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1YhtCkUR4Uc9FVVgF9gtRjcWXl9ky5jGN/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">HTAP multi-model assessment of ozone source-receptor relationships</a>, <i>Arlene Fiore, NOAA/GFDL</i>
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1nvqZfSEewyGY1NRl9XuaUqFQUVwQlAXn/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Intercontinental transport of air pollution</a>, <i>Rokjin Park, Seoul National University</i>
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1SZoggXP7CiSYimG0KDc19RPKlecBbpgM/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Long-range transport of NOy and ozone from Asia</a>, <i>Thomas Walker, Dalhousie University</i>
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1dRc6q2AAdNB3fc1tiUE6X2FTDIC5v1QM/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Analysis of MILAGRO/INTEX-B data</a>, <i>Changshub Shim, JPL</i>
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/18At7zjw6ReisvsN9ineVL0Er3KkCOuSC/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Transpacific transport of ozone pollution during INTEX-B</a>, <i>Lin Zhang, Harvard University</i>
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1hvab1xUOMbr8RyHJSUT6s3yuS5CaJUM_/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Long-range transport of black carbon to northern highlatitudes</a>, <i>Qinbin Li, JPL</i>
+ </li>
 </ul>
 
 <h3><a name="wgs" id="wgs"></a>Working Group Summaries</h3>
 
 <ul class="disc">
-	<li>
-		Emissions <i>(Prasad Kasibhatla and Jennifer Logan, leads)</i>
-	</li>
-	<li>
-		<a href="https://docs.google.com/presentation/d/1Mc7ZKK1dQrrBCI0GEnlaXVJQHCZspCGz/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Chemistry</a>,  <i>(Isabelle Bey and Yuhang Wang, leads)</i>
-	</li>
-	<li>
-		Aerosols <i>(Rokjin Park and Fangqun Yu, leads)</i>
-	</li>
-	<li>
-		Regional Air Quality <i>(Daewon Byun and Yuxuan Wang, leads)</i>
-	</li>
-	<li>
-		Inverse Modeling and Data Assimilation <i>(Dylan Jones and Qinbin Li, leads)</i>
-	</li>
-	<li>
-		Mercury and Biogeochemistry <i>(Lyatt Jaegle and Parv Suntharalingam, leads)</i>
-	</li>
+ <li>
+  Emissions <i>(Prasad Kasibhatla and Jennifer Logan, leads)</i>
+ </li>
+ <li>
+  <a href="https://docs.google.com/presentation/d/1Mc7ZKK1dQrrBCI0GEnlaXVJQHCZspCGz/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Chemistry</a>,  <i>(Isabelle Bey and Yuhang Wang, leads)</i>
+ </li>
+ <li>
+  Aerosols <i>(Rokjin Park and Fangqun Yu, leads)</i>
+ </li>
+ <li>
+  Regional Air Quality <i>(Daewon Byun and Yuxuan Wang, leads)</i>
+ </li>
+ <li>
+  Inverse Modeling and Data Assimilation <i>(Dylan Jones and Qinbin Li, leads)</i>
+ </li>
+ <li>
+  Mercury and Biogeochemistry <i>(Lyatt Jaegle and Parv Suntharalingam, leads)</i>
+ </li>
 </ul>
 
 </div>
@@ -476,65 +461,16 @@
 </div>
 </div>
 
-<!--footer region beg-->
+<!--footer-->
 <footer id="footer" class="clearfix" role="contentinfo">
-
-<!-- Three column 3x33 Gpanel -->
-<div class="at-panel gpanel panel-display footer clearfix">
-<div class="region region-footer">
-<div class="region-inner clearfix">
-<div id="block-boxes-1617037690" class="block block-boxes block-boxes-os_boxes_html no-title"  module="boxes" delta="1617037690">
-<div class="block-inner clearfix">  
-<div class="block-content content" ng-non-bindable="">  
-<div id='boxes-box-1617037690' class='boxes-box'>  
 <div class="boxes-box-content">
   <p style="text-align:center">
-    Copyright © 2023 by the International GEOS-Chem Community. All rights reserved.
+    Copyright © 2026 by the International GEOS-Chem Community. All rights reserved.
   </p>
 </div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-<div class="region region-footer-bottom">  
-<div class="region-inner clearfix">  
-<div id="block-boxes-1616879798" class="block block-boxes block-boxes-os_boxes_media no-title"  module="boxes" delta="1616879798">  
-<div class="block-inner clearfix">  
-<div class="block-content content"> 
-<div id='boxes-box-1616879798' class='boxes-box'> 
-<div class="boxes-box-content"> 
-<div id="file-3900146" class="file file-html file-html-embed">
-<h2 class="element-invisible"><a href="">css-brand</a></h2>
-<div class="content">
-<div class="file-info">
-</div>
-<div class="field field-name-field-html-code field-type-text-long field-label-hidden view-mode-full">
-<div class="field-items">
-<div class="field-item even">
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-
-<!--footer region end-->
 </footer>
-</div>
-</div>
 
-<!--page area ends-->
-
-<div id="extradiv"></div>
+</div>
 </div>
 
 </body>

--- a/igc3.html
+++ b/igc3.html
@@ -1,9 +1,4 @@
 <!DOCTYPE html>
-<!--[if IEMobile 7]><html class="iem7"  lang="en" dir="ltr"><![endif]-->
-<!--[if lte IE 6]><html class="lt-ie9 lt-ie8 lt-ie7"  lang="en" dir="ltr"><![endif]-->
-<!--[if (IE 7)&(!IEMobile)]><html class="lt-ie9 lt-ie8"  lang="en" dir="ltr"><![endif]-->
-<!--[if IE 8]><html class="lt-ie9"  lang="en" dir="ltr"><![endif]-->
-<!--[if (gte IE 9)|(gt IEMobile 7)]><!--><html  lang="en" dir="ltr"><!--<![endif]-->
 <head>
 <meta charset="utf-8" />
 <!--<base href="/igc3" />-->
@@ -18,23 +13,12 @@
 <title>The 3rd GEOS-Chem Meeting</title>
 <meta http-equiv="x-ua-compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<link type="text/css" rel="stylesheet" href="css/css_xE-rWrJf-fncB6ztZfd2huxqgxu4WO-qwma6Xer30m4%EF%B9%96m=1675397288.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_1kR8T1_c-l5pBT6ZwbDT7BFda-4fyqW9Jjum29_2IY8%EF%B9%96m=1675397312.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_YnlUIvHP13qgpYEqubzE8JyDwlSxUnVibfnVkSoSDb0%EF%B9%96m=1675397273.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_Ku-3OcT9qU9h7dnGig5e23q6EVryY8orK4wzVDxsweE%EF%B9%96m=1675397367.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_vprtFTrWyg23GbY50_zJZHWGYMNfS8vsrRS26i4-ISk%EF%B9%96m=1675397406.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_dW-aNNrctRhQNc-KECjtQd0PxuW-h19IEum-TX2MeEk%EF%B9%96m=1675397301.css" media="print" />
-<link type="text/css" rel="stylesheet" href="css/css_SH2Lx3Qprh0GZo_9xRp85U9NsWfkSXn_Bi-rJoMY1sw%EF%B9%96m=1675397273.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_uaIDKcYMUK5osSQXuirpr3ZleXtnnpBN-eiECm7N0M0%EF%B9%96m=1675397395.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/responsive.blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/geos-chem.css" media="all"/>
 <script type="text/javascript" src="dropdown-menu.js"></script>
-<!--[if lte IE 8]>
-<script type="text/javascript">
-  var os_c = document.createElement;os_c('header');os_c('nav');os_c('section');os_c('article');os_c('aside');os_c('footer');os_c('hgroup');os_c('figure');
-</script>
-<![endif]-->
 </head>
 
 <body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-1585687 node-type-page og-context og-context-node og-context-node-1585652 navbar-on">
@@ -45,7 +29,7 @@
 <div id="page_wrap" class="page_wrap">
 <div id="page" class="container page header-main content-top footer-none">
 <div id="page-wrapper">
-		
+  
 <!--header regions beg-->
 <header id="header" class="clearfix" role="banner">
 <div id="header-container">
@@ -76,15 +60,16 @@
 
 <!--main menu region beg-->
 <div id="menu-bar" class="nav region-menu-bar clearfix">
-<nav id="block-os-igc3-menu" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="igc3_menu">  
-<ul class="nice-menu nice-menu-down nice-menu-igc3_menu" id="nice-menu-igc3_menu">
-  <li class="menu-860313 menu-path-node-1587125  first   odd  "><a href="igc3.html"  class="active">Home</a></li>
-  <li class="menu-860317 menu-path-node-1587126   even   last "><a href="igc3-presentations.html" >Presentations</a></li>
+<nav id="block-os-igc3-menu" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="igc3_menu">
+<ul class="nice-menu nice-menu-down">
+  <li><a href="igc3.html" class="active">IGC3 Home</a></li>
+  <li><a href="igc3-presentations.html">Presentations and Posters</a></li>
+  <li><a href="index.html">GEOS-Chem Home</a></li>
 </ul>
 </nav>
 </div>
 <!--main menu region end-->
-		
+  
 <div id="columns" class="clearfix">
 <div class="hg-container">
 <div id="content-column" role="main">
@@ -94,7 +79,7 @@
 <a name="main-content"></a>
 <h1 id="page-title" ng-non-bindable="">Overview</h1>
 </header>
-														
+              
 <!--front panel regions beg-->
 <div id="content-panels" class="at-panel gpanel panel-display content clearfix">
 <div class="region region-content-top">
@@ -113,12 +98,12 @@
 </p>
 
 <ul>
-	<li>
-		<a href="https://drive.google.com/file/d/1i7tHbQKXI7av1aF7IHnY8i3-_fdR5o5z/view?usp=drive_link">View the list of GEOS-Chem meeting attendees</a>
-	</li>
-	<li>
-		<a href="https://drive.google.com/drive/folders/1HmMzcb9hjMHckWa8Z_LPfBec-6L1LAaS?usp=drive_link">View photos from the GEOS-Chem meeting</a> (Photographers: Eric Leibensperger and Shiliang Wu)
-	</li>
+ <li>
+  <a href="https://drive.google.com/file/d/1i7tHbQKXI7av1aF7IHnY8i3-_fdR5o5z/view?usp=drive_link">View the list of GEOS-Chem meeting attendees</a>
+ </li>
+ <li>
+  <a href="https://drive.google.com/drive/folders/1HmMzcb9hjMHckWa8Z_LPfBec-6L1LAaS?usp=drive_link">View photos from the GEOS-Chem meeting</a> (Photographers: Eric Leibensperger and Shiliang Wu)
+ </li>
 </ul>
 
 </div>
@@ -139,65 +124,16 @@
 </div>
 </div>
 
-<!--footer region beg-->
+<!--footer-->
 <footer id="footer" class="clearfix" role="contentinfo">
-
-<!-- Three column 3x33 Gpanel -->
-<div class="at-panel gpanel panel-display footer clearfix">
-<div class="region region-footer">
-<div class="region-inner clearfix">
-<div id="block-boxes-1617037690" class="block block-boxes block-boxes-os_boxes_html no-title"  module="boxes" delta="1617037690">
-<div class="block-inner clearfix">  
-<div class="block-content content" ng-non-bindable="">  
-<div id='boxes-box-1617037690' class='boxes-box'>  
 <div class="boxes-box-content">
   <p style="text-align:center">
-    Copyright © 2023 by the International GEOS-Chem Community. All rights reserved.
+    Copyright © 2026 by the International GEOS-Chem Community. All rights reserved.
   </p>
 </div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-<div class="region region-footer-bottom">  
-<div class="region-inner clearfix">  
-<div id="block-boxes-1616879798" class="block block-boxes block-boxes-os_boxes_media no-title"  module="boxes" delta="1616879798">  
-<div class="block-inner clearfix">  
-<div class="block-content content"> 
-<div id='boxes-box-1616879798' class='boxes-box'> 
-<div class="boxes-box-content"> 
-<div id="file-3900146" class="file file-html file-html-embed">
-<h2 class="element-invisible"><a href="">css-brand</a></h2>
-<div class="content">
-<div class="file-info">
-</div>
-<div class="field field-name-field-html-code field-type-text-long field-label-hidden view-mode-full">
-<div class="field-items">
-<div class="field-item even">
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-
-<!--footer region end-->
 </footer>
-</div>
-</div>
 
-<!--page area ends-->
-
-<div id="extradiv"></div>
+</div>
 </div>
 
 </body>

--- a/igc3.html
+++ b/igc3.html
@@ -29,22 +29,20 @@
 <div id="page_wrap" class="page_wrap">
 <div id="page" class="container page header-main content-top footer-none">
 <div id="page-wrapper">
-  
+
 <!--header regions beg-->
 <header id="header" class="clearfix" role="banner">
 <div id="header-container">
 <div id="header-panels" class="at-panel gpanel panel-display three-col clearfix">
 <div class="region region-header-second"><div class="region-inner clearfix">
 <section id="block-boxes-1630413211" class="block block-boxes block-boxes-os_boxes_html"  module="boxes" delta="1630413211">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <h2 class="block-title" ng-non-bindable="">Site-Logo</h2>
 <div class="block-content content" ng-non-bindable="">
 <div id='boxes-box-1630413211' class='boxes-box'>
 <div class="boxes-box-content">
-<img height="551" width="1101" style="float: right; width: 350px; height: 175px; margin-bottom: 1.5em;" alt="gca2 logo" class="media-element file-default file-os-files-xxlarge" src="img/igc-early-logo.png" title="" />
-<h2 class="css-brand--css-geos-meetings-header-h2-xxxlarge">
-  The 3rd GEOS-Chem Scientific and Users' Meeting (IGC3)<br />April 11-13 2007
-</h2>
+<a href="https://geoschem.github.io/"><img height="600" width="1034" style="float: right; width: 350px; height: 203px;" class="media-element file-default file-os-files-xxlarge" src="img/GEOS-Chem_Logo_Square_Light_Background_Orig.png" alt="" title="" /></a>
+<h2 class="css-brand--css-geos-meetings-header-h2-xxxlarge">The 3rd GEOS-Chem Scientific and Users' Meeting (IGC3)<br />April 11-13 2007</h2>
 </div>
 </div>
 </div>
@@ -69,7 +67,7 @@
 </nav>
 </div>
 <!--main menu region end-->
-  
+
 <div id="columns" class="clearfix">
 <div class="hg-container">
 <div id="content-column" role="main">
@@ -79,13 +77,13 @@
 <a name="main-content"></a>
 <h1 id="page-title" ng-non-bindable="">Overview</h1>
 </header>
-              
+
 <!--front panel regions beg-->
 <div id="content-panels" class="at-panel gpanel panel-display content clearfix">
 <div class="region region-content-top">
 <div class="region-inner clearfix">
 <div id="block-os-pages-main-content" class="block block-os-pages no-title"  module="os_pages" delta="main_content">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <div class="block-content content" ng-non-bindable="">
 <article id="node-1585687" class="node node-page article clearfix" role="article">
 <div class="node-content" ng-non-bindable="">
@@ -93,17 +91,15 @@
 <div class="field-items">
 <div class="field-item even">
 
-<p align="justify">
-  The 3rd GEOS-Chem Users' Meeting was held from April 11–13, 2007 at Harvard University. It brought together over 140 scientists from 50 institutions and 12 countries. We are thankful to NASA/ACMAP, NSF/ATM, and the Harvard University Committee on the Environment for their travel support.
-</p>
+<p align="justify">The 3rd GEOS-Chem Users' Meeting was held from April 11–13, 2007 at Harvard University. It brought together over 140 scientists from 50 institutions and 12 countries. We are thankful to NASA/ACMAP, NSF/ATM, and the Harvard University Committee on the Environment for their travel support.</p>
 
 <ul>
- <li>
-  <a href="https://drive.google.com/file/d/1i7tHbQKXI7av1aF7IHnY8i3-_fdR5o5z/view?usp=drive_link">View the list of GEOS-Chem meeting attendees</a>
- </li>
- <li>
-  <a href="https://drive.google.com/drive/folders/1HmMzcb9hjMHckWa8Z_LPfBec-6L1LAaS?usp=drive_link">View photos from the GEOS-Chem meeting</a> (Photographers: Eric Leibensperger and Shiliang Wu)
- </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1i7tHbQKXI7av1aF7IHnY8i3-_fdR5o5z/view?usp=drive_link">View the list of GEOS-Chem meeting attendees</a>
+  </li>
+  <li>
+    <a href="https://drive.google.com/drive/folders/1HmMzcb9hjMHckWa8Z_LPfBec-6L1LAaS?usp=drive_link">View photos from the GEOS-Chem meeting</a> (Photographers: Eric Leibensperger and Shiliang Wu)
+  </li>
 </ul>
 
 </div>

--- a/igc4-presentations.html
+++ b/igc4-presentations.html
@@ -1,9 +1,4 @@
 <!DOCTYPE html>
-<!--[if IEMobile 7]><html class="iem7"  lang="en" dir="ltr"><![endif]-->
-<!--[if lte IE 6]><html class="lt-ie9 lt-ie8 lt-ie7"  lang="en" dir="ltr"><![endif]-->
-<!--[if (IE 7)&(!IEMobile)]><html class="lt-ie9 lt-ie8"  lang="en" dir="ltr"><![endif]-->
-<!--[if IE 8]><html class="lt-ie9"  lang="en" dir="ltr"><![endif]-->
-<!--[if (gte IE 9)|(gt IEMobile 7)]><!--><html  lang="en" dir="ltr"><!--<![endif]-->
 <head>
 <meta charset="utf-8" />
 <!--<base href="/igc4-presentations" />-->
@@ -18,23 +13,12 @@
 <title>The 4th GEOS-Chem Meeting</title>
 <meta http-equiv="x-ua-compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<link type="text/css" rel="stylesheet" href="css/css_xE-rWrJf-fncB6ztZfd2huxqgxu4WO-qwma6Xer30m4%EF%B9%96m=1675397288.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_1kR8T1_c-l5pBT6ZwbDT7BFda-4fyqW9Jjum29_2IY8%EF%B9%96m=1675397312.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_YnlUIvHP13qgpYEqubzE8JyDwlSxUnVibfnVkSoSDb0%EF%B9%96m=1675397273.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_Ku-3OcT9qU9h7dnGig5e23q6EVryY8orK4wzVDxsweE%EF%B9%96m=1675397367.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_vprtFTrWyg23GbY50_zJZHWGYMNfS8vsrRS26i4-ISk%EF%B9%96m=1675397406.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_dW-aNNrctRhQNc-KECjtQd0PxuW-h19IEum-TX2MeEk%EF%B9%96m=1675397301.css" media="print" />
-<link type="text/css" rel="stylesheet" href="css/css_SH2Lx3Qprh0GZo_9xRp85U9NsWfkSXn_Bi-rJoMY1sw%EF%B9%96m=1675397273.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_uaIDKcYMUK5osSQXuirpr3ZleXtnnpBN-eiECm7N0M0%EF%B9%96m=1675397395.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/responsive.blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/geos-chem.css" media="all"/>
 <script type="text/javascript" src="dropdown-menu.js"></script>
-<!--[if lte IE 8]>
-<script type="text/javascript">
-  var os_c = document.createElement;os_c('header');os_c('nav');os_c('section');os_c('article');os_c('aside');os_c('footer');os_c('hgroup');os_c('figure');
-</script>
-<![endif]-->
 </head>
 
 <body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-1585687 node-type-page og-context og-context-node og-context-node-1585652 navbar-on">
@@ -45,7 +29,7 @@
 <div id="page_wrap" class="page_wrap">
 <div id="page" class="container page header-main content-top footer-none">
 <div id="page-wrapper">
-		
+
 <!--header regions beg-->
 <header id="header" class="clearfix" role="banner">
 <div id="header-container">
@@ -57,10 +41,8 @@
 <div class="block-content content" ng-non-bindable="">
 <div id='boxes-box-1630413211' class='boxes-box'>
 <div class="boxes-box-content">
-<img height="551" width="1101" style="float: right; width: 350px; height: 175px; margin-bottom: 1.5em;" alt="gca2 logo" class="media-element file-default file-os-files-xxlarge" src="img/igc-early-logo.png" title="" />
-<h2 class="css-brand--css-geos-meetings-header-h2-xxxlarge">
-  The 4th GEOS-Chem Scientific and Users' Meeting (IGC4)<br />April 7-10 2009
-</h2>
+<a href="https://geoschem.github.io/"><img height="600" width="1034" style="float: right; width: 350px; height: 203px;" class="media-element file-default file-os-files-xxlarge" src="img/GEOS-Chem_Logo_Square_Light_Background_Orig.png" alt="" title="" /></a>
+<h2 class="css-brand--css-geos-meetings-header-h2-xxxlarge">The 4th GEOS-Chem Scientific and Users' Meeting (IGC4)<br />April 7-10 2009</h2>
 </div>
 </div>
 </div>
@@ -76,15 +58,17 @@
 
 <!--main menu region beg-->
 <div id="menu-bar" class="nav region-menu-bar clearfix">
-<nav id="block-os-igc4-menu" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="igc4_menu">  
-<ul class="nice-menu nice-menu-down nice-menu-igc4_menu" id="nice-menu-igc4_menu">
-  <li class="menu-859934 menu-path-node-1587057  first   odd  "><a href="igc4.html"  class="active">Home</a></li>
-  <li class="menu-859969 menu-path-node-1587065   even   last "><a href="igc4-presentations.html" >Presentations and Posters</a></li>
+<nav id="block-os-igc4-menu" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="igc4_menu">
+<ul class="nice-menu nice-menu-down">
+  <li><a href="igc4.html" class="active">IGC4 Home</a></li>
+  <li><a href="igc4-presentations.html">Presentations and Posters</a></li>
+  <li><a href="index.html">GEOS-Chem Home</a></li>
 </ul>
 </nav>
 </div>
 <!--main menu region end-->
-		
+
+
 <div id="columns" class="clearfix">
 <div class="hg-container">
 <div id="content-column" role="main">
@@ -94,7 +78,7 @@
 <a name="main-content"></a>
 <h1 id="page-title" ng-non-bindable="">Presentations and Posters</h1>
 </header>
-														
+
 <!--front panel regions beg-->
 <div id="content-panels" class="at-panel gpanel panel-display content clearfix">
 <div class="region region-content-top">
@@ -109,648 +93,577 @@
 <div class="field-item even">
 
 <p>
-	<strong>Day 1, Apr 7</strong>: <a href="#model_overview">Model Overview and Development</a> | <a href="#chem_tran">Chemical Transport</a> | <a href="#aer_src_chem">Aerosol Sources and Chemistry</a> | <a href="#aer_mp_rad">Aerosol Microphysics &amp; Radiation</a> | <a href="#bioburn">Biomass Burning</a>
+<strong>Day 1, Apr 7</strong>: <a href="#model_overview">Model Overview and Development</a> | <a href="#chem_tran">Chemical Transport</a> | <a href="#aer_src_chem">Aerosol Sources and Chemistry</a> | <a href="#aer_mp_rad">Aerosol Microphysics &amp; Radiation</a> | <a href="#bioburn">Biomass Burning</a>
 </p>
 
 <p>
-	<strong>Day 2, Apr 8</strong>: <a href="#trop_o3">Tropospheric Ozone</a> | <a href="#photochem">Photochemistry</a> | <a href="#raq">Regional Air Quality</a> | <a href="#raq_space">Regional Air Quality Observed from Space</a> | <a href="#mercury">Mercury</a> | <a href="#carb_gases">Carbon Gases</a>
+<strong>Day 2, Apr 8</strong>: <a href="#trop_o3">Tropospheric Ozone</a> | <a href="#photochem">Photochemistry</a> | <a href="#raq">Regional Air Quality</a> | <a href="#raq_space">Regional Air Quality Observed from Space</a> | <a href="#mercury">Mercury</a> | <a href="#carb_gases">Carbon Gases</a>
 </p>
 
 <p>
-	<strong>Day 3, Apr 9</strong>: <a href="#chem_clim_land">Chemistry-Climate-Land Interactions</a> | <a href="#softeng">Software Engineering etc.</a>
+<strong>Day 3, Apr 9</strong>: <a href="#chem_clim_land">Chemistry-Climate-Land Interactions</a> | <a href="#softeng">Software Engineering etc.</a>
 </p>
 
 <p>
-	<strong>Day 4, Apr 10</strong>: <a href="#wg_reports">Working Group Reports etc.</a>
+<strong>Day 4, Apr 10</strong>: <a href="#wg_reports">Working Group Reports etc.</a>
 </p>
 
-<h2>
-	<strong>Day 1, Tuesday April 7</strong>
-</h2>
+<h2><strong>Day 1, Tuesday April 7</strong></h2>
 
 <h3>
-	<a name="model_overview" id="model_overview"></a>Model Overview and Development (Daniel Jacob, Harvard, chair)
+<a name="model_overview" id="model_overview"></a>Model Overview and Development (Daniel Jacob, Harvard, chair)
 </h3>
 
-<h4>
-	Presentations
-</h4>
+<h4>Presentations</h4>
 
 <ul>
 <li>
-		Welcome, meeting goals (Daniel Jacob, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1DrPLCnNu0Mlh2O8FAPNYk2G9RRP40uBA/view?usp=drive_link" target="_blank">GEOS-Chem model: new developments, future directions</a> (Daniel Jacob, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/14Ck279TKoWC1IuxxsMepxkId4h375Ban/view?usp=drive_link" target="_blank">GEOS-Chem code: new developments, future directions </a>(Bob Yantosca, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1WgvCscGWi5P2ePdZnS2jfQ5Fcu7lWl3O/view?usp=drive_link" target="_blank">Emissions update in standard and ESMF GEOS-Chem</a> (Philippe LeSager, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/11TlKLooMjNG7lVQWTu1WOAMn1FEcUTmf/view?usp=drive_link" target="_blank">GEOS-Chem model development activities</a> (Claire Carouge, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1fjSB5A_0JMzz9P1yJUGd_3qQ1SBB1FV7/view?usp=drive_link" target="_blank">GEOS-Chem adjoint: status and plans</a> (Kevin Bowman, JPL)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/12vv71noPYJ6EzOvBSmxRfNt1EeHp3uwW/view?usp=drive_link" target="_blank">GMAO activities and partnership with GEOS-Chem</a> (Steven Pawson, NASA/Goddard)
-	</li>
+Welcome, meeting goals (Daniel Jacob, Harvard)
+</li>
+<li>
+<a href="https://drive.google.com/file/d/1DrPLCnNu0Mlh2O8FAPNYk2G9RRP40uBA/view?usp=drive_link" target="_blank">GEOS-Chem model: new developments, future directions</a> (Daniel Jacob, Harvard)
+</li>
+<li>
+<a href="https://drive.google.com/file/d/14Ck279TKoWC1IuxxsMepxkId4h375Ban/view?usp=drive_link" target="_blank">GEOS-Chem code: new developments, future directions </a>(Bob Yantosca, Harvard)
+</li>
+<li>
+<a href="https://drive.google.com/file/d/1WgvCscGWi5P2ePdZnS2jfQ5Fcu7lWl3O/view?usp=drive_link" target="_blank">Emissions update in standard and ESMF GEOS-Chem</a> (Philippe LeSager, Harvard)
+</li>
+<li>
+<a href="https://drive.google.com/file/d/11TlKLooMjNG7lVQWTu1WOAMn1FEcUTmf/view?usp=drive_link" target="_blank">GEOS-Chem model development activities</a> (Claire Carouge, Harvard)
+</li>
+<li>
+<a href="https://drive.google.com/file/d/1fjSB5A_0JMzz9P1yJUGd_3qQ1SBB1FV7/view?usp=drive_link" target="_blank">GEOS-Chem adjoint: status and plans</a> (Kevin Bowman, JPL)
+</li>
+<li>
+<a href="https://drive.google.com/file/d/12vv71noPYJ6EzOvBSmxRfNt1EeHp3uwW/view?usp=drive_link" target="_blank">GMAO activities and partnership with GEOS-Chem</a> (Steven Pawson, NASA/Goddard)
+</li>
 </ul>
-<h4>
-	Posters
-</h4>
+<h4>Posters</h4>
 
 <ul>
-	<li>
-		GMI online in GEOS-5 (Steven Pawson, NASA/Goddard)
-	</li>
+<li>
+GMI online in GEOS-5 (Steven Pawson, NASA/Goddard)
+</li>
 </ul>
 
 <h3>
-	<a name="chem_tran" id="chem_tran"></a>Chemical Transport (Steven Pawson, NASA/GFSC, chair)
+<a name="chem_tran" id="chem_tran"></a>Chemical Transport (Steven Pawson, NASA/GFSC, chair)
 </h3>
 
 <h4>
-	Presentations
+Presentations
 </h4>
 
 <ul>
-	<li>
-		<a href="https://drive.google.com/file/d/1nIhKZkMUcoLTjNlzPaKjz_Spp5KxfvKy/view?usp=drive_link" target="_blank">Using beryllium-7 to assess stratosphere-to-troposphere transport in global models</a> (Hongyu Liu, Nat'l Inst. Aerospace/NASA Langley)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Jm_kk4lWHKAtq7CnPUR-2zrZ5Hm2yBOJ/view?usp=drive_link" target="_blank">Seasonal variations in the mixing layer in the UTLS</a> (Dave McKenzie, U. Toronto)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/18lTl7_MFaSdFS1rXgecbfrci_LNgtYk4/view?usp=drive_link" target="_blank">An analysis of pollution transport events during ARCTAS using aircraft, satellite, and model results</a> (Jenny Fisher, Harvard)
-	</li>
-	<li>
-		Trans-Pacific transport of black carbon and other aerosols into western N. America (Qinbin Li, UCLA)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1K3ZJweW6WpQmY-cz3AkyGw42RGIJqja_/view?usp=drive_link" target="_blank">Intercontinental source attribution of ozone pollution at western U.S. sites using an adjoint model</a> (Lin Zhang, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1coKYoyzR9FTvtOX_bD375Ck3kYwiZqmn/view?usp=drive_link">Transpacific transport of Asian dust and pollution</a> (Junsan Nam , Georgia Tech)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/13XJsp4LAFNfY7Be5LCcKciu_iX0ZUJNW/view?usp=drive_link" target="_blank">Interannual variations in transport of Asian pollution to  the Middle East</a> (Jane Liu, U. Toronto)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/13CUCnDQet5hVMxOdvtdWbtDAT1TSlgH1/view?usp=drive_link" target="_blank">Impacts of PBL mixing representations on global model simulation of summertime surface ozone concentrations</a> (Jintai Lin, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1NhtA4944unjhNrhli_0rFEvRLnw4UpW-/view?usp=drive_link" target="_blank">Model reduction algorithms in atmospheric pollution transport simulations</a> (Mauricio Santillana, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1oiCMyPQ3phptCIfe4TwPAt1FOgu_BSnw/view?usp=drive_link" target="_blank">Development and evaluation of GEOS-Chem driven by CCSM3 meteorological data</a> (Daeok Youn, SNU)
-	</li>
+  <li>
+    <a href="https://drive.google.com/file/d/1nIhKZkMUcoLTjNlzPaKjz_Spp5KxfvKy/view?usp=drive_link" target="_blank">Using beryllium-7 to assess stratosphere-to-troposphere transport in global models</a> (Hongyu Liu, Nat'l Inst. Aerospace/NASA Langley)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Jm_kk4lWHKAtq7CnPUR-2zrZ5Hm2yBOJ/view?usp=drive_link" target="_blank">Seasonal variations in the mixing layer in the UTLS</a> (Dave McKenzie, U. Toronto)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/18lTl7_MFaSdFS1rXgecbfrci_LNgtYk4/view?usp=drive_link" target="_blank">An analysis of pollution transport events during ARCTAS using aircraft, satellite, and model results</a> (Jenny Fisher, Harvard)
+  </li>
+  <li>
+    Trans-Pacific transport of black carbon and other aerosols into western N. America (Qinbin Li, UCLA)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1K3ZJweW6WpQmY-cz3AkyGw42RGIJqja_/view?usp=drive_link" target="_blank">Intercontinental source attribution of ozone pollution at western U.S. sites using an adjoint model</a> (Lin Zhang, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1coKYoyzR9FTvtOX_bD375Ck3kYwiZqmn/view?usp=drive_link">Transpacific transport of Asian dust and pollution</a> (Junsan Nam , Georgia Tech)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/13XJsp4LAFNfY7Be5LCcKciu_iX0ZUJNW/view?usp=drive_link" target="_blank">Interannual variations in transport of Asian pollution to  the Middle East</a> (Jane Liu, U. Toronto)
+  </li>
+  <li>
+  <a href="https://drive.google.com/file/d/13CUCnDQet5hVMxOdvtdWbtDAT1TSlgH1/view?usp=drive_link" target="_blank">Impacts of PBL mixing representations on global model simulation of summertime surface ozone concentrations</a> (Jintai Lin, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1NhtA4944unjhNrhli_0rFEvRLnw4UpW-/view?usp=drive_link" target="_blank">Model reduction algorithms in atmospheric pollution transport simulations</a> (Mauricio Santillana, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1oiCMyPQ3phptCIfe4TwPAt1FOgu_BSnw/view?usp=drive_link" target="_blank">Development and evaluation of GEOS-Chem driven by CCSM3 meteorological data</a> (Daeok Youn, SNU)
+  </li>
 </ul>
 
-<h4>
-	Posters
-</h4>
+<h4>Posters</h4>
 
 <ul>
-	<li>
-		<a href="https://drive.google.com/file/d/15_DNH9ztceH-wLQwRVEQeh8D557qCQff/view?usp=drive_link" target="_blank">Using GEOS-Chem alongside observations from Mount Bachelor to understand the relationship between PAN and ozone during Spring 2008</a> (Emily Fischer, U. Washington)
-	</li>
+  <li>
+    <a href="https://drive.google.com/file/d/15_DNH9ztceH-wLQwRVEQeh8D557qCQff/view?usp=drive_link" target="_blank">Using GEOS-Chem alongside observations from Mount Bachelor to understand the relationship between PAN and ozone during Spring 2008</a> (Emily Fischer, U. Washington)
+  </li>
 </ul>
+
+<h3><a name="aer_src_chem" id="aer_src_chem"></a>Aerosol sources and chemistry (Jun Wang, U. Nebraska, chair)</h3>
+
+<h4>Presentations</h4>
+
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1itUbavtbLeDMbvZs1lQJnVgYOyAvR3vo/view?usp=drive_link" target="_blank">Retrieval of SO2 vertical columns from SCIAMACHY and OMI: air mass factor algorithm development</a> (Chulkyu Lee, Dalhousie)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1iboV5uBbSGbErFAr0ywZJyVD0054ezGm/view?usp=drive_link" target="_blank">Primary Biological Aerosol Particles (PBAP): an important part of the global organic aerosol budget?</a> (Colette Heald, CSU)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1psY6B44Ael7gZVUNQnP2Sd4w-Ii41Qsw/view?usp=drive_link" target="_blank">Can we constrain sea-salt emissions over the Southern Ocean?</a> (Lyatt Jaeglé, U. Washington)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1XltBFc1dZjocSRn3yHjPPqSCyzl4_1BZ/view?usp=drive_link" target="_blank">Modeling dust and dissolved iron deposition to the Southern Ocean using GEOS-Chem</a> (Nicholas Meskhidze, NC State)
+  </li>
+  <li>
+  <  a href="https://drive.google.com/file/d/1H4TQWmPuS7jlzRM0OjIbWbY4_50JtufE/view?usp=drive_link" target="_blank">Impact of mineral dust on nitrate and sulfate partitioning over the Northern Pacific during INTEX-B</a> (Duncan Fairlie, NASA/Langley)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1c9iQHGj_rpFSH3JAMythR4qfHbNBzhMG/view?usp=drive_link" target="_blank">Impacts of Asian summer monsoon on aerosols over eastern China</a> (Hong Liao, Chinese Acad. Sci.)
+  </li>
+  <li>
+    Synthesis of satellite (MODIS), aircraft (ICARTT), and surface (IMPROVE, AERONET) aerosol observations over eastern North America to improve MODIS aerosol retrievals and constrain aerosol concentrations and sources (Easan Drury, NREL)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1E5gaLaGk8ch7dBynZ4cLwfhPfig2exmo/view?usp=drive_link" target="_blank">Climate response to changing United States aerosol sources: historical and projected aerosol burdens using GEOS-Chem</a> (Eric Leibensperger, Harvard)
+  </li>
+</ul>
+
+<h4>Posters</h4>
+
+<ul>
+  <li>
+    Aqueous-phase reactive uptake of dicarbonyls as a source of organic aerosol over eastern North America (Tzung-May Fu, Hong Kong Polytechnic U.)
+  </li>
+  <li>
+    Exploring the effects of Patagonian dust on biological activity and carbon uptake in the South Atlantic Ocean using GEOS-Chem (Matthew Johnson, NC State)
+  </li>
+</ul>
+
+<h3><a name="aer_mp_rad" id="aer_mp_rad"></a>Aerosols: microphysics and radiation (Hong Liao, Chinese Acad. Sci., chair)</h3>
+
+<h4>Presentations</h4>
+
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1BzauEK7rqxxKIpqlvF5VZusRnrTmEcHk/view?usp=drive_link" target="_blank">On the seasonality of aerosol optical thickness over the southeastern U.S.</a>  (Jun Wang, U. Nebraska - Lincoln)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1SvHwCcaJRoRrOU8e1JMvaF0548pONRpQ/view?usp=drive_link" target="_blank">Arctic Haze: Comparing GEOS-Chem and CALIPSO</a> (Maurizio Di Pierro, U. Washington)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1gaNGtbmsl14p9237aAGcpGFFdgPzrKq5/view?usp=drive_link" target="_blank">Attributing direct radiative forcing to specific emissions using adjoint sensitivities</a> (Daven Henze, U. Colorado)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1tN8vzFBQJ43FYQSy9ZrqF6omz30vdhE8/view?usp=drive_link" target="_blank">Two-moment aerosol sectional (TOMAS) microphysics in GEOS-Chem</a> (Peter Adams, Carnegie-Mellon U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1FFPayet0_Q9fNWBS-waPl2iBkolDPt9X/view?usp=drive_link" target="_blank">Global particle size distributions simulated with GEOS-Chem incorporating a sectional aerosol microphysics model: Key features and comparison with observations</a> (Fangqun Yu, SUNY Albany)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1g5yUAvOTv2TYF8VVm3cSDlYG9ILFgojG/view?usp=drive_link" target="_blank">Effect of oceanic organic carbon emissions on the growth of secondary particles and global CCN abundance</a> (Gan Luo, SUNY Albany)
+  </li>
+</ul>
+
+<h4>Posters</h4>
+
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/17gt4EH-OvuDJ3rVBcw_qbaSQ6SiWLY9v/view?usp=drive_link" target="_blank">Secondary organic aerosol formation from aqueous-phase reactions of glyoxal with OH radicals</a> (Yong Bin Lim, Rutgers)
+  </li>
+  <li>
+    Global distribution of CCN number concentration: Effect of sizes and emission heights of primary carbonaceous aerosol (Fangqun Yu, SUNY Albany)
+  </li>
+  <li>
+    Particle size distributions and CCN concentrations in the global atmosphere: Uncertainties associated with sulfur emission inventories and primary sulfate emission parameterizations (Gan Luo, SUNY Albany)
+  </li>
+  <li>
+    Quantifying aerosol direct radiative effect with MISR observations (Qinbin Li, UCLA)
+  </li>
+  <li>
+    Fine-mode aerosol optical thickness over East Asia : GEOS-Chem simulations constrained by MODIS and CALIOP (Xiaoguang Xu, U. Nebraska – Lincoln)
+  </li>
+</ul>
+
+<h3><a name="bioburn" id="bioburn"></a>Biomass burning (Bob Yokelson, U. Montana , chair)</h3>
+
+<h4>Presentations</h4>
+
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1QZQ5iPwidp4XKqWHKwVvYMHMM_Yu9m8Y/view?usp=drive_link" target="_blank">Large variations in vertical transport of surface fire emissions observed from space</a> (Siegfried Gonzi, U. Edinburgh)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1SGF3hjW9Rks5OGCngsjZF35t1UQTdt2_/view?usp=drive_link" target="_blank">Incorporating a 1-D plume-rise model parameterization into GEOS-Chem to simulate vertical transport of fire emissions over North America</a> (Maria Val Martin, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1U4GGDknzLSbrt5OU_rkKgKwkQbgYC5sK/view?usp=drive_link" target="_blank">The sensitivity of CO and aerosol transport to the temporal and vertical distribution of N. American boreal fire emissions</a> (Yang Chen, JPL)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1KoZwhuDFuG4dE77tYMYehsz7jDdHBVhL/view?usp=drive_link" target="_blank">Effects of Siberian forest fires on regional air quality and meteorology in spring 2003</a> (Rokjin Park , SNU)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1b0O_bBtql1Xa83bM3_FH_rj2L9fsEVRo/view?usp=drive_link" target="_blank">Geos-Chem simulations of the impact on tropospheric O 3 from the 2003 Canberra megafires</a> (Nicholas Jones, U. Wollongong)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1vJP_DU1I34YvaKOtKCJwHGA0dehelPVJ/view?usp=drive_link" target="_blank">Satellite detection and model analysis of wildfire  NO x emissions in Siberia: Links to interannual variability of surface ozone for the period 1998-2004</a> (Hiroshi Tanimoto, NIES)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/17obn2Ue2d8Pmx0qftUzo3Ix3XsUXebf7/view?usp=drive_link" target="_blank">Nationwide impacts by fire emissions in the United Sates in summer 2002</a> (Tao Zeng , Georgia EPD)
+  </li>
+  <li>
+    Comparing CO and O3 measurements from TES during ARCTAS with GEOS-Chem simulations (Matthew Alvarado, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1ChsbCE098KDo1T2e3uZTP8U-iva6Wlc8/view?usp=drive_link" target="_blank">Interpretation of OMI NO2 observations during ARCTAS</a> (Nicolas Bousserez, Dalhousie)
+  </li>
+</ul>
+
+<h4>Posters</h4>
+
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1oKnHWfGs7Lbp4OyNzhugJgaFjyAxx57D/view?usp=drive_link" target="_blank">Recent measurements of biomass burning emissions and plume chemistry</a> (Robert Yokelson, U. Montana)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/18NvLWIoDYX58GeUKxd-Woe0kPWQJ2rP7/view?usp=drive_link" target="_blank">Observing boreal wildfire emissions from space: HCHO and NO2</a> (Kateryna Lapina, CSU)
+</li>
+</ul>
+
+<h2>Day 2: Wednesday, April 8</h2>
+
+<h3><a name="trop_o3" id="trop_o3"></a>Tropospheric ozone (Yuhang Wang, Georgia Tech, chair)</h3>
+
+<h4>Presentations</h4>
+
+<ul>
+  <li>
+    <a href="hhttps://drive.google.com/file/d/1ZU9Q8JLMOmDSFR0pUXgzfJFxVb98kNos/view?usp=drive_link" target="_blank">The HTAP model inter-comparisons: What do we learn about GEOS-Chem? </a>(Mat Evans, U. Leeds )
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1uFBQBNYsAdDWOMVdWk8bllEBhHXapehM/view?usp=drive_link" target="_blank">Spatially and temporally constraining the lightning flash rate  parameterization in GEOS-Chem and its impact on tropospheric ozone variability</a> (and additional <a href="https://projects.iq.harvard.edu/files/acmg-geos/files/igc4-weda_ozone_murray_2_mac.mov" target="_blank">movie</a>) (Lee Murray, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1P-_qVPRQ1agIYM5X6uT5rYyZq66T5iAF/view?usp=drive_link" target="_blank">Interannual variability in tropical CO and ozone as seen by Aura satellite data and global models</a> (Jennifer Logan, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1_kAkneGUJjwt0qqe-N8Mg9mc6zQ8FWhT/view?usp=drive_link" target="_blank">The impacts of dynamics on tropical tropospheric ozone variability inferred from TES and GEOS-Chem Model</a> (Junhua Liu, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1-bzYVSnu5WIvKwbloY4JluIZUSFp5Za8/view?usp=drive_link" target="_blank">Insight into processes affecting upper tropospheric ozone: interpretation of satellite (OSIRIS, MAESTRO, ACE) and in-situ observations</a> (Matthew Cooper, Dalhousie)
+  </li>
+  <li>
+<a <a href=""></a>="https://drive.google.com/file/d/1Kj_j6LOD7O-OMrTh9-Cox-0Bg-ZSuHw7/view?usp=drive_link" target="_blank">Assimilating Tropospheric Emission Spectrometer profiles in GEOS-Chem</a> (K. Singh, Virginia Tech)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/19DNINGsx1R-l7N-cpnvI8NRIWct9iwYE/view?usp=drive_link">Quantifying the impact of long-range transport of pollution on ozone abundances in the Arctic troposphere </a>(Thomas Walker, U. Toronto)
+  </li>
+</ul>
+
+<h4>Posters</h4>
+
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1rq7R1-MG9MUoWQ1DMPc14EBPayHLmO0M/view?usp=drive_link" target="_blank">Partitioning the LIS/OTD lightning climatological dataset into separate ground and cloud flash distributions </a>(William Koshak, NASA/Marshall)
+  </li>
+  <li>
+    Improving techniques for satellite-based constraints of the lightning parameterization in a global chemical transport model (Lee Murray, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1RdDpI2xyLx_xGQhKzzPN1ZHdn4A3Q5Oe/view?usp=drive_link" target="_blank">Spring O3 at Mount Washington Observatory:  implications for stratospheric intrusions</a> (Yaping Xiao, U. New Hampshire )
+  </li>
+</ul>
+
+<h3><a name="photochem" id="photochem"></a>Photochemistry (Lyatt Jaeglé, U. Washington , chair)</h3>
+
+<h4>Presentations</h4>
+
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1Jm9baX2cMPfgULFNjKwtW0nsnRPiwieC/view?usp=drive_link" target="_blank">Global model of the oxygen isotopic composition of atmospheric nitrate and comparison with observations</a> (Becky Alexander, U. Washington)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1mhP3r6NVMeKz_wZQ-H8oF2Fb5y1c_cvD/view?usp=drive_link" target="_blank">The sensitivity of the oxygen isotopes of sulfate to changes in oxidant concentrations during the preindustrial-industrial transition</a> (Eric Sofen, U. Washington)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1n0ts1SOYzOFdGxByOrlsM0DTfpzK8-fm/view?usp=drive_link" target="_blank">New insights in isoprene photooxidation: from chamber studies to global model</a> (Fabien Paulot, Caltech)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/14CccC-mQw_wfdt-C34B8NGzsVsqdPDcP/view?usp=drive_link" target="_blank">Implications of the uptake and reaction of HO2 on aerosols</a> (Helen McIntyre, U. Leeds)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1XiccyfY9pkxdH_ZnIWsrN7ggcG3iBgqu/view?usp=drive_link" target="_blank">Assessing the oxidation capacity in the polar region</a> (Jingqiu Mao, Harvard)
+  </li>
+</ul>
+
+<h4>Posters</h4>
+
+<ul>
+  <li>
+    Developments on tropospheric bromine chemistry in GEOS-Chem (Justin Parrella, Harvard)
+  </li>
+</ul>
+
+<h3><a name="raq" id="raq"></a>Regional air quality (Rob Pinder, EPA, chair)</h3>
+
+<h4>Presentations</h4>
+
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1OSrAHPDvS0KRxPFyTs3TNjYLXGGSGprF/view?usp=drive_link" target="_blank">Impacts of NO x emissions change on surface ozone in East Asia and China : the HTAP SR3 and SR6 cases</a> (Joshua Fu, U. Tennessee)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1gTNykNZFYkVcE_scj3ygOYga7dFRYvVH/view?usp=drive_link" target="_blank">Air quality during the Beijing 2008 Olympics: effectiveness of emission restrictions</a> (Yuxuan Wang, Tsinghua U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1LfrmCPMqbOfOkY-pUcvtLtDh1RuMaolB/view?usp=drive_link" target="_blank">High resolution modeling of CO spatial and temporal variations in Europe</a> (Anna Protonotariou, Nat'l Obs. Athens )
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1_t2G1M5W7gUA8CI-CCqAKA6wCi3_KAQI/view?usp=drive_link" target="_blank">Gas &amp; aerosol boundary conditions to Chimere CTM from GEOS-Chem</a> (Gabriele Curci, U. L'Aquila)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1O7ZQQCkrVro01mADA-AuWarLSY_CBUw3/view?usp=drive_link" target="_blank">Investigating downscaling techniques for the linkage of GEOS-Chem and CMAQ</a> (Yun-Fat Lam, U. Tennessee )
+  </li>
+</ul>
+
+<h4>Posters</h4>
+
+<ul>
+  <li>
+    Global health and economic impacts of future ozone pollution (Noelle Selin, MIT)
+  </li>
+  <li>
+    Using GEOS-Chem in global multimedia models for life cycle assessment (Shanna Shaked, U. Michigan)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/16o04r2wDVKugBrzte9v8PN1G1N4t62KC/view?usp=drive_link" target="_blank">A comparison of field observations with global and regional chemical mechanisms</a> (Barron Henderson, U. North Carolina)
+  </li>
+  <li>
+    Development of global and regional modeling emission inventories in support of climate-chemistry modeling using GEOS-Chem/CMAQ (Jung-Hun Woo, Konkuk U.)
+  </li>
+  <li>
+    Climate change in the Eastern Mediterranean-Links with air quality (Kostas Varotsos, Nat'l Obs. Athens)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/153LGr60D5V1U7SSwUjoNEaF2-Tq6Huty/view?usp=drive_link">Correlations between PM 2.5 and meteorology in the U.S. and its relation to climate change: a statistical study</a> (Amos Tai, Harvard)
+  </li>
+</ul>
+
+<h3><a name="raq_space" id="raq_space"></a>Regional air quality observed from space (Folkert Boersma, KNMI, chair)</h3>
+
+<h4>Presentations</h4>
+
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/15ndQVrrIN2CXIxMzigEJT5UXClf6SQ_p/view?usp=drive_link" target="_blank">Adjoint inversion of SCIAMACHY NO 2 columns</a> (Changsub Shim, JPL/Caltech)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1-C3-jknOEpn2t1__K7yfER__uTt7aowB/view?usp=drive_link" target="_blank">Seasonal variation in nitrogen oxides at northern midlatitudes as inferred from ground-based and satellite-based observations </a>(Lok Lamsal, Dalhousie)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1gv5AwLSwjlq0BizrmWXjZBAgwtSLU9Yn/view?usp=drive_link" target="_blank">Integrating satellite observation for assessing air quality over North America with GEOS-Chem</a> (Mark Parrington, U. Toronto)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1xLTJ016xbwPHTq1oUcu2l5L1zhIxkvxA/view?usp=drive_link" target="_blank">Global ground-level PM2.5 concentrations inferred from MODIS and MISR observations</a> (Aaron van Donkelaar, Dalhousie)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1F1C78ot3yvH1RVkdew1o3r82G8PtrqWA/view?usp=drive_link" target="_blank">Satellite remote sensing of a Multipollutant Air Quality Health Index </a>(Randall Martin, Dalhousie)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1oWjyaTaGpKP4bBjFOiY_Zgq59rKJUChJ/view?usp=drive_link" target="_blank">Estimating particle sulfate concentrations using MISR aerosol properties</a> (Yang Liu, Emory U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1yJ3smvqgDfx2zr_gp3ePN86s3_22RquM/view?usp=drive_link" target="_blank">Observing System Simulation Experiments (OSSE) in support of GEO-CAPE science and measurement requirements definition </a>[with additional movies: <a href="https://projects.iq.harvard.edu/files/acmg-geos/files/igc4-wedd_airquality2_bowman_2_mac.gif" target="_blank">movie 1</a> <a href="https://projects.iq.harvard.edu/files/acmg-geos/files/igc4-wedd_airquality2_bowman_3_mac.gif" target="_blank">movie 2</a>] (Kevin Bowman, JPL)
+  </li>
+</ul>
+
+<h4>Posters</h4>
+
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1mdt7J8hLz1x-eOiNTpuRfoVHOi-_pvKl/view?usp=drive_link" target="_blank">Air quality forecasting using geostationary satellite observations</a> (Peter Zoogman, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1ZwD9MRpSyP3QOi98IvFGO38WgZrTikrU/view?usp=drive_link" target="_blank">Using satellite observations of tropospheric NO2 to test global changes in anthropogenic NOx emissions: from the Clean Air Act to the Mediterranean Sea and the 2008 Beijing Olympic Games</a> (Folkert Boersma, KNMI)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1EKjsz8o0eN_p6FREkkeEWKrZgoF5wSuu/view?usp=drive_link" target="_blank">Assimilated inversion of NO x emissions over East Asia using OMI NO2 column measurements</a> (Yuhang Wang , Georgia Tech)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1vS-weUfUPWKpQjtm4iz5wUp4nHUhKMwP/view?usp=drive_link" target="_blank">The impact of Hurricanes Katrina and Rita on pollution emissions as inferred by OMI NO2</a> (Bryan Duncan, NASA/GSFC)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Z9LG3T_Ku0B280BCOyjbjSBUOS2BjzE0/view?usp=drive_link" target="_blank">Application of OMI Ozone Profiles in CMAQ </a>(Lihua Wang, U. Alabama Huntsville)
+  </li>
+  <li>
+    Constraint on anthropogenic NOx emissions in China from different sectors: a new methodology using multiple satellite retrievals (Jintai Lin, Harvard)
+  </li>
+</ul>
+
+<h3><a name="mercury" id="mercury"></a>Mercury (Elsie Sunderland, Harvard, chair)</h3>
+
+<h4>Presentations</h4>
+
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1WOxca3AQ0D1BKbQ6SK7P-8bIfzLUFHpW/view?usp=drive_link" target="_blank">A global mercury simulation and budget based on Hg+Br chemistry</a> (Chris Holmes, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1b84WQhrfEeh_Cuqlh8y2j-8jnV0J4aG5/view?usp=drive_link" target="_blank">Changing emissions and global mercury cycling</a> (Elizabeth Corbitt, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1x5cXFB9PzYyBRVFGrL0XYm0kDFYkLXBM/view?usp=drive_link" target="_blank">Incorporating a global terrestrial mercury model into GEOS-Chem</a> (Nicole Smith-Downey, U. Texas)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1FExo0hXp9fI0yAZhIyVal31o4e3Jl8o7/view?usp=drive_link" target="_blank">Evaluating mercury exposure and source attribution using GEOS-Chem</a> (Noelle Selin, MIT)
+  </li>
+</ul>
+
+<h4>Posters</h4>
+
+<ul>
+  <li>
+<a href="https://drive.google.com/file/d/1AVf8aW-CM5VyNFox__rk_GNsz8GxMzEn/view?usp=drive_link" target="_blank">Enhancements to the ocean mercury modeling capability in GEOS-Chem</a> (Elsie Sunderland, Harvard)
+  </li>
+</ul>
+
+<h3><a name="carb_gases" id="carb_gases"></a>Carbon gases (Qinbin Li, UCLA, chair)</h3>
+
+<h4>Presentations</h4>
+
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1ag2EZdintg55j2gRGmVnFswb8xCZA6a5/view?usp=drive_link" target="_blank">Northern hemispheric CO source estimates as derived in an adjoint inversion from combined MOPITT, AIRS and SCIAMACHY measurements of CO columns</a> (Monika Kopacz, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1UOpiqwUCrNf7ShYdXLLg6q3IELA0kd_V/view?usp=drive_link" target="_blank">Evidence for a soil source of CO in the deserts of Saudi Arabia</a> (Dylan Jones, U. Toronto)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Fw0P9bn9HFbP4fRrBq8wJ8F-yknFFBs6/view?usp=drive_link" target="_blank">Modeling CO2 and its sources and sinks with GEOS-Chem</a> (Ray Nassar, U. Toronto)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1OVo0y5u39vaV79T2Hh1AhIy5MxGkZAbd/view?usp=drive_link" target="_blank">What can we learn about upper tropospheric CO2?</a> (Xun Jiang, JPL)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1D8jNQX4HrLT0CFs8nrkB-m89auzMibXW/view?usp=drive_link" target="_blank">Using satellite data in joint CO2 - CO inversion</a> (Helen Wang, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1c1pO50xEVZKmA-GweeaJeSX2YJIrarmM/view?usp=drive_link" target="_blank">Atmospheric constraints on the global budget of carbonyl sulfide</a> (Parvadha Suntharalingam, U. East Anglia)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1z2apTfzcCK_-tk51wK_fRcvdvj6G1q-u/view?usp=drive_link" target="_blank">Primary and secondary sources of atmospheric acetaldehyde</a> (Dylan Millet, U. Minnesota)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1I3k_mNX-fy3ObrRgUwc6wH0DbSXsDGSt/view?usp=drive_link" target="_blank">Methane source contribution in the Arctic: a study using GEOS-Chem and  airborne CH4 measurements obtained during ARCTAS-08</a> (Christopher Pickett-Heaps, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Gk9bQXPKnpGwV8P528hipmt6pDCYI2sv/view?usp=drive_link" target="_blank">Evaluating hotspot tropospheric methane concentrations in Himalaya region with GEOS-Chem and AIRS satellite retrievals</a> (Jinyun Tang, Purdue)
+  </li>
+</ul>
+
+<h4>Posters</h4>
+
+<ul>
+  <li>
+    A satellite perspective on the inter-hemispheric transport of CO (Chenxia Cai, JPL)
+  </li>
+  <li>
+    Quantifying the impact of aggregation errors and model transport biases on top-down estimates of carbon monoxide emissions using satellites observations (Zhe Jiang, U. Toronto)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/19nXgMUNEpdFoklCBuivQK3KnB5aBywOh/view?usp=drive_link" target="_blank">Atmospheric formic acid: modeling and satellite remote sensing</a> (Gonzalo Gonzalez Abad, York U. )
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1dFDtq9ZmEo94AF-lup63YmdnBWFe2vY3/view?usp=drive_link" target="_blank">Evaluating a simulation of methane using ground-based and satellite measurements</a> (Annemarie Fraser, U. Edinburgh)
+  </li>
+  <li>
+    Inversion analysis of North American methane emissions Using INTEX-NA aircraft data (Kevin Wecht, Harvard)
+  </li>
+  <li>
+    BVOC emissions in GEOS-Chem:  model evaluation at two tropical rain forest sites (Michael Barkley, U. Edinburgh)
+  </li>
+</ul>
+
+<h2>Day 3: Thursday, April 9</h2>
 
 <h3>
-	<a name="aer_src_chem" id="aer_src_chem"></a>Aerosol sources and chemistry (Jun Wang, U. Nebraska, chair)
+<a name="chem_clim_land" id="chem_clim_land"></a>Chemistry-Climate-Land Interactions (Dylan Millet, U. Minnesota , chair)
 </h3>
 
-<h4>
-	Presentations
-</h4>
+<h4>Presentations</h4>
 
 <ul>
-	<li>
-		<a href="https://drive.google.com/file/d/1itUbavtbLeDMbvZs1lQJnVgYOyAvR3vo/view?usp=drive_link" target="_blank">Retrieval of SO2 vertical columns from SCIAMACHY and OMI: air mass factor algorithm development</a> (Chulkyu Lee, Dalhousie)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1iboV5uBbSGbErFAr0ywZJyVD0054ezGm/view?usp=drive_link" target="_blank">Primary Biological Aerosol Particles (PBAP): an important part of the global organic aerosol budget?</a> (Colette Heald, CSU)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1psY6B44Ael7gZVUNQnP2Sd4w-Ii41Qsw/view?usp=drive_link" target="_blank">Can we constrain sea-salt emissions over the Southern Ocean?</a> (Lyatt Jaeglé, U. Washington)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1XltBFc1dZjocSRn3yHjPPqSCyzl4_1BZ/view?usp=drive_link" target="_blank">Modeling dust and dissolved iron deposition to the Southern Ocean using GEOS-Chem</a> (Nicholas Meskhidze, NC State)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1H4TQWmPuS7jlzRM0OjIbWbY4_50JtufE/view?usp=drive_link" target="_blank">Impact of mineral dust on nitrate and sulfate partitioning over the Northern Pacific during INTEX-B</a> (Duncan Fairlie, NASA/Langley)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1c9iQHGj_rpFSH3JAMythR4qfHbNBzhMG/view?usp=drive_link" target="_blank">Impacts of Asian summer monsoon on aerosols over eastern China</a> (Hong Liao, Chinese Acad. Sci.)
-	</li>
-	<li>
-		Synthesis of satellite (MODIS), aircraft (ICARTT), and surface (IMPROVE, AERONET) aerosol observations over eastern North America to improve MODIS aerosol retrievals and constrain aerosol concentrations and sources (Easan Drury, NREL)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1E5gaLaGk8ch7dBynZ4cLwfhPfig2exmo/view?usp=drive_link" target="_blank">Climate response to changing United States aerosol sources: historical and projected aerosol burdens using GEOS-Chem</a> (Eric Leibensperger, Harvard)
-	</li>
+  <li>
+    <a href="https://drive.google.com/file/d/1lTr3qCJmFc3xG1ZUeYivwcoV9poPzyoA/view?usp=drive_link" target="_blank">New directions in studies of chemistry-climate interactions using GEOS-Chem</a> (Loretta Mickley, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Rdi7CS3mwf40Z-CTZDq5ksyKFkU9CBoF/view?usp=drive_link" target="_blank">Effects of tropical deforestation on tropospheric chemistry: a 10-year study using GEOS-Chem </a>(Prasad Kasibhatla, Duke)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1OkRg4ypo2O5p6SqEPyKdbsghzfAssPs4/view?usp=drive_link" target="_blank">Impacts of changes in land use/land cover on chemistry &amp; air quality </a>(Shiliang Wu , Michigan Tech)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/12lnuE75TIoORForY5t7nay6Xa9VktTae/view?usp=drive_link" target="_blank">Future inorganic aerosol levels</a> (Havala Pye, Caltech)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1eXozvjlEQU_D9UdO7cUdxBkJ0eDJFhqQ/view?usp=drive_link" target="_blank">Application of sensitivity of ozone air quality to temperature change to validate chemical transport models for future ozone simulation over the United States</a> (Moeko Yoshitomi, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1OBHiK_9hIiv_fPJ2pw2frkxNWAztmWQN/view?usp=drive_link" target="_blank">Impact of climate change on North American wildfire and ozone air quality in the United States</a> (Rynda Hudman, UC Berkeley)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1IZk4wNP5QC1VCML59uRsw5CABpcq_CbP/view?usp=drive_link" target="_blank">Effects of climate change on future forest fire and its impact on regional air quality</a> (Hyun Cheol Kim, U. Houston )
+  </li>
+  <li>
+    Re-thinking the IPCC radiative forcing bar chart: the sector based paradigm (Nadine Unger, GISS)
+  </li>
 </ul>
 
-<h4>
-	Posters
-</h4>
+<h3><a name="softeng" id="softeng"></a>Software Engineering etc.</h3>
 
 <ul>
-	<li>
-		Aqueous-phase reactive uptake of dicarbonyls as a source of organic aerosol over eastern North America (Tzung-May Fu, Hong Kong Polytechnic U.)
-	</li>
-	<li>
-		Exploring the effects of Patagonian dust on biological activity and carbon uptake in the South Atlantic Ocean using GEOS-Chem (Matthew Johnson, NC State)
-	</li>
+  <li>
+    <a href="https://drive.google.com/file/d/1-SC5Qr5tSwH_LS7YM_lCc6e1tM39WGAk/view?usp=drive_link" target="_blank">Software engineering, code development, user support issues</a> (Bob Yantosca, Philippe LeSager, Claire Carouge, leads)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1g8ClbZAfpPvdX-dX7JUu6oi6Uc8WUIHz/view?usp=drive_link">Adjoint Model Clinic</a> (led by: Daven Henze, Monika Kopacz, Kumaresh Singh)
+  </li>
 </ul>
 
-<h3>
-	<a name="aer_mp_rad" id="aer_mp_rad"></a>Aerosols: microphysics and radiation (Hong Liao, Chinese Acad. Sci., chair)
-</h3>
+<h2>Day 4: Friday, April 10</h2>
 
-<h4>
-	Presentations
-</h4>
+<h3><a name="wg_reports" id="wg_reports"></a>Working Group Reports</h3>
 
 <ul>
-	<li>
-		<a href="https://drive.google.com/file/d/1BzauEK7rqxxKIpqlvF5VZusRnrTmEcHk/view?usp=drive_link" target="_blank">On the seasonality of aerosol optical thickness over the southeastern U.S.</a>  (Jun Wang, U. Nebraska - Lincoln)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1SvHwCcaJRoRrOU8e1JMvaF0548pONRpQ/view?usp=drive_link" target="_blank">Arctic Haze: Comparing GEOS-Chem and CALIPSO</a> (Maurizio Di Pierro, U. Washington)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1gaNGtbmsl14p9237aAGcpGFFdgPzrKq5/view?usp=drive_link" target="_blank">Attributing direct radiative forcing to specific emissions using adjoint sensitivities</a> (Daven Henze, U. Colorado)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1tN8vzFBQJ43FYQSy9ZrqF6omz30vdhE8/view?usp=drive_link" target="_blank">Two-moment aerosol sectional (TOMAS) microphysics in GEOS-Chem</a> (Peter Adams, Carnegie-Mellon U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1FFPayet0_Q9fNWBS-waPl2iBkolDPt9X/view?usp=drive_link" target="_blank">Global particle size distributions simulated with GEOS-Chem incorporating a sectional aerosol microphysics model: Key features and comparison with observations</a> (Fangqun Yu, SUNY Albany)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1g5yUAvOTv2TYF8VVm3cSDlYG9ILFgojG/view?usp=drive_link" target="_blank">Effect of oceanic organic carbon emissions on the growth of secondary particles and global CCN abundance</a> (Gan Luo, SUNY Albany)
-	</li>
+  <li>
+    <a href="https://drive.google.com/file/d/1CSj2IueqsfQes79ZQPp9Wsbst6lnQQwB/view?usp=drive_link" target="_blank">Adjoint</a> (co-chairs Kevin Bowman, Daven Henze)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1qV5FfaHwxyeLmo8naJ2uUj55G8vUXdic/view?usp=drive_link" target="_blank">Aerosol processes</a> (co-chairs Colette Heald, Fangqun Yu)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1h59jOyDu9ZIdtzWY86Z2ETeN5W7aXsL7/view?usp=drive_link"
+    target="_blank">Carbon gases</a> (co-chairs Dylan Jones, Prasad
+    Kasibhatla)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/13toz6QLfgiEA6IBxCXJ0OulmtuAlNy3R/view?usp=drive_link" target="_blank">Chemistry-climate interactions</a> (co-chairs Becky Alexander, Loretta Mickley)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Bm3kv6389n_Gei0JHz6oP_Y5DXyGPZf9/view?usp=drive_link" target="_blank">Emission inventories</a> (co-chairs Jennifer Logan, Randall Martin)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1xxrKwQ4EDCR-GGU4Lr2zDYEJtmSU8eaW/view?usp=drive_link">Oxidants and chemistry</a> (co-chairs Mat Evans, May Fu)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1sYKMoYkOLsgFpqWi-jhWIfQb_fOwaVyW/view?usp=drive_link" target="_blank">Regional modeling </a>(co-chairs Rokjin Park , Yuxuan Wang)
+  </li>
 </ul>
 
-<h4>
-	Posters
-</h4>
+<h3>GEOS-Chem Model Clinic</h3>
 
 <ul>
-	<li>
-		<a href="https://drive.google.com/file/d/17gt4EH-OvuDJ3rVBcw_qbaSQ6SiWLY9v/view?usp=drive_link" target="_blank">Secondary organic aerosol formation from aqueous-phase reactions of glyoxal with OH radicals</a> (Yong Bin Lim, Rutgers)
-	</li>
-	<li>
-		Global distribution of CCN number concentration: Effect of sizes and emission heights of primary carbonaceous aerosol (Fangqun Yu, SUNY Albany)
-	</li>
-	<li>
-		Particle size distributions and CCN concentrations in the global atmosphere: Uncertainties associated with sulfur emission inventories and primary sulfate emission parameterizations (Gan Luo, SUNY Albany)
-	</li>
-	<li>
-		Quantifying aerosol direct radiative effect with MISR observations (Qinbin Li, UCLA)
-	</li>
-	<li>
-		Fine-mode aerosol optical thickness over East Asia : GEOS-Chem simulations constrained by MODIS and CALIOP (Xiaoguang Xu, U. Nebraska – Lincoln)
-	</li>
-</ul>
-
-<h3>
-	<a name="bioburn" id="bioburn"></a>Biomass burning (Bob Yokelson, U. Montana , chair)
-</h3>
-
-<h4>
-	Presentations
-</h4>
-
-<ul>
-	<li>
-		<a href="https://drive.google.com/file/d/1QZQ5iPwidp4XKqWHKwVvYMHMM_Yu9m8Y/view?usp=drive_link" target="_blank">Large variations in vertical transport of surface fire emissions observed from space</a> (Siegfried Gonzi, U. Edinburgh)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1SGF3hjW9Rks5OGCngsjZF35t1UQTdt2_/view?usp=drive_link" target="_blank">Incorporating a 1-D plume-rise model parameterization into GEOS-Chem to simulate vertical transport of fire emissions over North America</a> (Maria Val Martin, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1U4GGDknzLSbrt5OU_rkKgKwkQbgYC5sK/view?usp=drive_link" target="_blank">The sensitivity of CO and aerosol transport to the temporal and vertical distribution of N. American boreal fire emissions</a> (Yang Chen, JPL)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1KoZwhuDFuG4dE77tYMYehsz7jDdHBVhL/view?usp=drive_link" target="_blank">Effects of Siberian forest fires on regional air quality and meteorology in spring 2003</a> (Rokjin Park , SNU)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1b0O_bBtql1Xa83bM3_FH_rj2L9fsEVRo/view?usp=drive_link" target="_blank">Geos-Chem simulations of the impact on tropospheric O 3 from the 2003 Canberra megafires</a> (Nicholas Jones, U. Wollongong)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1vJP_DU1I34YvaKOtKCJwHGA0dehelPVJ/view?usp=drive_link" target="_blank">Satellite detection and model analysis of wildfire  NO x emissions in Siberia: Links to interannual variability of surface ozone for the period 1998-2004</a> (Hiroshi Tanimoto, NIES)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/17obn2Ue2d8Pmx0qftUzo3Ix3XsUXebf7/view?usp=drive_link" target="_blank">Nationwide impacts by fire emissions in the United Sates in summer 2002</a> (Tao Zeng , Georgia EPD)
-	</li>
-	<li>
-		Comparing CO and O3 measurements from TES during ARCTAS with GEOS-Chem simulations (Matthew Alvarado, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1ChsbCE098KDo1T2e3uZTP8U-iva6Wlc8/view?usp=drive_link" target="_blank">Interpretation of OMI NO2 observations during ARCTAS</a> (Nicolas Bousserez, Dalhousie)
-	</li>
-</ul>
-
-<h4>
-	Posters
-</h4>
-
-<ul><li>
-		<a href="https://drive.google.com/file/d/1oKnHWfGs7Lbp4OyNzhugJgaFjyAxx57D/view?usp=drive_link" target="_blank">Recent measurements of biomass burning emissions and plume chemistry</a> (Robert Yokelson, U. Montana)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/18NvLWIoDYX58GeUKxd-Woe0kPWQJ2rP7/view?usp=drive_link" target="_blank">Observing boreal wildfire emissions from space: HCHO and NO2</a> (Kateryna Lapina, CSU)
-	</li>
-</ul><h2>
-	Day 2: Wednesday, April 8
-</h2>
-
-<h3>
-	<a name="trop_o3" id="trop_o3"></a>Tropospheric ozone (Yuhang Wang, Georgia Tech, chair)
-</h3>
-
-<h4>
-	Presentations
-</h4>
-
-<ul>
-	<li>
-		<a href="hhttps://drive.google.com/file/d/1ZU9Q8JLMOmDSFR0pUXgzfJFxVb98kNos/view?usp=drive_link" target="_blank">The HTAP model inter-comparisons: What do we learn about GEOS-Chem? </a>(Mat Evans, U. Leeds )
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1uFBQBNYsAdDWOMVdWk8bllEBhHXapehM/view?usp=drive_link" target="_blank">Spatially and temporally constraining the lightning flash rate  parameterization in GEOS-Chem and its impact on tropospheric ozone variability</a> (and additional <a href="https://projects.iq.harvard.edu/files/acmg-geos/files/igc4-weda_ozone_murray_2_mac.mov" target="_blank">movie</a>) (Lee Murray, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1P-_qVPRQ1agIYM5X6uT5rYyZq66T5iAF/view?usp=drive_link" target="_blank">Interannual variability in tropical CO and ozone as seen by Aura satellite data and global models</a> (Jennifer Logan, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1_kAkneGUJjwt0qqe-N8Mg9mc6zQ8FWhT/view?usp=drive_link" target="_blank">The impacts of dynamics on tropical tropospheric ozone variability inferred from TES and GEOS-Chem Model</a> (Junhua Liu, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1-bzYVSnu5WIvKwbloY4JluIZUSFp5Za8/view?usp=drive_link" target="_blank">Insight into processes affecting upper tropospheric ozone: interpretation of satellite (OSIRIS, MAESTRO, ACE) and in-situ observations</a> (Matthew Cooper, Dalhousie)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Kj_j6LOD7O-OMrTh9-Cox-0Bg-ZSuHw7/view?usp=drive_link" target="_blank">Assimilating Tropospheric Emission Spectrometer profiles in GEOS-Chem</a> (K. Singh, Virginia Tech)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/19DNINGsx1R-l7N-cpnvI8NRIWct9iwYE/view?usp=drive_link">Quantifying the impact of long-range transport of pollution on ozone abundances in the Arctic troposphere </a>(Thomas Walker, U. Toronto)
-	</li>
-</ul>
-
-<h4>
-	Posters
-</h4>
-
-<ul>
-	<li>
-		<a href="https://drive.google.com/file/d/1rq7R1-MG9MUoWQ1DMPc14EBPayHLmO0M/view?usp=drive_link" target="_blank">Partitioning the LIS/OTD lightning climatological dataset into separate ground and cloud flash distributions </a>(William Koshak, NASA/Marshall)
-	</li>
-	<li>
-		Improving techniques for satellite-based constraints of the lightning parameterization in a global chemical transport model (Lee Murray, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1RdDpI2xyLx_xGQhKzzPN1ZHdn4A3Q5Oe/view?usp=drive_link" target="_blank">Spring O3 at Mount Washington Observatory:  implications for stratospheric intrusions</a> (Yaping Xiao, U. New Hampshire )
-	</li>
-</ul>
-
-<h3>
-	<a name="photochem" id="photochem"></a>Photochemistry (Lyatt Jaeglé, U. Washington , chair)
-</h3>
-
-<h4>
-	Presentations
-</h4>
-
-<ul>
-	<li>
-		<a href="https://drive.google.com/file/d/1Jm9baX2cMPfgULFNjKwtW0nsnRPiwieC/view?usp=drive_link" target="_blank">Global model of the oxygen isotopic composition of atmospheric nitrate and comparison with observations</a> (Becky Alexander, U. Washington)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1mhP3r6NVMeKz_wZQ-H8oF2Fb5y1c_cvD/view?usp=drive_link" target="_blank">The sensitivity of the oxygen isotopes of sulfate to changes in oxidant concentrations during the preindustrial-industrial transition</a> (Eric Sofen, U. Washington)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1n0ts1SOYzOFdGxByOrlsM0DTfpzK8-fm/view?usp=drive_link" target="_blank">New insights in isoprene photooxidation: from chamber studies to global model</a> (Fabien Paulot, Caltech)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/14CccC-mQw_wfdt-C34B8NGzsVsqdPDcP/view?usp=drive_link" target="_blank">Implications of the uptake and reaction of HO2 on aerosols</a> (Helen McIntyre, U. Leeds)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1XiccyfY9pkxdH_ZnIWsrN7ggcG3iBgqu/view?usp=drive_link" target="_blank">Assessing the oxidation capacity in the polar region</a> (Jingqiu Mao, Harvard)
-	</li>
-</ul>
-
-<h4>
-	Posters
-</h4>
-
-<ul>
-	<li>
-		Developments on tropospheric bromine chemistry in GEOS-Chem (Justin Parrella, Harvard)
-	</li>
-</ul>
-
-<h3>
-	<a name="raq" id="raq"></a>Regional air quality (Rob Pinder, EPA, chair)
-</h3>
-
-<h4>
-	Presentations
-</h4>
-
-<ul>
-	<li>
-		<a href="https://drive.google.com/file/d/1OSrAHPDvS0KRxPFyTs3TNjYLXGGSGprF/view?usp=drive_link" target="_blank">Impacts of NO x emissions change on surface ozone in East Asia and China : the HTAP SR3 and SR6 cases</a> (Joshua Fu, U. Tennessee)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1gTNykNZFYkVcE_scj3ygOYga7dFRYvVH/view?usp=drive_link" target="_blank">Air quality during the Beijing 2008 Olympics: effectiveness of emission restrictions</a> (Yuxuan Wang, Tsinghua U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1LfrmCPMqbOfOkY-pUcvtLtDh1RuMaolB/view?usp=drive_link" target="_blank">High resolution modeling of CO spatial and temporal variations in Europe</a> (Anna Protonotariou, Nat'l Obs. Athens )
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1_t2G1M5W7gUA8CI-CCqAKA6wCi3_KAQI/view?usp=drive_link" target="_blank">Gas &amp; aerosol boundary conditions to Chimere CTM from GEOS-Chem</a> (Gabriele Curci, U. L'Aquila)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1O7ZQQCkrVro01mADA-AuWarLSY_CBUw3/view?usp=drive_link" target="_blank">Investigating downscaling techniques for the linkage of GEOS-Chem and CMAQ</a> (Yun-Fat Lam, U. Tennessee )
-	</li>
-</ul>
-
-<h4>
-	Posters
-</h4>
-
-<ul>
-	<li>
-		Global health and economic impacts of future ozone pollution (Noelle Selin, MIT)
-	</li>
-	<li>
-		Using GEOS-Chem in global multimedia models for life cycle assessment (Shanna Shaked, U. Michigan)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/16o04r2wDVKugBrzte9v8PN1G1N4t62KC/view?usp=drive_link" target="_blank">A comparison of field observations with global and regional chemical mechanisms</a> (Barron Henderson, U. North Carolina)
-	</li>
-	<li>
-		Development of global and regional modeling emission inventories in support of climate-chemistry modeling using GEOS-Chem/CMAQ (Jung-Hun Woo, Konkuk U.)
-	</li>
-	<li>
-		Climate change in the Eastern Mediterranean-Links with air quality (Kostas Varotsos, Nat'l Obs. Athens)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/153LGr60D5V1U7SSwUjoNEaF2-Tq6Huty/view?usp=drive_link">Correlations between PM 2.5 and meteorology in the U.S. and its relation to climate change: a statistical study</a> (Amos Tai, Harvard)
-	</li>
-</ul>
-
-<h3>
-	<a name="raq_space" id="raq_space"></a>Regional air quality observed from space (Folkert Boersma, KNMI, chair)
-</h3>
-
-<h4>
-	Presentations
-</h4>
-
-<ul>
-	<li>
-		<a href="https://drive.google.com/file/d/15ndQVrrIN2CXIxMzigEJT5UXClf6SQ_p/view?usp=drive_link" target="_blank">Adjoint inversion of SCIAMACHY NO 2 columns</a> (Changsub Shim, JPL/Caltech)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1-C3-jknOEpn2t1__K7yfER__uTt7aowB/view?usp=drive_link" target="_blank">Seasonal variation in nitrogen oxides at northern midlatitudes as inferred from ground-based and satellite-based observations </a>(Lok Lamsal, Dalhousie)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1gv5AwLSwjlq0BizrmWXjZBAgwtSLU9Yn/view?usp=drive_link" target="_blank">Integrating satellite observation for assessing air quality over North America with GEOS-Chem</a> (Mark Parrington, U. Toronto)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1xLTJ016xbwPHTq1oUcu2l5L1zhIxkvxA/view?usp=drive_link" target="_blank">Global ground-level PM2.5 concentrations inferred from MODIS and MISR observations</a> (Aaron van Donkelaar, Dalhousie)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1F1C78ot3yvH1RVkdew1o3r82G8PtrqWA/view?usp=drive_link" target="_blank">Satellite remote sensing of a Multipollutant Air Quality Health Index </a>(Randall Martin, Dalhousie)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1oWjyaTaGpKP4bBjFOiY_Zgq59rKJUChJ/view?usp=drive_link" target="_blank">Estimating particle sulfate concentrations using MISR aerosol properties</a> (Yang Liu, Emory U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1yJ3smvqgDfx2zr_gp3ePN86s3_22RquM/view?usp=drive_link" target="_blank">Observing System Simulation Experiments (OSSE) in support of GEO-CAPE science and measurement requirements definition </a>[with additional movies: <a href="https://projects.iq.harvard.edu/files/acmg-geos/files/igc4-wedd_airquality2_bowman_2_mac.gif" target="_blank">movie 1</a> <a href="https://projects.iq.harvard.edu/files/acmg-geos/files/igc4-wedd_airquality2_bowman_3_mac.gif" target="_blank">movie 2</a>] (Kevin Bowman, JPL)
-	</li>
-</ul>
-
-<h4>
-	Posters
-</h4>
-
-<ul>
-	<li>
-		<a href="https://drive.google.com/file/d/1mdt7J8hLz1x-eOiNTpuRfoVHOi-_pvKl/view?usp=drive_link" target="_blank">Air quality forecasting using geostationary satellite observations</a> (Peter Zoogman, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1ZwD9MRpSyP3QOi98IvFGO38WgZrTikrU/view?usp=drive_link" target="_blank">Using satellite observations of tropospheric NO2 to test global changes in anthropogenic NOx emissions: from the Clean Air Act to the Mediterranean Sea and the 2008 Beijing Olympic Games</a> (Folkert Boersma, KNMI)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1EKjsz8o0eN_p6FREkkeEWKrZgoF5wSuu/view?usp=drive_link" target="_blank">Assimilated inversion of NO x emissions over East Asia using OMI NO2 column measurements</a> (Yuhang Wang , Georgia Tech)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1vS-weUfUPWKpQjtm4iz5wUp4nHUhKMwP/view?usp=drive_link" target="_blank">The impact of Hurricanes Katrina and Rita on pollution emissions as inferred by OMI NO2</a> (Bryan Duncan, NASA/GSFC)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Z9LG3T_Ku0B280BCOyjbjSBUOS2BjzE0/view?usp=drive_link" target="_blank">Application of OMI Ozone Profiles in CMAQ </a>(Lihua Wang, U. Alabama Huntsville)
-	</li>
-	<li>
-		Constraint on anthropogenic NOx emissions in China from different sectors: a new methodology using multiple satellite retrievals (Jintai Lin, Harvard)
-	</li>
-</ul>
-
-<h3>
-	<a name="mercury" id="mercury"></a>Mercury (Elsie Sunderland, Harvard, chair)
-</h3>
-
-<h4>
-	Presentations
-</h4>
-
-<ul>
-	<li>
-		<a href="https://drive.google.com/file/d/1WOxca3AQ0D1BKbQ6SK7P-8bIfzLUFHpW/view?usp=drive_link" target="_blank">A global mercury simulation and budget based on Hg+Br chemistry</a> (Chris Holmes, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1b84WQhrfEeh_Cuqlh8y2j-8jnV0J4aG5/view?usp=drive_link" target="_blank">Changing emissions and global mercury cycling</a> (Elizabeth Corbitt, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1x5cXFB9PzYyBRVFGrL0XYm0kDFYkLXBM/view?usp=drive_link" target="_blank">Incorporating a global terrestrial mercury model into GEOS-Chem</a> (Nicole Smith-Downey, U. Texas)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1FExo0hXp9fI0yAZhIyVal31o4e3Jl8o7/view?usp=drive_link" target="_blank">Evaluating mercury exposure and source attribution using GEOS-Chem</a> (Noelle Selin, MIT)
-	</li>
-</ul>
-
-<h4>
-	Posters
-</h4>
-
-<ul>
-	<li>
-		<a href="https://drive.google.com/file/d/1AVf8aW-CM5VyNFox__rk_GNsz8GxMzEn/view?usp=drive_link" target="_blank">Enhancements to the ocean mercury modeling capability in GEOS-Chem</a> (Elsie Sunderland, Harvard)
-	</li>
-</ul>
-
-<h3>
-	<a name="carb_gases" id="carb_gases"></a>Carbon gases (Qinbin Li, UCLA, chair)
-</h3>
-
-<h4>
-	Presentations
-</h4>
-
-<ul>
-	<li>
-		<a href="https://drive.google.com/file/d/1ag2EZdintg55j2gRGmVnFswb8xCZA6a5/view?usp=drive_link" target="_blank">Northern hemispheric CO source estimates as derived in an adjoint inversion from combined MOPITT, AIRS and SCIAMACHY measurements of CO columns</a> (Monika Kopacz, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1UOpiqwUCrNf7ShYdXLLg6q3IELA0kd_V/view?usp=drive_link" target="_blank">Evidence for a soil source of CO in the deserts of Saudi Arabia</a> (Dylan Jones, U. Toronto)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Fw0P9bn9HFbP4fRrBq8wJ8F-yknFFBs6/view?usp=drive_link" target="_blank">Modeling CO2 and its sources and sinks with GEOS-Chem</a> (Ray Nassar, U. Toronto)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1OVo0y5u39vaV79T2Hh1AhIy5MxGkZAbd/view?usp=drive_link" target="_blank">What can we learn about upper tropospheric CO2?</a> (Xun Jiang, JPL)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1D8jNQX4HrLT0CFs8nrkB-m89auzMibXW/view?usp=drive_link" target="_blank">Using satellite data in joint CO2 - CO inversion</a> (Helen Wang, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1c1pO50xEVZKmA-GweeaJeSX2YJIrarmM/view?usp=drive_link" target="_blank">Atmospheric constraints on the global budget of carbonyl sulfide</a> (Parvadha Suntharalingam, U. East Anglia)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1z2apTfzcCK_-tk51wK_fRcvdvj6G1q-u/view?usp=drive_link" target="_blank">Primary and secondary sources of atmospheric acetaldehyde</a> (Dylan Millet, U. Minnesota)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1I3k_mNX-fy3ObrRgUwc6wH0DbSXsDGSt/view?usp=drive_link" target="_blank">Methane source contribution in the Arctic: a study using GEOS-Chem and  airborne CH4 measurements obtained during ARCTAS-08</a> (Christopher Pickett-Heaps, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Gk9bQXPKnpGwV8P528hipmt6pDCYI2sv/view?usp=drive_link" target="_blank">Evaluating hotspot tropospheric methane concentrations in Himalaya region with GEOS-Chem and AIRS satellite retrievals</a> (Jinyun Tang, Purdue)
-	</li>
-</ul>
-
-<h4>
-	Posters
-</h4>
-
-<ul>
-	<li>
-		A satellite perspective on the inter-hemispheric transport of CO (Chenxia Cai, JPL)
-	</li>
-	<li>
-		Quantifying the impact of aggregation errors and model transport biases on top-down estimates of carbon monoxide emissions using satellites observations (Zhe Jiang, U. Toronto)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/19nXgMUNEpdFoklCBuivQK3KnB5aBywOh/view?usp=drive_link" target="_blank">Atmospheric formic acid: modeling and satellite remote sensing</a> (Gonzalo Gonzalez Abad, York U. )
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1dFDtq9ZmEo94AF-lup63YmdnBWFe2vY3/view?usp=drive_link" target="_blank">Evaluating a simulation of methane using ground-based and satellite measurements</a> (Annemarie Fraser, U. Edinburgh)
-	</li>
-	<li>
-		Inversion analysis of North American methane emissions Using INTEX-NA aircraft data (Kevin Wecht, Harvard)
-	</li>
-	<li>
-		BVOC emissions in GEOS-Chem:  model evaluation at two tropical rain forest sites (Michael Barkley, U. Edinburgh)
-	</li>
-</ul>
-
-<h2>
-	Day 3: Thursday, April 9
-</h2>
-
-<h3>
-	<a name="chem_clim_land" id="chem_clim_land"></a>Chemistry-Climate-Land Interactions (Dylan Millet, U. Minnesota , chair)
-</h3>
-
-<h4>
-	Presentations
-</h4>
-
-<ul>
-	<li>
-		<a href="https://drive.google.com/file/d/1lTr3qCJmFc3xG1ZUeYivwcoV9poPzyoA/view?usp=drive_link" target="_blank">New directions in studies of chemistry-climate interactions using GEOS-Chem</a> (Loretta Mickley, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Rdi7CS3mwf40Z-CTZDq5ksyKFkU9CBoF/view?usp=drive_link" target="_blank">Effects of tropical deforestation on tropospheric chemistry: a 10-year study using GEOS-Chem </a>(Prasad Kasibhatla, Duke)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1OkRg4ypo2O5p6SqEPyKdbsghzfAssPs4/view?usp=drive_link" target="_blank">Impacts of changes in land use/land cover on chemistry &amp; air quality </a>(Shiliang Wu , Michigan Tech)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/12lnuE75TIoORForY5t7nay6Xa9VktTae/view?usp=drive_link" target="_blank">Future inorganic aerosol levels</a> (Havala Pye, Caltech)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1eXozvjlEQU_D9UdO7cUdxBkJ0eDJFhqQ/view?usp=drive_link" target="_blank">Application of sensitivity of ozone air quality to temperature change to validate chemical transport models for future ozone simulation over the United States</a> (Moeko Yoshitomi, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1OBHiK_9hIiv_fPJ2pw2frkxNWAztmWQN/view?usp=drive_link" target="_blank">Impact of climate change on North American wildfire and ozone air quality in the United States</a> (Rynda Hudman, UC Berkeley)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1IZk4wNP5QC1VCML59uRsw5CABpcq_CbP/view?usp=drive_link" target="_blank">Effects of climate change on future forest fire and its impact on regional air quality</a> (Hyun Cheol Kim, U. Houston )
-	</li>
-	<li>
-		Re-thinking the IPCC radiative forcing bar chart: the sector based paradigm (Nadine Unger, GISS)
-	</li>
-</ul>
-
-<h3>
-	<a name="softeng" id="softeng"></a>Software Engineering etc.
-</h3>
-
-<ul>
-	<li>
-		<a href="https://drive.google.com/file/d/1-SC5Qr5tSwH_LS7YM_lCc6e1tM39WGAk/view?usp=drive_link" target="_blank">Software engineering, code development, user support issues</a> (Bob Yantosca, Philippe LeSager, Claire Carouge, leads)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1g8ClbZAfpPvdX-dX7JUu6oi6Uc8WUIHz/view?usp=drive_link">Adjoint Model Clinic</a> (led by: Daven Henze, Monika Kopacz, Kumaresh Singh)
-	</li>
-</ul>
-
-<h2>
-	Day 4: Friday, April 10
-</h2>
-
-<h3>
-	<a name="wg_reports" id="wg_reports"></a>Working Group Reports
-</h3>
-
-<ul>
-	<li>
-		<a href="https://drive.google.com/file/d/1CSj2IueqsfQes79ZQPp9Wsbst6lnQQwB/view?usp=drive_link" target="_blank">Adjoint</a> (co-chairs Kevin Bowman, Daven Henze)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1qV5FfaHwxyeLmo8naJ2uUj55G8vUXdic/view?usp=drive_link" target="_blank">Aerosol processes</a> (co-chairs Colette Heald, Fangqun Yu)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1h59jOyDu9ZIdtzWY86Z2ETeN5W7aXsL7/view?usp=drive_link" target="_blank">Carbon gases</a> (co-chairs Dylan Jones, Prasad Kasibhatla)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/13toz6QLfgiEA6IBxCXJ0OulmtuAlNy3R/view?usp=drive_link" target="_blank">Chemistry-climate interactions</a> (co-chairs Becky Alexander, Loretta Mickley)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Bm3kv6389n_Gei0JHz6oP_Y5DXyGPZf9/view?usp=drive_link" target="_blank">Emission inventories</a> (co-chairs Jennifer Logan, Randall Martin)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1xxrKwQ4EDCR-GGU4Lr2zDYEJtmSU8eaW/view?usp=drive_link">Oxidants and chemistry</a> (co-chairs Mat Evans, May Fu)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1sYKMoYkOLsgFpqWi-jhWIfQb_fOwaVyW/view?usp=drive_link" target="_blank">Regional modeling </a>(co-chairs Rokjin Park , Yuxuan Wang)
-	</li>
-</ul>
-
-<h3>
-	GEOS-Chem Model Clinic
-</h3>
-
-<ul>
-	<li>
-		<a href="https://drive.google.com/file/d/1MH43evVHZZH90m77UTeLBuRKlgKXjETx/view?usp=drive_link" target="_blank">Model Clinic Summary</a> (led by: Bob Yantosca, Philippe Le Sager, Claire Carouge)
-	</li>
+  <li>
+    <a href="https://drive.google.com/file/d/1MH43evVHZZH90m77UTeLBuRKlgKXjETx/view?usp=drive_link" target="_blank">Model Clinic Summary</a> (led by: Bob Yantosca, Philippe Le Sager, Claire Carouge)
+  </li>
 </ul>
 
 </div>
@@ -775,64 +688,16 @@
 </div>
 </div>
 
-<!--footer region beg-->
+<!--footer-->
 <footer id="footer" class="clearfix" role="contentinfo">
-
-<!-- Three column 3x33 Gpanel -->
-<div class="at-panel gpanel panel-display footer clearfix">
-<div class="region region-footer">
-<div class="region-inner clearfix">
-<div id="block-boxes-1617037690" class="block block-boxes block-boxes-os_boxes_html no-title"  module="boxes" delta="1617037690">
-<div class="block-inner clearfix">  
-<div class="block-content content" ng-non-bindable="">  
-<div id='boxes-box-1617037690' class='boxes-box'>  
 <div class="boxes-box-content">
   <p style="text-align:center">
-    Copyright © 2023 by the International GEOS-Chem Community. All rights reserved.
+    Copyright © 2026 by the International GEOS-Chem Community. All rights reserved.
   </p>
 </div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-<div class="region region-footer-bottom">  
-<div class="region-inner clearfix">  
-<div id="block-boxes-1616879798" class="block block-boxes block-boxes-os_boxes_media no-title"  module="boxes" delta="1616879798">  
-<div class="block-inner clearfix">  
-<div class="block-content content"> 
-<div id='boxes-box-1616879798' class='boxes-box'> 
-<div class="boxes-box-content"> 
-<div id="file-3900146" class="file file-html file-html-embed">
-<h2 class="element-invisible"><a href="">css-brand</a></h2>
-<div class="content">
-<div class="file-info">
-</div>
-<div class="field field-name-field-html-code field-type-text-long field-label-hidden view-mode-full">
-<div class="field-items">
-<div class="field-item even">
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-
-<!--footer region end-->
 </footer>
-</div>
-</div>
 
-<!--page area ends-->
-<div id="extradiv"></div>
+</div>
 </div>
 
 </body>

--- a/igc4.html
+++ b/igc4.html
@@ -1,9 +1,4 @@
 <!DOCTYPE html>
-<!--[if IEMobile 7]><html class="iem7"  lang="en" dir="ltr"><![endif]-->
-<!--[if lte IE 6]><html class="lt-ie9 lt-ie8 lt-ie7"  lang="en" dir="ltr"><![endif]-->
-<!--[if (IE 7)&(!IEMobile)]><html class="lt-ie9 lt-ie8"  lang="en" dir="ltr"><![endif]-->
-<!--[if IE 8]><html class="lt-ie9"  lang="en" dir="ltr"><![endif]-->
-<!--[if (gte IE 9)|(gt IEMobile 7)]><!--><html  lang="en" dir="ltr"><!--<![endif]-->
 <head>
 <meta charset="utf-8" />
 <!--<base href="/igc4" />-->
@@ -18,23 +13,12 @@
 <title>The 4th GEOS-Chem Meeting</title>
 <meta http-equiv="x-ua-compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<link type="text/css" rel="stylesheet" href="css/css_xE-rWrJf-fncB6ztZfd2huxqgxu4WO-qwma6Xer30m4%EF%B9%96m=1675397288.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_1kR8T1_c-l5pBT6ZwbDT7BFda-4fyqW9Jjum29_2IY8%EF%B9%96m=1675397312.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_YnlUIvHP13qgpYEqubzE8JyDwlSxUnVibfnVkSoSDb0%EF%B9%96m=1675397273.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_Ku-3OcT9qU9h7dnGig5e23q6EVryY8orK4wzVDxsweE%EF%B9%96m=1675397367.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_vprtFTrWyg23GbY50_zJZHWGYMNfS8vsrRS26i4-ISk%EF%B9%96m=1675397406.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_dW-aNNrctRhQNc-KECjtQd0PxuW-h19IEum-TX2MeEk%EF%B9%96m=1675397301.css" media="print" />
-<link type="text/css" rel="stylesheet" href="css/css_SH2Lx3Qprh0GZo_9xRp85U9NsWfkSXn_Bi-rJoMY1sw%EF%B9%96m=1675397273.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_uaIDKcYMUK5osSQXuirpr3ZleXtnnpBN-eiECm7N0M0%EF%B9%96m=1675397395.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/responsive.blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/geos-chem.css" media="all"/>
 <script type="text/javascript" src="dropdown-menu.js"></script>
-<!--[if lte IE 8]>
-<script type="text/javascript">
-  var os_c = document.createElement;os_c('header');os_c('nav');os_c('section');os_c('article');os_c('aside');os_c('footer');os_c('hgroup');os_c('figure');
-</script>
-<![endif]-->
 </head>
 
 <body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-1585687 node-type-page og-context og-context-node og-context-node-1585652 navbar-on">
@@ -57,10 +41,8 @@
 <div class="block-content content" ng-non-bindable="">
 <div id='boxes-box-1630413211' class='boxes-box'>
 <div class="boxes-box-content">
-<img height="551" width="1101" style="float: right; width: 350px; height: 175px; margin-bottom: 1.5em;" alt="gca2 logo" class="media-element file-default file-os-files-xxlarge" src="img/igc-early-logo.png" title="" />
-<h2 class="css-brand--css-geos-meetings-header-h2-xxxlarge">
-  The 4th GEOS-Chem Scientific and Users' Meeting (IGC4)<br />April 7-10 2009
-</h2>
+<a href="https://geoschem.github.io/"><img height="600" width="1034" style="float: right; width: 350px; height: 203px;" class="media-element file-default file-os-files-xxlarge" src="img/GEOS-Chem_Logo_Square_Light_Background_Orig.png" alt="" title="" /></a>
+<h2 class="css-brand--css-geos-meetings-header-h2-xxxlarge">The 4th GEOS-Chem Scientific and Users' Meeting (IGC4)<br />April 7-10 2009</h2>
 </div>
 </div>
 </div>
@@ -76,15 +58,16 @@
 
 <!--main menu region beg-->
 <div id="menu-bar" class="nav region-menu-bar clearfix">
-<nav id="block-os-igc4-menu" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="igc4_menu">  
-<ul class="nice-menu nice-menu-down nice-menu-igc4_menu" id="nice-menu-igc4_menu">
-  <li class="menu-859934 menu-path-node-1587057  first   odd  "><a href="igc4.html"  class="active">Home</a></li>
-  <li class="menu-859969 menu-path-node-1587065   even   last "><a href="igc4-presentations.html" >Presentations and Posters</a></li>
+<nav id="block-os-igc4-menu" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="igc4_menu">
+<ul class="nice-menu nice-menu-down">
+  <li><a href="igc4.html" class="active">IGC4 Home</a></li>
+  <li><a href="igc4-presentations.html">Presentations and Posters</a></li>
+  <li><a href="index.html">GEOS-Chem Home</a></li>
 </ul>
 </nav>
 </div>
 <!--main menu region end-->
-		
+
 <div id="columns" class="clearfix">
 <div class="hg-container">
 <div id="content-column" role="main">
@@ -94,7 +77,7 @@
 <a name="main-content"></a>
 <h1 id="page-title" ng-non-bindable="">Overview</h1>
 </header>
-														
+
 <!--front panel regions beg-->
 <div id="content-panels" class="at-panel gpanel panel-display content clearfix">
 <div class="region region-content-top">
@@ -109,20 +92,20 @@
 <div class="field-item even">
 
 <p align="justify">
-	The 4th GEOS-Chem Scientific and Users' Meeting was held from April 7–10, 2009 at Harvard University. It brought together over 160 scientists from more than 50 institutions and 15 countries.
+The 4th GEOS-Chem Scientific and Users' Meeting was held from April 7–10, 2009 at Harvard University. It brought together over 160 scientists from more than 50 institutions and 15 countries.
 </p>
 
 <p align="justify">
-	We would like to thank NASA/ACMAP, EPRI, NSF-ATM for financial support; Harvard School of Engineering &amp; Applied Science for facilities; Brenda Mathieu and the Jacob graduate students for logistics.
+We would like to thank NASA/ACMAP, EPRI, NSF-ATM for financial support; Harvard School of Engineering &amp; Applied Science for facilities; Brenda Mathieu and the Jacob graduate students for logistics.
 </p>
 
 <ul>
-	<li>
-		<a href="https://drive.google.com/file/d/1Ad9N7nX39zlB8W8zRDJoUH1lUKbqFGij/view?usp=drive_link">View the list of GEOS-Chem meeting attendees</a>
-	</li>
-	<li>
-		<a href="https://drive.google.com/drive/folders/1An-cMEQcGg3EV4tE-EBL8ihxFhCqtJKJ?usp=drive_link">View photos from the GEOS-Chem meeting</a> (photographer: Peter Zoogman)
-	</li>
+<li>
+<a href="https://drive.google.com/file/d/1Ad9N7nX39zlB8W8zRDJoUH1lUKbqFGij/view?usp=drive_link">View the list of GEOS-Chem meeting attendees</a>
+</li>
+<li>
+<a href="https://drive.google.com/drive/folders/1An-cMEQcGg3EV4tE-EBL8ihxFhCqtJKJ?usp=drive_link">View photos from the GEOS-Chem meeting</a> (photographer: Peter Zoogman)
+</li>
 </ul>
 
 </div>
@@ -143,64 +126,16 @@
 </div>
 </div>
 
-<!--footer region beg-->
+<!--footer-->
 <footer id="footer" class="clearfix" role="contentinfo">
-
-<!-- Three column 3x33 Gpanel -->
-<div class="at-panel gpanel panel-display footer clearfix">
-<div class="region region-footer">
-<div class="region-inner clearfix">
-<div id="block-boxes-1617037690" class="block block-boxes block-boxes-os_boxes_html no-title"  module="boxes" delta="1617037690">
-<div class="block-inner clearfix">  
-<div class="block-content content" ng-non-bindable="">  
-<div id='boxes-box-1617037690' class='boxes-box'>  
 <div class="boxes-box-content">
   <p style="text-align:center">
-    Copyright © 2023 by the International GEOS-Chem Community. All rights reserved.
+    Copyright © 2026 by the International GEOS-Chem Community. All rights reserved.
   </p>
 </div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-<div class="region region-footer-bottom">  
-<div class="region-inner clearfix">  
-<div id="block-boxes-1616879798" class="block block-boxes block-boxes-os_boxes_media no-title"  module="boxes" delta="1616879798">  
-<div class="block-inner clearfix">  
-<div class="block-content content"> 
-<div id='boxes-box-1616879798' class='boxes-box'> 
-<div class="boxes-box-content"> 
-<div id="file-3900146" class="file file-html file-html-embed">
-<h2 class="element-invisible"><a href="">css-brand</a></h2>
-<div class="content">
-<div class="file-info">
-</div>
-<div class="field field-name-field-html-code field-type-text-long field-label-hidden view-mode-full">
-<div class="field-items">
-<div class="field-item even">
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-
-<!--footer region end-->
 </footer>
-</div>
-</div>
 
-<!--page area ends-->
-<div id="extradiv"></div>
+</div>
 </div>
 
 </body>

--- a/igc5-presentations.html
+++ b/igc5-presentations.html
@@ -1,9 +1,4 @@
 <!DOCTYPE html>
-<!--[if IEMobile 7]><html class="iem7"  lang="en" dir="ltr"><![endif]-->
-<!--[if lte IE 6]><html class="lt-ie9 lt-ie8 lt-ie7"  lang="en" dir="ltr"><![endif]-->
-<!--[if (IE 7)&(!IEMobile)]><html class="lt-ie9 lt-ie8"  lang="en" dir="ltr"><![endif]-->
-<!--[if IE 8]><html class="lt-ie9"  lang="en" dir="ltr"><![endif]-->
-<!--[if (gte IE 9)|(gt IEMobile 7)]><!--><html  lang="en" dir="ltr"><!--<![endif]-->
 <head>
 <meta charset="utf-8" />
 <!--<base href="/igc5-presentations" />-->
@@ -18,23 +13,12 @@
 <title>The 5th International GEOS-Chem Meeting</title>
 <meta http-equiv="x-ua-compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<link type="text/css" rel="stylesheet" href="css/css_xE-rWrJf-fncB6ztZfd2huxqgxu4WO-qwma6Xer30m4%EF%B9%96m=1675397288.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_1kR8T1_c-l5pBT6ZwbDT7BFda-4fyqW9Jjum29_2IY8%EF%B9%96m=1675397312.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_YnlUIvHP13qgpYEqubzE8JyDwlSxUnVibfnVkSoSDb0%EF%B9%96m=1675397273.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_Ku-3OcT9qU9h7dnGig5e23q6EVryY8orK4wzVDxsweE%EF%B9%96m=1675397367.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_vprtFTrWyg23GbY50_zJZHWGYMNfS8vsrRS26i4-ISk%EF%B9%96m=1675397406.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_dW-aNNrctRhQNc-KECjtQd0PxuW-h19IEum-TX2MeEk%EF%B9%96m=1675397301.css" media="print" />
-<link type="text/css" rel="stylesheet" href="css/css_SH2Lx3Qprh0GZo_9xRp85U9NsWfkSXn_Bi-rJoMY1sw%EF%B9%96m=1675397273.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_uaIDKcYMUK5osSQXuirpr3ZleXtnnpBN-eiECm7N0M0%EF%B9%96m=1675397395.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/responsive.blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/geos-chem.css" media="all"/>
 <script type="text/javascript" src="dropdown-menu.js"></script>
-<!--[if lte IE 8]>
-<script type="text/javascript">
-  var os_c = document.createElement;os_c('header');os_c('nav');os_c('section');os_c('article');os_c('aside');os_c('footer');os_c('hgroup');os_c('figure');
-</script>
-<![endif]-->
 </head>
 
 <body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-1585687 node-type-page og-context og-context-node og-context-node-1585652 navbar-on">
@@ -45,14 +29,14 @@
 <div id="page_wrap" class="page_wrap">
 <div id="page" class="container page header-main content-top footer-none">
 <div id="page-wrapper">
-		
+
 <!--header regions beg-->
 <header id="header" class="clearfix" role="banner">
 <div id="header-container">
 <div id="header-panels" class="at-panel gpanel panel-display three-col clearfix">
 <div class="region region-header-second"><div class="region-inner clearfix">
 <section id="block-boxes-1630413211" class="block block-boxes block-boxes-os_boxes_html"  module="boxes" delta="1630413211">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <h2 class="block-title" ng-non-bindable="">Site-Logo</h2>
 <div class="block-content content" ng-non-bindable="">
 <div id='boxes-box-1630413211' class='boxes-box'>
@@ -76,15 +60,16 @@
 
 <!--main menu region beg-->
 <div id="menu-bar" class="nav region-menu-bar clearfix">
-<nav id="block-os-igc5-menu" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="igc5_menu">  
-<ul class="nice-menu nice-menu-down nice-menu-igc5_menu" id="nice-menu-igc5_menu">
-  <li class="menu-859829 menu-path-node-1587046  first   odd  "><a href="igc5.html"  class="active">Home</a></li>
-  <li class="menu-859880 menu-path-node-1587048   even   last "><a href="igc5-presentations.html" >Presentations and Posters</a></li>
+<nav id="block-os-igc5-menu" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="igc5_menu">
+<ul class="nice-menu nice-menu-down">
+  <li><a href="igc5.html" class="active">IGC5 Home</a></li>
+  <li><a href="igc5-presentations.html">Presentations and Posters</a></li>
+  <li><a href="index.html">GEOS-Chem Home</a></li>
 </ul>
 </nav>
 </div>
 <!--main menu region end-->
-		
+
 <div id="columns" class="clearfix">
 <div class="hg-container">
 <div id="content-column" role="main">
@@ -94,13 +79,13 @@
 <a name="main-content"></a>
 <h1 id="page-title" ng-non-bindable="">Presentations and Posters</h1>
 </header>
-														
+
 <!--front panel regions beg-->
 <div id="content-panels" class="at-panel gpanel panel-display content clearfix">
 <div class="region region-content-top">
 <div class="region-inner clearfix">
 <div id="block-os-pages-main-content" class="block block-os-pages no-title"  module="os_pages" delta="main_content">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <div class="block-content content" ng-non-bindable="">
 <article id="node-1585687" class="node node-page article clearfix" role="article">
 <div class="node-content" ng-non-bindable="">
@@ -109,748 +94,698 @@
 <div class="field-item even">
 
 <p>
-	<strong>Day 1 (May 2)</strong>: <a href="#model">Model overview and development</a> | <a href="#aersrc">Aerosol sources and chemistry</a> | <a href="#orgaer"> Organic aerosol</a> |<br /><a href="#aerfrc">Aerosol processes and radiative forcing</a> | <a href="#tropo3">Tropospheric ozone</a> | <a href="#photchem">Photochemistry</a>
+ <strong>Day 1 (May 2)</strong>: <a href="#model">Model overview and development</a> | <a href="#aersrc">Aerosol sources and chemistry</a> | <a href="#orgaer"> Organic aerosol</a> |<br /><a href="#aerfrc">Aerosol processes and radiative forcing</a> | <a href="#tropo3">Tropospheric ozone</a> | <a href="#photchem">Photochemistry</a>
 </p>
 
 <p>
-	<strong>Day 2 (May 3)</strong>: <a href="#srcsnk">Sources and sinks</a> | <a href="#srcsnkngas">Sources and sinks: Nitrogen gases</a> |<br /><a href="#cgas">Carbon gases</a> | <a href="#climchem">Climate-chemistry interactions</a> | <a href="#hgpop">Mercury and POPs</a>
+ <strong>Day 2 (May 3)</strong>: <a href="#srcsnk">Sources and sinks</a> | <a href="#srcsnkngas">Sources and sinks: Nitrogen gases</a> |<br /><a href="#cgas">Carbon gases</a> | <a href="#climchem">Climate-chemistry interactions</a> | <a href="#hgpop">Mercury and POPs</a>
 </p>
 
 <p>
-	<strong>Day 3 (May 4)</strong>: <a href="#transport">Transport and dynamics</a> | <a href="#regaq">Regional air quality</a> | <a href="#breakout">Working group breakout sessions</a>
+ <strong>Day 3 (May 4)</strong>: <a href="#transport">Transport and dynamics</a> | <a href="#regaq">Regional air quality</a> | <a href="#breakout">Working group breakout sessions</a>
 </p>
 
 <p>
-	<strong>Day 4 (May 5)</strong>: <a href="#wgreports">Working group reports</a> | <a href="#business">Business meeting</a> | <a href="#clinics">Model clinics</a>
+ <strong>Day 4 (May 5)</strong>: <a href="#wgreports">Working group reports</a> | <a href="#business">Business meeting</a> | <a href="#clinics">Model clinics</a>
 </p>
 
 <h2>
-	<a name="model" id="model"></a>Day 1, Session 1: Model overview and development
+ <a name="model" id="model"></a>Day 1, Session 1: Model overview and development
 </h2>
 
-<h3>
-	Presentations
-</h3>
+<h3>Presentations</h3>
 
 <ul>
-	<li>
-		Welcome <em>(Daniel Jacob, Harvard / Randall Martin, Dalhousie)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1IpJxynk_FKKeG1ESfzd-v2um3rxwp5H7/view?usp=drive_link">GEOS-Chem model: new developments, future directions</a> <em>(Daniel Jacob, Harvard)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1WUcCr-d2WWPPl718ZVW4Vhb5bVx5-uIB/view?usp=drive_link">GEOS-Chem adjoint model: new developments, future directions</a><em> (Daven Henze, U Colorado, Boulder)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1hNm8JwD97HHOPdFgOGJWlM_0UKKKj2WC/view?usp=drive_link">GEOS-Chem code: recent developments, future directions</a> <em>(Bob Yantosca, Harvard)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1mh8GHzAq_pLCm_e-Ok24quvtPSuIbYBq/view?usp=drive_link">The view from NASA Headquarters</a> <em>(Richard Eckman, NASA)</em>
-	</li>
+ <li>
+  Welcome <em>(Daniel Jacob, Harvard / Randall Martin, Dalhousie)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1IpJxynk_FKKeG1ESfzd-v2um3rxwp5H7/view?usp=drive_link">GEOS-Chem model: new developments, future directions</a> <em>(Daniel Jacob, Harvard)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1WUcCr-d2WWPPl718ZVW4Vhb5bVx5-uIB/view?usp=drive_link">GEOS-Chem adjoint model: new developments, future directions</a><em> (Daven Henze, U Colorado, Boulder)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1hNm8JwD97HHOPdFgOGJWlM_0UKKKj2WC/view?usp=drive_link">GEOS-Chem code: recent developments, future directions</a> <em>(Bob Yantosca, Harvard)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1mh8GHzAq_pLCm_e-Ok24quvtPSuIbYBq/view?usp=drive_link">The view from NASA Headquarters</a> <em>(Richard Eckman, NASA)</em>
+ </li>
 </ul>
 
 <h2>
-	<a name="aersrc" id="aersrc"></a>Day 1, Session 2: Aerosol sources and chemistry (Chair: Havala Pye, US EPA)
+ <a name="aersrc" id="aersrc"></a>Day 1, Session 2: Aerosol sources and chemistry (Chair: Havala Pye, US EPA)
 </h2>
 
-<h3>
-	Presentations
-</h3>
+<h3>Presentations</h3>
 
 <ul>
-	<li>
-		<a href="https://drive.google.com/file/d/1Q9peNPhwYO0Rqg9J0dQEVDI3lB3qToBQ/view?usp=drive_link">Sources, distribution, and acidity of sulfate-ammonium aerosol in the Arctic in winter-spring</a> <em>(Jenny Fisher, Harvard)</em>
-	</li>
-	<li>
-		New constraints on the global distribution of sea salt aerosols <em>(Lyatt Jaeglé, U. Washington)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1lFm2G9yn_b5erNnaIjCq6ZY-T1Zy0v-s/view?usp=drive_link">The sensitivity of aerosol formation and cloud-condensation nuclei to cosmic rays in GEOS-Chem/TOMAS</a> <em>(Jeffrey Pierce, Dalhousie)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1rqbay78YYN99piSrTAtKxSZAOz0oTW59/view?usp=drive_link">Modeling new particle formation in GEOS-Chem</a> <em>(Dan Westervelt, Carnegie Mellon Univ.)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/15og15KlSGfcummyht7Rk3ZF0Nt8KPOSa/view?usp=drive_link">Updated dust-iron dissolution mechanism in GEOS-Chem: effects of organic acids, photolysis, cloud cycling and dust mineralogy</a> <em>(Matthew Johnson, North Carolina State U.)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/15j4uP9y1BpUDtd-tNuzlGLyO79bcxr5H/view?usp=drive_link">Sources of carbonaceous aerosols and deposited black carbon in the Arctic in winter-spring</a> <em>(Qiaoqiao Wang, Harvard)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1ZPhTyRBxwwz0ULVm3BZKtpMgm_aV_jRO/view?usp=drive_link">Forest fire contribution to black carbon in the western United States</a> <em>(Yuhao Mao, UCLA)</em>
-	</li>
+ <li>
+  <a href="https://drive.google.com/file/d/1Q9peNPhwYO0Rqg9J0dQEVDI3lB3qToBQ/view?usp=drive_link">Sources, distribution, and acidity of sulfate-ammonium aerosol in the Arctic in winter-spring</a> <em>(Jenny Fisher, Harvard)</em>
+ </li>
+ <li>
+  New constraints on the global distribution of sea salt aerosols <em>(Lyatt Jaeglé, U. Washington)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1lFm2G9yn_b5erNnaIjCq6ZY-T1Zy0v-s/view?usp=drive_link">The sensitivity of aerosol formation and cloud-condensation nuclei to cosmic rays in GEOS-Chem/TOMAS</a> <em>(Jeffrey Pierce, Dalhousie)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1rqbay78YYN99piSrTAtKxSZAOz0oTW59/view?usp=drive_link">Modeling new particle formation in GEOS-Chem</a> <em>(Dan Westervelt, Carnegie Mellon Univ.)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/15og15KlSGfcummyht7Rk3ZF0Nt8KPOSa/view?usp=drive_link">Updated dust-iron dissolution mechanism in GEOS-Chem: effects of organic acids, photolysis, cloud cycling and dust mineralogy</a> <em>(Matthew Johnson, North Carolina State U.)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/15j4uP9y1BpUDtd-tNuzlGLyO79bcxr5H/view?usp=drive_link">Sources of carbonaceous aerosols and deposited black carbon in the Arctic in winter-spring</a> <em>(Qiaoqiao Wang, Harvard)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1ZPhTyRBxwwz0ULVm3BZKtpMgm_aV_jRO/view?usp=drive_link">Forest fire contribution to black carbon in the western United States</a> <em>(Yuhao Mao, UCLA)</em>
+ </li>
 </ul>
 
-<h3>
-	Posters
-</h3>
+<h3>Posters</h3>
 
 <ul>
-	<li>
-		<a href="https://drive.google.com/file/d/19SxCDQIpp4INlyOt6MT1ujc8oACxCExV/view?usp=drive_link">Top-down estimate of aerosol emissions over China using MODIS reflectance and GEOS-Chem adjoint models</a> <em>(Xiaoguang Xu, Univ. Nebraska-Lincoln)</em>
-	</li>
-	<li>
-		Top-down estimates of soil dust emissions in East Asia using inverse methods <em>(Bonyang Ku, Seoul Nat'l Univ.)</em>
-	</li>
+ <li>
+  <a href="https://drive.google.com/file/d/19SxCDQIpp4INlyOt6MT1ujc8oACxCExV/view?usp=drive_link">Top-down estimate of aerosol emissions over China using MODIS reflectance and GEOS-Chem adjoint models</a> <em>(Xiaoguang Xu, Univ. Nebraska-Lincoln)</em>
+ </li>
+ <li>
+  Top-down estimates of soil dust emissions in East Asia using inverse methods <em>(Bonyang Ku, Seoul Nat'l Univ.)</em>
+ </li>
 </ul>
 
 <h2>
-	<a name="orgaer" id="orgaer"></a>Day 1, Session 3: Organic aerosol (Chair: Jeffrey Pierce, Dalhousie U.)
+ <a name="orgaer" id="orgaer"></a>Day 1, Session 3: Organic aerosol (Chair: Jeffrey Pierce, Dalhousie U.)
 </h2>
 
-<h3>
-	Presentations
-</h3>
+<h3>Presentations</h3>
 
 <ul>
-	<li>
-		<a href="https://drive.google.com/file/d/1D1gTWdN-mgqeRkuPvt2t-1mQiLsQF13Q/view?usp=drive_link">Sources of carbonaceous aerosols in China</a> <em>(May Fu, Peking Univ)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1O6rkyzs2gkkTJsB_Ilbjm9z7q-qTf3PL/view?usp=drive_link">Extended SOA formation model considering SOG oxidation aging and kinetic condensation: GEOS-Chem simulations and comparisons with measurements</a> <em>(Fangqun Yu, SUNY Albany)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1aeLSmP3yMxmY1_M2y2_xJdCaufZh-MPY/view?usp=drive_link">What satellite and aircraft observations can tell us about the organic aerosol budget</a> <em>(Colette Heald, Colorado State Univ.)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1FxuD9lVSIuesGdfeWD5JDYlmf9RJz7g7/view?usp=drive_link">Investigating organic aerosol loading in the remote marine environment</a> <em>(Kateryna Lapina, Colorado State Univ.)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1423ZDR2DuUEczsXwOQU2XEky5hQrFJBG/view?usp=drive_link">Secondary organic aerosol from low volatility and traditional VOC precursors</a> <em>(Havala Pye, US EPA)</em>
-	</li>
+ <li>
+  <a href="https://drive.google.com/file/d/1D1gTWdN-mgqeRkuPvt2t-1mQiLsQF13Q/view?usp=drive_link">Sources of carbonaceous aerosols in China</a> <em>(May Fu, Peking Univ)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1O6rkyzs2gkkTJsB_Ilbjm9z7q-qTf3PL/view?usp=drive_link">Extended SOA formation model considering SOG oxidation aging and kinetic condensation: GEOS-Chem simulations and comparisons with measurements</a> <em>(Fangqun Yu, SUNY Albany)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1aeLSmP3yMxmY1_M2y2_xJdCaufZh-MPY/view?usp=drive_link">What satellite and aircraft observations can tell us about the organic aerosol budget</a> <em>(Colette Heald, Colorado State Univ.)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1FxuD9lVSIuesGdfeWD5JDYlmf9RJz7g7/view?usp=drive_link">Investigating organic aerosol loading in the remote marine environment</a> <em>(Kateryna Lapina, Colorado State Univ.)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1423ZDR2DuUEczsXwOQU2XEky5hQrFJBG/view?usp=drive_link">Secondary organic aerosol from low volatility and traditional VOC precursors</a> <em>(Havala Pye, US EPA)</em>
+ </li>
 </ul>
 
-<h3>
-	Posters
-</h3>
+<h3>Posters</h3>
 
 <ul>
-	<li>
-		<a href="https://drive.google.com/file/d/1gfYQX3d7GNpjh7GfpvFQlofiUit_eHiM/view?usp=drive_link">Modeling of marine primary and secondary organic aerosols</a> <em>(Nicholas Meskhidze, North Carolina State Univ.)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1liq2Lhe6YJpT-DQh7utnw0sREPGZ5VqB/view?usp=drive_link">Modeling organic aerosol: using regional models to characterize global models</a> <em>(Joseph Ensberg, Caltech)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1RUk3swmlEG1aqAPFO4FXc7rT0qAieYdM/view?usp=drive_link">Sensitivity of atmospheric transport of carbonaceous aerosols to aging mechanism</a> <em>(Yaoxian Huang, Michigan Tech Univ.)</em>
-	</li>
+ <li>
+  <a href="https://drive.google.com/file/d/1gfYQX3d7GNpjh7GfpvFQlofiUit_eHiM/view?usp=drive_link">Modeling of marine primary and secondary organic aerosols</a> <em>(Nicholas Meskhidze, North Carolina State Univ.)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1liq2Lhe6YJpT-DQh7utnw0sREPGZ5VqB/view?usp=drive_link">Modeling organic aerosol: using regional models to characterize global models</a> <em>(Joseph Ensberg, Caltech)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1RUk3swmlEG1aqAPFO4FXc7rT0qAieYdM/view?usp=drive_link">Sensitivity of atmospheric transport of carbonaceous aerosols to aging mechanism</a> <em>(Yaoxian Huang, Michigan Tech Univ.)</em>
+ </li>
 </ul>
 
 <h2>
-	<a name="aerfrc" id="aerfrc"></a>Day 1, Session 4: Aerosol processes and radiative forcing (Chair: Fangqun Yu, SUNY-Albany)
+ <a name="aerfrc" id="aerfrc"></a>Day 1, Session 4: Aerosol processes and radiative forcing (Chair: Fangqun Yu, SUNY-Albany)
 </h2>
 
-<h3>
-	Presentations
-</h3>
+<h3>Presentations</h3>
 
 <ul>
-	<li>
-		<a href="https://drive.google.com/file/d/1syBjrUXctbzeWP-BzmUT11XnF4Kt7G2d/view?usp=drive_link">North African dust export: a global 3-D model analysis using MODIS, MISR, CALIPSO, and AERONET observations</a> <em>(David Ridley, Colorado State Univ.)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1-V6dh8ZhXNp6OWWZd8kJXchH0t4YJnXH/view?usp=drive_link">Origin and radiative forcing of black carbon transported to the Himalayas</a> (Monika Kopacz, NOAA)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1psZa7n5r9iy-nIYsC06cUy5S-XEB71hB/view?usp=drive_link">Aerosol scavenging in continental outflow pathways</a> <em>(Sungshik "Patrick" Kim, Harvard)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1C2yYQ7_Cro8aSlzEXFekOl6AEs7-IGT_/view?usp=drive_link">Estimate of volcanic aerosol forcing by combined use of OMI SO2 data and GEOS-Chem</a> <em>(Jun Wang, Univ. Nebraska-Lincoln)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1bdyK_12jGI-fr1vTjeoHW31_HZa8IDsM/view?usp=drive_link">A new GEOS-Chem post-processing tool for aerosol optical properties calculations</a> <em>(Gabriele Curci, Univ. of L'Aquila)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1vGVOdleMleEWblofDkcf1ofnAe8YYFIw/view?usp=drive_link">GEOS-Chem + APM simulations over three nested domains (Europe-North America-East Asia) and comparisons with particle measurements</a> <em>(Gan Luo, SUNY-Albany)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1e9XIe6g9x9on31hKU6ak0YRg32SN3i9Y/view?usp=drive_link">Impact of mixing state on aerosol optical depth and radiative forcing: simulation of APM</a> <em>(Xiaoyan Ma, SUNY-Albany)</em>
-	</li>
+ <li>
+  <a href="https://drive.google.com/file/d/1syBjrUXctbzeWP-BzmUT11XnF4Kt7G2d/view?usp=drive_link">North African dust export: a global 3-D model analysis using MODIS, MISR, CALIPSO, and AERONET observations</a> <em>(David Ridley, Colorado State Univ.)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1-V6dh8ZhXNp6OWWZd8kJXchH0t4YJnXH/view?usp=drive_link">Origin and radiative forcing of black carbon transported to the Himalayas</a> (Monika Kopacz, NOAA)
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1psZa7n5r9iy-nIYsC06cUy5S-XEB71hB/view?usp=drive_link">Aerosol scavenging in continental outflow pathways</a> <em>(Sungshik "Patrick" Kim, Harvard)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1C2yYQ7_Cro8aSlzEXFekOl6AEs7-IGT_/view?usp=drive_link">Estimate of volcanic aerosol forcing by combined use of OMI SO2 data and GEOS-Chem</a> <em>(Jun Wang, Univ. Nebraska-Lincoln)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1bdyK_12jGI-fr1vTjeoHW31_HZa8IDsM/view?usp=drive_link">A new GEOS-Chem post-processing tool for aerosol optical properties calculations</a> <em>(Gabriele Curci, Univ. of L'Aquila)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1vGVOdleMleEWblofDkcf1ofnAe8YYFIw/view?usp=drive_link">GEOS-Chem + APM simulations over three nested domains (Europe-North America-East Asia) and comparisons with particle measurements</a> <em>(Gan Luo, SUNY-Albany)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1e9XIe6g9x9on31hKU6ak0YRg32SN3i9Y/view?usp=drive_link">Impact of mixing state on aerosol optical depth and radiative forcing: simulation of APM</a> <em>(Xiaoyan Ma, SUNY-Albany)</em>
+ </li>
 </ul>
 
-<h3>
-	Posters
-</h3>
+<h3>Posters</h3>
 
 <ul>
-	<li>
-		Satellite observations and model simulations of Arctic aerosols <em>(Maurizio Di Pierro, U. Washington)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1XOruOwZOynoM9Zg8amJ9iAy9N01maTS8/view?usp=drive_link">Mineral dust events over the Mediterranean: GEOS-Chem + APM simulation and comparison with observations</a> <em>(Kevin Bartlett, SUNY-Albany)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1n6Aa4B3o2wWvj9p7IC9dIcO27fJWOdv6/view?usp=drive_link">Comparison of particle microphysics modeling over North America using GEOS-Chem + APM and WRF-Chem + APM</a> <em>(Gan Luo, SUNY-Albany)</em>
-	</li>
-	<li>
-		Deriving the effect of wind speed on clean maritime aerosol optical properties using CALIPSO data <em>(KV Praju, North Carolina State Univ.)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1u0jVzRI9huOSM7j1FwA8XFW91P7zPzEs/view?usp=drive_link">Global simulations of aerosol size-dependent in-cloud scavenging</a> <em>(Betty Croft, Dalhousie)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1v0mORGCRl03-iF-HoQtR2p3o0Eb3y9UH/view?usp=drive_link">Joint retrieval of aerosol optical properties over North America using GEOS-Chem and MISR</a> <em>(Shenshen Li, Emory Univ.)</em>
-	</li>
-	<li>
-		Evaluating GEOS-Chem predicted mineral dust transport using remotely-sensed data from the A-Train satellites <em>(Matthew Johnson, North Carolina State Univ.)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1FO-1qIkT9gIX0apYuhaAVMBHxk1yAA9f/view?usp=drive_link">Intercontinental influence of NOx and CO emissions on particulate matter air quality</a> <em>(Eric Leibensperger, Harvard)</em>
-	</li>
+ <li>
+  Satellite observations and model simulations of Arctic aerosols <em>(Maurizio Di Pierro, U. Washington)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1XOruOwZOynoM9Zg8amJ9iAy9N01maTS8/view?usp=drive_link">Mineral dust events over the Mediterranean: GEOS-Chem + APM simulation and comparison with observations</a> <em>(Kevin Bartlett, SUNY-Albany)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1n6Aa4B3o2wWvj9p7IC9dIcO27fJWOdv6/view?usp=drive_link">Comparison of particle microphysics modeling over North America using GEOS-Chem + APM and WRF-Chem + APM</a> <em>(Gan Luo, SUNY-Albany)</em>
+ </li>
+ <li>
+  Deriving the effect of wind speed on clean maritime aerosol optical properties using CALIPSO data <em>(KV Praju, North Carolina State Univ.)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1u0jVzRI9huOSM7j1FwA8XFW91P7zPzEs/view?usp=drive_link">Global simulations of aerosol size-dependent in-cloud scavenging</a> <em>(Betty Croft, Dalhousie)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1v0mORGCRl03-iF-HoQtR2p3o0Eb3y9UH/view?usp=drive_link">Joint retrieval of aerosol optical properties over North America using GEOS-Chem and MISR</a> <em>(Shenshen Li, Emory Univ.)</em>
+ </li>
+ <li>
+  Evaluating GEOS-Chem predicted mineral dust transport using remotely-sensed data from the A-Train satellites <em>(Matthew Johnson, North Carolina State Univ.)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1FO-1qIkT9gIX0apYuhaAVMBHxk1yAA9f/view?usp=drive_link">Intercontinental influence of NOx and CO emissions on particulate matter air quality</a> <em>(Eric Leibensperger, Harvard)</em>
+ </li>
 </ul>
 
 <h2>
-	<a name="tropo3" id="tropo3"></a>Day 1, Session 5: Tropspheric ozone (Chair: Shiliang Wu, Michigan Tech U.)
+ <a name="tropo3" id="tropo3"></a>Day 1, Session 5: Tropspheric ozone (Chair: Shiliang Wu, Michigan Tech U.)
 </h2>
 
-<h3>
-	Presentations
-</h3>
-
-<ul><
-	li>
-		<a href="https://drive.google.com/file/d/16qB2hoXDmdjMxfZz2Yi0rPR7Vxni0eGs/view?usp=drive_link">Sensitivity analysis of tropospheric ozone at middle and high latitudes to precursor emissions</a> <em>(Thomas Walker, U. Toronto)</em>
-	</li>
-	<li>
-		Variability in tropospheric oxidant concentrations on interannual to interglacial time scales <em>(Lee Murray, Harvard)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1VtCydMHMOKDQoEb2fP6q8dobLAVHLCia/view?usp=drive_link">Vertical distribution and sources of tropospheric ozone over South China in spring 2004: Ozonesonde measurements and modeling analysis</a> <em>(Hongyu Liu, NIA/NASA Langley)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/17At59hPyT9ciBg2Z9E6fPYIjf2iZcFzW/view?usp=drive_link">Evaluating ozone production efficiency in GEOS-Chem and satellite measurements</a> <em>(Matthew Cooper, Dalhousie)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1-C0MNRuqq2aPSE4QsBFRB19NH4SUm8GJ/view?usp=drive_link">Using error correlations between ozone and CO for geostationary measurements of ozone air quality</a> <em>(Peter Zoogman, Harvard)</em>
-	</li>
-</ul>
-
-<h3>
-	Posters
-</h3>
+<h3>Presentations</h3>
 
 <ul>
-	<li>
-		<a href="https://drive.google.com/file/d/1taD9FGqNs3ZXAXiSRHb3CXtFIndvbb-E/view?usp=drive_link">The impact of wildfires on surface ozone in Western US</a> <em>(Mei Gao, UCLA)</em>
-	</li>
-	<li>
-		Trends in Atlantic free troposphere CO and ozone from 2001-2010: a comparison of GEOS-Chem and PICO-NARE measurements <em>(Mark Weise, Michigan Tech Univ.)</em>
-	</li>
-	<li>
-		Cross-evaluation of OMI ozone profiles and GMI chemical transport model simulations <em>(Xiong Liu, Harvard Smithsonian CFA)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1qCAAPGXAYH6CnaM_bX7wtOaLGemhqcd-/view?usp=drive_link">Evaluating the factors influencing the tropospheric ozone distribution over the North Atlantic during summer 2010 with GEOS-Chem and its adjoint</a> <em>(Mark Parrington, Univ. of Edinburgh)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1R4lNzXJbC6tsr2o8LvzEZ7ru3Lf-tfV-/view?usp=drive_link">Using fire impulses to diagnose OH levels in GEOS-Chem</a> <em>(Mingquan Mu, UC Irvine)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1RXdvsHWUhaS-fVOWla4zz-eOYfmfD1hx/view?usp=drive_link">Evaluation of a hierarchy of chemical mechanisms to model net ozone production from seasonal biomass burning in boreal North America over the western boundary of the North Atlantic</a> <em>(A. Rickard, U. Leeds)</em>
-	</li>
+  <li>
+  <a href="https://drive.google.com/file/d/16qB2hoXDmdjMxfZz2Yi0rPR7Vxni0eGs/view?usp=drive_link">Sensitivity analysis of tropospheric ozone at middle and high latitudes to precursor emissions</a> <em>(Thomas Walker, U. Toronto)</em>
+ </li>
+ <li>
+  Variability in tropospheric oxidant concentrations on interannual to interglacial time scales <em>(Lee Murray, Harvard)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1VtCydMHMOKDQoEb2fP6q8dobLAVHLCia/view?usp=drive_link">Vertical distribution and sources of tropospheric ozone over South China in spring 2004: Ozonesonde measurements and modeling analysis</a> <em>(Hongyu Liu, NIA/NASA Langley)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/17At59hPyT9ciBg2Z9E6fPYIjf2iZcFzW/view?usp=drive_link">Evaluating ozone production efficiency in GEOS-Chem and satellite measurements</a> <em>(Matthew Cooper, Dalhousie)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1-C0MNRuqq2aPSE4QsBFRB19NH4SUm8GJ/view?usp=drive_link">Using error correlations between ozone and CO for geostationary measurements of ozone air quality</a> <em>(Peter Zoogman, Harvard)</em>
+ </li>
+</ul>
+
+<h3>Posters</h3>
+
+<ul>
+ <li>
+  <a href="https://drive.google.com/file/d/1taD9FGqNs3ZXAXiSRHb3CXtFIndvbb-E/view?usp=drive_link">The impact of wildfires on surface ozone in Western US</a> <em>(Mei Gao, UCLA)</em>
+ </li>
+ <li>
+  Trends in Atlantic free troposphere CO and ozone from 2001-2010: a comparison of GEOS-Chem and PICO-NARE measurements <em>(Mark Weise, Michigan Tech Univ.)</em>
+ </li>
+ <li>
+  Cross-evaluation of OMI ozone profiles and GMI chemical transport model simulations <em>(Xiong Liu, Harvard Smithsonian CFA)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1qCAAPGXAYH6CnaM_bX7wtOaLGemhqcd-/view?usp=drive_link">Evaluating the factors influencing the tropospheric ozone distribution over the North Atlantic during summer 2010 with GEOS-Chem and its adjoint</a> <em>(Mark Parrington, Univ. of Edinburgh)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1R4lNzXJbC6tsr2o8LvzEZ7ru3Lf-tfV-/view?usp=drive_link">Using fire impulses to diagnose OH levels in GEOS-Chem</a> <em>(Mingquan Mu, UC Irvine)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1RXdvsHWUhaS-fVOWla4zz-eOYfmfD1hx/view?usp=drive_link">Evaluation of a hierarchy of chemical mechanisms to model net ozone production from seasonal biomass burning in boreal North America over the western boundary of the North Atlantic</a> <em>(A. Rickard, U. Leeds)</em>
+ </li>
 </ul>
 
 <h2>
-	<a name="photchem" id="photchem"></a>Day 1, Session 6: Photochemistry (Chair: Nicholas Meshkidze, North Carolina State U.)
+ <a name="photchem" id="photchem"></a>Day 1, Session 6: Photochemistry (Chair: Nicholas Meshkidze, North Carolina State U.)
 </h2>
 
-<h3>
-	Presentations
-</h3>
+<h3>Presentations</h3>
 
 <ul>
-	<li>
-		<a href="https://drive.google.com/file/d/126fi94G9_VMbi723VBjwroP0luNbQvIy/view?usp=drive_link">Accounting for non-linear chemistry of NOx shipping plumes in GEOS-Chem; development, evaluation and implementation</a> <em>(Geert Vinken, Eindhoven Univ. of Technology)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1IWcEoFYHLtWucCdeuXzLV4LbSmQ03-NP/view?usp=drive_link">Understanding some of the simpler uncertainties in the GEOS-Chem chemistry</a> <em>(Mat Evans, Univ. Leeds)</em>
-	</li>
-	<li>
-		Sensitivity of continental boundary layer chemistry to a new isoprene oxidation mechanism <em>(Jingqiu Mao, NOAA GFDL)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1XLmH3BZb70GdByvEcA5a6X09IY2f_HxT/view?usp=drive_link">NOx spikes in the Arctic: chemistry or transport?</a> <em>(Shiliang Wu, Michigan Tech Univ.)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1kZj_S1XkmTKfymhQwDyydyQFZbHYFufo/view?usp=drive_link">Bromine chemistry in GEOS-Chem and its impact on ozone in the present-day and preindustrial atmosphere</a> <em>(Justin Parrella, Harvard)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/108OcAA-3tJFlHzE37St9UKq9_tagmIdV/view?usp=drive_link">Long term measurements and modeling of OH and HO2 radicals at a tropical marine location</a> <em>(Daniel Stone, Univ. Leeds)</em>
-	</li>
+ <li>
+  <a href="https://drive.google.com/file/d/126fi94G9_VMbi723VBjwroP0luNbQvIy/view?usp=drive_link">Accounting for non-linear chemistry of NOx shipping plumes in GEOS-Chem; development, evaluation and implementation</a> <em>(Geert Vinken, Eindhoven Univ. of Technology)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1IWcEoFYHLtWucCdeuXzLV4LbSmQ03-NP/view?usp=drive_link">Understanding some of the simpler uncertainties in the GEOS-Chem chemistry</a> <em>(Mat Evans, Univ. Leeds)</em>
+ </li>
+ <li>
+  Sensitivity of continental boundary layer chemistry to a new isoprene oxidation mechanism <em>(Jingqiu Mao, NOAA GFDL)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1XLmH3BZb70GdByvEcA5a6X09IY2f_HxT/view?usp=drive_link">NOx spikes in the Arctic: chemistry or transport?</a> <em>(Shiliang Wu, Michigan Tech Univ.)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1kZj_S1XkmTKfymhQwDyydyQFZbHYFufo/view?usp=drive_link">Bromine chemistry in GEOS-Chem and its impact on ozone in the present-day and preindustrial atmosphere</a> <em>(Justin Parrella, Harvard)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/108OcAA-3tJFlHzE37St9UKq9_tagmIdV/view?usp=drive_link">Long term measurements and modeling of OH and HO2 radicals at a tropical marine location</a> <em>(Daniel Stone, Univ. Leeds)</em>
+ </li>
 </ul>
 
-<h3>
-	Posters
-</h3>
+<h3>Posters</h3>
 
 <ul>
-	<li>
-		Impact of mechanistic changes of isoprene oxidation in GEOS-Chem <em>(Chris Miller, Harvard)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/18Liw0BdOyJsO71-SB_JrkbRHEpocIklm/view?usp=drive_link">HOx Budgets during HOx-Comp: a Case Study of HOx Chemistry under NOx limited Conditions</a> <em>(Yasin Elshorbany, Max Planck Institute for Chemistry)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/10S0cWXG9xlrQSRMUF1e1jSQ80I88FmNO/view?usp=drive_link">Investigating the impact of snowpack photodenitrification on Antarctic atmospheric chemistry utilizing results from a snowpack radiative transfer model in a global chemical transport model</a> <em>(Maria Zatko, U Washington)</em>
-	</li>
-	<li>
-		Isoprene oxidation mechanisms — modeling of OH and HO2 <em>(Daniel Stone, Univ. Leeds)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1VftiyK9C74X4yZdsLBBZh22HFXT_08aK/view?usp=drive_link">Interpreting the isotopic composition of sulfate and nitrate from an Antarctic ice core using GEOS-Chem</a> <em>(Eric Sofen, U Washington)</em>
-	</li>
+ <li>
+  Impact of mechanistic changes of isoprene oxidation in GEOS-Chem <em>(Chris Miller, Harvard)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/18Liw0BdOyJsO71-SB_JrkbRHEpocIklm/view?usp=drive_link">HOx Budgets during HOx-Comp: a Case Study of HOx Chemistry under NOx limited Conditions</a> <em>(Yasin Elshorbany, Max Planck Institute for Chemistry)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/10S0cWXG9xlrQSRMUF1e1jSQ80I88FmNO/view?usp=drive_link">Investigating the impact of snowpack photodenitrification on Antarctic atmospheric chemistry utilizing results from a snowpack radiative transfer model in a global chemical transport model</a> <em>(Maria Zatko, U Washington)</em>
+ </li>
+ <li>
+  Isoprene oxidation mechanisms — modeling of OH and HO2 <em>(Daniel Stone, Univ. Leeds)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1VftiyK9C74X4yZdsLBBZh22HFXT_08aK/view?usp=drive_link">Interpreting the isotopic composition of sulfate and nitrate from an Antarctic ice core using GEOS-Chem</a> <em>(Eric Sofen, U Washington)</em>
+ </li>
 </ul>
 
 <h2>
-	<a name="srcsnk" id="srcsnk"></a>Day 2, Session 1: Sources and sinks (Chair: May Fu, Peking U.)
+ <a name="srcsnk" id="srcsnk"></a>Day 2, Session 1: Sources and sinks (Chair: May Fu, Peking U.)
 </h2>
 
-<h3>
-	Presentations
-</h3>
+<h3>Presentations</h3>
 
 <ul>
-	<li>
-		<a href="https://drive.google.com/file/d/16aJ826EvnBuTykKYW-g3JNCKdPlIy73d/view?usp=drive_link">Integrating daily and hourly fire emissions into GEOS-Chem and impacts on atmospheric CO</a> <em>(James Randerson, UC Irvine)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1eno_EvRcCbAN-5hPMV_AkbhDbPdcQ4DF/view?usp=drive_link">Bayesian statistical modeling of correlated error structure in atmospheric tracer inverse analysis</a> <em>(Prasad Kasibhatla, Duke)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1TcUsnJb-4EbtJQUFYpBVUqN1_iTdk4bj/view?usp=drive_link">Space-based estimates of anthropogenic SO2 emissions</a> <em>(Randall Martin, Dalhousie)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1PTNfPKqV9DXrCwwtQngLPexokbpWJ7SK/view?usp=drive_link">Constraining global dust emissions using MISR AOD and OMI Aerosol Index</a> <em>(Qinbin Li, UCLA)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/12uczlnPGHHdxGYCzKMUrQ_0tESZmPRTu/view?usp=drive_link">Inversion of global isoprene emissions</a> <em>(Yuhang Wang, Georgia Inst. of Tech.)</em>
-	</li>
-	<li>
-		<a href="hhttps://drive.google.com/file/d/1hJTmPwhGkw4AUgJBl_8vWVkVWUu67Ol2/view?usp=drive_link">Simulating Amazonian biogenic emissions and tropospheric chemistry using a GEOS-Chem nested grid</a> <em>(Michael Barkley, Univ. of Leicester)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/16Hlhn6lJlCnMjmtZrbBDSrBYaFlO23Dh/view?usp=drive_link">Using GEOS-Chem to obtain a top-down estimate of isoprene emissions over Africa</a> <em>(Eloise Marais, Harvard)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1hPlduvbj1jvvtt9ShZhmTHi2gHH2e2mz/view?usp=drive_link">Assessing the range of modeled source influences on column concentrations of short-lived species (SO2, NH3, and NOx) using adjoint sensitivities</a> <em>(Alexander Turner, U Colorado Boulder)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1maoY8xBIjLpnXFCdYY2WNuAN0XiDI944/view?usp=drive_link">Toward inverse modeling of US methane sources: The effect of model resolution on comparisons to SCIAMACHY and INTEX-NA</a> <em>(Kevin Wecht, Harvard)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1IhCx7X4xT5weJA_p2qQRjX0i9H7JEZPt/view?usp=drive_link">Biogenic methanol production by plant functional type: insights from GEOS-Chem and space-based observations</a> <em>(Kelley Wells, Univ. Minnesota)</em>
-	</li>
+ <li>
+  <a href="https://drive.google.com/file/d/16aJ826EvnBuTykKYW-g3JNCKdPlIy73d/view?usp=drive_link">Integrating daily and hourly fire emissions into GEOS-Chem and impacts on atmospheric CO</a> <em>(James Randerson, UC Irvine)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1eno_EvRcCbAN-5hPMV_AkbhDbPdcQ4DF/view?usp=drive_link">Bayesian statistical modeling of correlated error structure in atmospheric tracer inverse analysis</a> <em>(Prasad Kasibhatla, Duke)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1TcUsnJb-4EbtJQUFYpBVUqN1_iTdk4bj/view?usp=drive_link">Space-based estimates of anthropogenic SO2 emissions</a> <em>(Randall Martin, Dalhousie)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1PTNfPKqV9DXrCwwtQngLPexokbpWJ7SK/view?usp=drive_link">Constraining global dust emissions using MISR AOD and OMI Aerosol Index</a> <em>(Qinbin Li, UCLA)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/12uczlnPGHHdxGYCzKMUrQ_0tESZmPRTu/view?usp=drive_link">Inversion of global isoprene emissions</a> <em>(Yuhang Wang, Georgia Inst. of Tech.)</em>
+ </li>
+ <li>
+  <a href="hhttps://drive.google.com/file/d/1hJTmPwhGkw4AUgJBl_8vWVkVWUu67Ol2/view?usp=drive_link">Simulating Amazonian biogenic emissions and tropospheric chemistry using a GEOS-Chem nested grid</a> <em>(Michael Barkley, Univ. of Leicester)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/16Hlhn6lJlCnMjmtZrbBDSrBYaFlO23Dh/view?usp=drive_link">Using GEOS-Chem to obtain a top-down estimate of isoprene emissions over Africa</a> <em>(Eloise Marais, Harvard)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1hPlduvbj1jvvtt9ShZhmTHi2gHH2e2mz/view?usp=drive_link">Assessing the range of modeled source influences on column concentrations of short-lived species (SO2, NH3, and NOx) using adjoint sensitivities</a> <em>(Alexander Turner, U Colorado Boulder)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1maoY8xBIjLpnXFCdYY2WNuAN0XiDI944/view?usp=drive_link">Toward inverse modeling of US methane sources: The effect of model resolution on comparisons to SCIAMACHY and INTEX-NA</a> <em>(Kevin Wecht, Harvard)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1IhCx7X4xT5weJA_p2qQRjX0i9H7JEZPt/view?usp=drive_link">Biogenic methanol production by plant functional type: insights from GEOS-Chem and space-based observations</a> <em>(Kelley Wells, Univ. Minnesota)</em>
+ </li>
 </ul>
 
-<h3>
-	Posters
-</h3>
+<h3>Posters</h3>
 
 <ul>
-	<li>
-		Hourly biomass burning emissions product from global geostationary satellite constellation, and its application in GEOS-Chem <em>(Xiaoyang Zhang, NOAA)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1UegyeQZVzw46OlQJMa0tH1MauZdskVyB/view?usp=drive_link">Biogenic emissions of volatile organic compounds in China estimated using satellite measurements and the GEOS-Chem model</a> <em>(Yu Fu, Chinese Academy of Sciences)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1F2Y-NToIfFEUE4g7bb-aTvZrDVSxcJvv/view?usp=drive_link">Recent advances in applying satellite observations for inverse modeling of NOx emissions</a> <em>(Akhila Padmanabhan, Dalhousie)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1FAX9-brdVPwKu4PWy2AvxghG6SLGIYEa/view?usp=drive_link">Using TES to determine the composition of boreal biomass burning plumes</a> <em>(Matthew Alvarado, AER)</em>
-	</li>
-	<li>
-		CO2: CO error correlation as a method for improving source / sink inversion with satellite data <em>(Huiqun Wang, Harvard Smithsonian CFA)</em>
-	</li>
+ <li>
+  Hourly biomass burning emissions product from global geostationary satellite constellation, and its application in GEOS-Chem <em>(Xiaoyang Zhang, NOAA)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1UegyeQZVzw46OlQJMa0tH1MauZdskVyB/view?usp=drive_link">Biogenic emissions of volatile organic compounds in China estimated using satellite measurements and the GEOS-Chem model</a> <em>(Yu Fu, Chinese Academy of Sciences)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1F2Y-NToIfFEUE4g7bb-aTvZrDVSxcJvv/view?usp=drive_link">Recent advances in applying satellite observations for inverse modeling of NOx emissions</a> <em>(Akhila Padmanabhan, Dalhousie)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1FAX9-brdVPwKu4PWy2AvxghG6SLGIYEa/view?usp=drive_link">Using TES to determine the composition of boreal biomass burning plumes</a> <em>(Matthew Alvarado, AER)</em>
+ </li>
+ <li>
+  CO2: CO error correlation as a method for improving source / sink inversion with satellite data <em>(Huiqun Wang, Harvard Smithsonian CFA)</em>
+ </li>
 </ul>
 
 <h2>
-	<a name="srcsnkngas" id="srcsnkngas"></a>Day 2, Session 2: Sources and sinks: Nitrogen gases (Chair: Qinbin Li, UCLA)
+ <a name="srcsnkngas" id="srcsnkngas"></a>Day 2, Session 2: Sources and sinks: Nitrogen gases (Chair: Qinbin Li, UCLA)
 </h2>
 
-<h3>
-	Presentations
-</h3>
+<h3>Presentations</h3>
 
 <ul>
-	<li>
-		<a href="https://drive.google.com/file/d/1hpe0FiEYBTaTVCR9jd_MB3uQwlqSaOp2/view?usp=drive_link">An improved biogenic soil NOx model for GEOS-Chem: influence on global ozone and fertilization effect of anthropogenic deposition</a> <em>(Rynda Hudman, UC Berkeley)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1K95QkfgVKZiHJZATWEEF_mXIMCzLNaH4/view?usp=drive_link">Source attribution of nitrogen deposition over the United States</a> <em>(Lin Zhang, Harvard)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/19zZF0NWe1frVAetbsEKAAcRmT9auCzvd/view?usp=drive_link">Application of satellite observations for timely update to global anthropogenic NOx emission inventories</a> <em>(Lok Lamsal, NASA GSFC)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1-BDGjWCVyNVX-yB63oeN3DzoLVXMlnk4/view?usp=drive_link">NOx emissions from power plants in China: bottom-up estimates and satellite constraints</a> <em>(Siwen Wang, Tsinghua Univ.)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/16BQtnoQwKeC8mh7DwUyBQgeilySSzp3T/view?usp=drive_link">Fast update of NOx emission trend for China: synthesis of bottom-up method and satellite observations</a> <em>(Qiang Zhang, Tsinghua Univ.)</em>
-	</li>
-	<li>
-		Improving the lightning NOx source using satellite observations and the adjoint of GEOS-Chem <em>(Nicolas Bousserez, Dalhousie)</em>
-	</li>
+ <li>
+  <a href="https://drive.google.com/file/d/1hpe0FiEYBTaTVCR9jd_MB3uQwlqSaOp2/view?usp=drive_link">An improved biogenic soil NOx model for GEOS-Chem: influence on global ozone and fertilization effect of anthropogenic deposition</a> <em>(Rynda Hudman, UC Berkeley)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1K95QkfgVKZiHJZATWEEF_mXIMCzLNaH4/view?usp=drive_link">Source attribution of nitrogen deposition over the United States</a> <em>(Lin Zhang, Harvard)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/19zZF0NWe1frVAetbsEKAAcRmT9auCzvd/view?usp=drive_link">Application of satellite observations for timely update to global anthropogenic NOx emission inventories</a> <em>(Lok Lamsal, NASA GSFC)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1-BDGjWCVyNVX-yB63oeN3DzoLVXMlnk4/view?usp=drive_link">NOx emissions from power plants in China: bottom-up estimates and satellite constraints</a> <em>(Siwen Wang, Tsinghua Univ.)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/16BQtnoQwKeC8mh7DwUyBQgeilySSzp3T/view?usp=drive_link">Fast update of NOx emission trend for China: synthesis of bottom-up method and satellite observations</a> <em>(Qiang Zhang, Tsinghua Univ.)</em>
+ </li>
+ <li>
+  Improving the lightning NOx source using satellite observations and the adjoint of GEOS-Chem <em>(Nicolas Bousserez, Dalhousie)</em>
+ </li>
 </ul>
 
-<h3>
-	Posters
-</h3>
+<h3>Posters</h3>
 
 <ul>
-	<li>
-		<a href="https://drive.google.com/file/d/18HC4BfteoGABxNqXUkTCj3rdkDsL6gId/view?usp=drive_link">Sensitivity analysis of nitrate concentration and deposition in Antarctica using GEOS-Chem</a> <em>(Hyung-Min Lee, U Colorado)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/125aWTdaQ3ne7pmXCszWBHiQ9CFKI9RoV/view?usp=drive_link">Recent results from the NASA MSFC Lightning Nitrogen Oxides Model (LNOM)</a> <em>(William Koshak, NASA MSFC)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/15tQORpXa9CjpE0_04Is5EBqABEKLD8mg/view?usp=drive_link">Constraining NH3 emissions using TES NH3 observations and surface measurements</a> <em>(Liye Zhu, U Colorado Boulder)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1h0y_oPTRk0vLtYU7gZc0rG4PDDh1vOPy/view?usp=drive_link">Evaluation of CMAQ NO2 predictions over the U.S. using satellite data</a> <em>(Havala Pye, US EPA)</em>
-	</li>
+ <li>
+  <a href="https://drive.google.com/file/d/18HC4BfteoGABxNqXUkTCj3rdkDsL6gId/view?usp=drive_link">Sensitivity analysis of nitrate concentration and deposition in Antarctica using GEOS-Chem</a> <em>(Hyung-Min Lee, U Colorado)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/125aWTdaQ3ne7pmXCszWBHiQ9CFKI9RoV/view?usp=drive_link">Recent results from the NASA MSFC Lightning Nitrogen Oxides Model (LNOM)</a> <em>(William Koshak, NASA MSFC)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/15tQORpXa9CjpE0_04Is5EBqABEKLD8mg/view?usp=drive_link">Constraining NH3 emissions using TES NH3 observations and surface measurements</a> <em>(Liye Zhu, U Colorado Boulder)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1h0y_oPTRk0vLtYU7gZc0rG4PDDh1vOPy/view?usp=drive_link">Evaluation of CMAQ NO2 predictions over the U.S. using satellite data</a> <em>(Havala Pye, US EPA)</em>
+ </li>
 </ul>
 
 <h2>
-	<a name="cgas" id="cgas"></a>Day 2, Session 3: Carbon gases (Chair: Jim Randerson, UC Irvine)
+ <a name="cgas" id="cgas"></a>Day 2, Session 3: Carbon gases (Chair: Jim Randerson, UC Irvine)
 </h2>
 
-<h3>
-	Presentations
-</h3>
+<h3>Presentations</h3>
 
 <ul>
-	<li>
-		<a href="https://drive.google.com/file/d/1EMntIoBzRh86DQ6i7ts12yE-H6N9Kldf/view?usp=drive_link">GEOS-Chem CO2 simulation: update, applications and future directions</a> <em>(Ray Nassar, Environment Canada)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1oDCxtfHqmff_d_dykHa0ahZ3OJIwYO5T/view?usp=drive_link">Anthropogenic and natural sources of ethanol from North America and implications of ethanol fuel use</a> <em>(Dylan Millet, Univ. Minnesota)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/18zS_DeNiaOBWQGmPuEKsSBIG2VOsbU8x/view?usp=drive_link">NASA Carbon Monitoring Study</a> <em>(Kevin Bowman, JPL)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1myQV8irSuHOJfSCcP2TGxhc-GFo7fg3Q/view?usp=drive_link">Inverse modeling of urban and regional emission of CO in China using observations from the MOPITT instrument</a> <em>(Zhe Jiang, Univ. Toronto)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1h_fwr6kcZHNY__cdfyhr_Sin4kl1TA6L/view?usp=drive_link">An ensemble Kalman filter based on the 3D GEOS-Chem transport model for estimation of CH4 and CO2 surface fluxes from GOSAT XCO2 and XCH4 observations: preliminary results</a> <em>(Liang Feng, Univ. of Edinburgh)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1r7EzNYURoDT8z1nAwkVEIbETzdal-B0n/view?usp=drive_link">Analysis of CO, O3 and HCN using GEOS-Chem and ground-based FTIR observations for the Toronto Atmospheric Observatory</a> <em>(Cynthia Whaley, Univ. Toronto)</em>
-	</li>
+ <li>
+  <a href="https://drive.google.com/file/d/1EMntIoBzRh86DQ6i7ts12yE-H6N9Kldf/view?usp=drive_link">GEOS-Chem CO2 simulation: update, applications and future directions</a> <em>(Ray Nassar, Environment Canada)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1oDCxtfHqmff_d_dykHa0ahZ3OJIwYO5T/view?usp=drive_link">Anthropogenic and natural sources of ethanol from North America and implications of ethanol fuel use</a> <em>(Dylan Millet, Univ. Minnesota)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/18zS_DeNiaOBWQGmPuEKsSBIG2VOsbU8x/view?usp=drive_link">NASA Carbon Monitoring Study</a> <em>(Kevin Bowman, JPL)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1myQV8irSuHOJfSCcP2TGxhc-GFo7fg3Q/view?usp=drive_link">Inverse modeling of urban and regional emission of CO in China using observations from the MOPITT instrument</a> <em>(Zhe Jiang, Univ. Toronto)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1h_fwr6kcZHNY__cdfyhr_Sin4kl1TA6L/view?usp=drive_link">An ensemble Kalman filter based on the 3D GEOS-Chem transport model for estimation of CH4 and CO2 surface fluxes from GOSAT XCO2 and XCH4 observations: preliminary results</a> <em>(Liang Feng, Univ. of Edinburgh)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1r7EzNYURoDT8z1nAwkVEIbETzdal-B0n/view?usp=drive_link">Analysis of CO, O3 and HCN using GEOS-Chem and ground-based FTIR observations for the Toronto Atmospheric Observatory</a> <em>(Cynthia Whaley, Univ. Toronto)</em>
+ </li>
 </ul>
 
-<h3>
-	Posters
-</h3>
+<h3>Posters</h3>
 
 <ul>
-	<li>
-		Quantifying terrestrial carbon fluxes using surface and satellite observations <em>(Feng Deng, Univ. Toronto)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1S9dAqU12ocsuBCJL-_MfkbhIH-wZmlo1/view?usp=drive_link">GEOS-Chem vs ACE satellite data comparison</a> <em>(Gonzalo Gonzalez Abad, Univ. York)</em>
-	</li>
-	<li>
-		Influence of boreal forest taking up organic nitrogen on regional carbon budget and atmospheric CO2 <em>(Qing Zhu, Purdue Univ.)</em>
-	</li>
-	<li>
-		European CO budget: its links with synoptic circulation and long-range transport <em>(Anna Protonotariou, Univ. Athens)</em>
-	</li>
-	<li>
-		Monthly CO2 flux inversion with a focus over China <em>(Hengmao Wang, Nanjing Univ.)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1SFHiP3l5z7jLlYlicel-YBH3NkvhnQ6C/view?usp=drive_link">Validating CO2 Fluxes and d13 CO2 in land surface model for coupling with GEOS-Chem</a> <em>(Kuo-Hsien Chang, Univ. of Guelph)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1L80N5Iuur7oE96nVGFTCW_87L56mhb-6/view?usp=drive_link">Constraining North American CH4 fluxes: Integrated analysis of Satellite, Aircraft, and Ground-Based Observations</a> <em>(Yaping Xiao, AER)</em>
-	</li>
+ <li>
+  Quantifying terrestrial carbon fluxes using surface and satellite observations <em>(Feng Deng, Univ. Toronto)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1S9dAqU12ocsuBCJL-_MfkbhIH-wZmlo1/view?usp=drive_link">GEOS-Chem vs ACE satellite data comparison</a> <em>(Gonzalo Gonzalez Abad, Univ. York)</em>
+ </li>
+ <li>
+  Influence of boreal forest taking up organic nitrogen on regional carbon budget and atmospheric CO2 <em>(Qing Zhu, Purdue Univ.)</em>
+ </li>
+ <li>
+  European CO budget: its links with synoptic circulation and long-range transport <em>(Anna Protonotariou, Univ. Athens)</em>
+ </li>
+ <li>
+  Monthly CO2 flux inversion with a focus over China <em>(Hengmao Wang, Nanjing Univ.)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1SFHiP3l5z7jLlYlicel-YBH3NkvhnQ6C/view?usp=drive_link">Validating CO2 Fluxes and d13 CO2 in land surface model for coupling with GEOS-Chem</a> <em>(Kuo-Hsien Chang, Univ. of Guelph)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1L80N5Iuur7oE96nVGFTCW_87L56mhb-6/view?usp=drive_link">Constraining North American CH4 fluxes: Integrated analysis of Satellite, Aircraft, and Ground-Based Observations</a> <em>(Yaping Xiao, AER)</em>
+ </li>
 </ul>
 
 <h2>
-	<a name="climchem" id="climchem"></a>Day 2, Session 4: Climate-chemistry interactions (Chair: Nadine Unger, Yale U.)
+ <a name="climchem" id="climchem"></a>Day 2, Session 4: Climate-chemistry interactions (Chair: Nadine Unger, Yale U.)
 </h2>
 
-<h3>
-	Presentations
-</h3>
+<h3>Presentations</h3>
 
 <ul>
-	<li>
-		<a href="https://drive.google.com/file/d/1ICPoozPdGw53w6JFdUCkqYcBzFilBUdf/view?usp=drive_link">Effects of future climate change on air quality over East Asia</a> <em>(Rokjin Park, Seoul National Univ.)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1EWHgnUDj9teLLaTurFykARo50aHcpfwN/view?usp=drive_link"">New directions in GEOS-Chem studies of chemistry-climate interactions</a> <em>(Loretta Mickley, Harvard)</em>
-	</li>
-	<li>
-		Impact of climate change on pollution in Africa <em>(Ellen Dyer, Univ. Toronto)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1c7EKVrGvz_PEEuaGR53rMZFknfbabHFh/view?usp=drive_link">Climate effects of US aerosol sources: aerosol trends, radiative forcing, and climate response</a> <em>(Eric Leibensperger, Harvard)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1ckfWk9aclX9o0Ii1ouOCNxfgPXKcAYIz/view?usp=drive_link">Source attribution of ozone radiative forcing using TES observations and the GEOS-Chem adjoint</a> <em>(Daven Henze, U Colorado Boulder)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1__P06QE8fsbw1EMyirnlWXfTIQ-92Ooi/view?usp=drive_link">Projections of air-quality in Europe under climate change: A two way approach</a> <em>(Kostantinos Varotsos, Univ. Athens)</em>
-	</li>
+ <li>
+  <a href="https://drive.google.com/file/d/1ICPoozPdGw53w6JFdUCkqYcBzFilBUdf/view?usp=drive_link">Effects of future climate change on air quality over East Asia</a> <em>(Rokjin Park, Seoul National Univ.)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1EWHgnUDj9teLLaTurFykARo50aHcpfwN/view?usp=drive_link">New directions in GEOS-Chem studies of chemistry-climate interactions</a> <em>(Loretta Mickley, Harvard)</em>
+ </li>
+ <li>
+  Impact of climate change on pollution in Africa <em>(Ellen Dyer, Univ. Toronto)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1c7EKVrGvz_PEEuaGR53rMZFknfbabHFh/view?usp=drive_link">Climate effects of US aerosol sources: aerosol trends, radiative forcing, and climate response</a> <em>(Eric Leibensperger, Harvard)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1ckfWk9aclX9o0Ii1ouOCNxfgPXKcAYIz/view?usp=drive_link">Source attribution of ozone radiative forcing using TES observations and the GEOS-Chem adjoint</a> <em>(Daven Henze, U Colorado Boulder)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1__P06QE8fsbw1EMyirnlWXfTIQ-92Ooi/view?usp=drive_link">Projections of air-quality in Europe under climate change: A two way approach</a> <em>(Kostantinos Varotsos, Univ. Athens)</em>
+ </li>
 </ul>
 
-<h3>
-	Posters
-</h3>
+<h3>Posters</h3>
 
 <ul>
-	<li>
-		<a href="https://drive.google.com/file/d/1PU7lBpOs7QJKOGT1J0gxly0A-xXCUc20/view?usp=drive_link">Regional climate model downscaling in Eastern United States</a> <em>(Yang Gao, Univ. Tennessee)</em>
-	</li>
-	<li>
-		Ozone climate impact from aviation <em>(Nadine Unger, Yale)</em>
-	</li>
+ <li>
+  <a href="https://drive.google.com/file/d/1PU7lBpOs7QJKOGT1J0gxly0A-xXCUc20/view?usp=drive_link">Regional climate model downscaling in Eastern United States</a> <em>(Yang Gao, Univ. Tennessee)</em>
+ </li>
+ <li>
+  Ozone climate impact from aviation <em>(Nadine Unger, Yale)</em>
+ </li>
 </ul>
 
 <h2>
-	<a name="hgpop" id="hgpop"></a>Day 2, Session 5: Mercury and POPs (Chair: Elsie Sunderland, Harvard)
+ <a name="hgpop" id="hgpop"></a>Day 2, Session 5: Mercury and POPs (Chair: Elsie Sunderland, Harvard)
 </h2>
 
-<h3>
-	Presentations
-</h3>
+<h3>Presentations</h3>
 
 <ul>
-	<li>
-		<a href="https://drive.google.com/file/d/1zVj9HF9MVvfRUxLaUASenJ3XRsugRTM9/view?usp=drive_link">Sources and fate of mercury deposited to land</a> <em>(Bess Corbitt, Harvard)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1xd54Z3tt4LrxQ4A6NOnFjzuUc8LnWY83/view?usp=drive_link">Fast matrix calculations of mercury fate and transport</a> <em>(Chris Holmes, UC Irvine)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/13nidDamA5LpOuayM0ickdUfRPlzEgpY4/view?usp=drive_link">Constraining reactive gaseous mercury transformation and fate over the U.S.: combining model and measurements</a> <em>(Noelle Selin, MIT)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1yWmaTS-GTR4L5IVeTmJGd_7qg-aBPLav/view?usp=drive_link">Nested-grid modeling of mercury over North America</a> <em>(Yanxu Zhang, U Washington)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1A41Q9HKdEoQzYtt6WtY0PiTWMKXzqOgz/view?usp=drive_link">Modeling mercury in the ocean and its effect on the marine boundary layer </a><em>(Anne Laerke Soerensen, Aarhus Univ.)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1dOaB9y8BSVgIbSW1-04DXGctKJLWTgyw/view?usp=drive_link">Hg(II) gas-particle partitioning and its effect on global mercury deposition</a> <em>(Helen Amos, Harvard)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/10U6AcF9rOyHhXyDgJTKgOZTr9YrVKmU_/view?usp=drive_link">Modeling global atmospheric transport of polycyclic aromatic hydrocarbons (PAHs) with GEOS-Chem</a> <em>(Carey Friedman, MIT)</em>
-	</li>
+ <li>
+  <a href="https://drive.google.com/file/d/1zVj9HF9MVvfRUxLaUASenJ3XRsugRTM9/view?usp=drive_link">Sources and fate of mercury deposited to land</a> <em>(Bess Corbitt, Harvard)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1xd54Z3tt4LrxQ4A6NOnFjzuUc8LnWY83/view?usp=drive_link">Fast matrix calculations of mercury fate and transport</a> <em>(Chris Holmes, UC Irvine)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/13nidDamA5LpOuayM0ickdUfRPlzEgpY4/view?usp=drive_link">Constraining reactive gaseous mercury transformation and fate over the U.S.: combining model and measurements</a> <em>(Noelle Selin, MIT)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1yWmaTS-GTR4L5IVeTmJGd_7qg-aBPLav/view?usp=drive_link">Nested-grid modeling of mercury over North America</a> <em>(Yanxu Zhang, U Washington)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1A41Q9HKdEoQzYtt6WtY0PiTWMKXzqOgz/view?usp=drive_link">Modeling mercury in the ocean and its effect on the marine boundary layer </a><em>(Anne Laerke Soerensen, Aarhus Univ.)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1dOaB9y8BSVgIbSW1-04DXGctKJLWTgyw/view?usp=drive_link">Hg(II) gas-particle partitioning and its effect on global mercury deposition</a> <em>(Helen Amos, Harvard)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/10U6AcF9rOyHhXyDgJTKgOZTr9YrVKmU_/view?usp=drive_link">Modeling global atmospheric transport of polycyclic aromatic hydrocarbons (PAHs) with GEOS-Chem</a> <em>(Carey Friedman, MIT)</em>
+ </li>
 </ul>
 
 <h2>
-	<a name="transport" id="transport"></a>Day 3, Session 1: Transport and dynamics (Chair: Jintai Lin, Peking U.)
+ <a name="transport" id="transport"></a>Day 3, Session 1: Transport and dynamics (Chair: Jintai Lin, Peking U.)
 </h2>
 
-<h3>
-	Presentations
-</h3>
+<h3>Presentations</h3>
 
 <ul>
-	<li>
-		<a href="https://drive.google.com/file/d/1CYmVaTB_wpaREMopmW5RWZzDKsrVe74N/view?usp=drive_link">Seven slides about GEOS-5</a> <em>(Steven Pawson, NASA GMAO)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1By7ia8baNUgzwEHHYcJRtdlVzU1Mx0RM/view?usp=drive_link">Meteorological modes of variability for PM2.5 air quality and application to evaluate GEOS-Chem simulations of PM2.5 sensitivity to climate change</a> <em>(Amos P.K. Tai, Harvard)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/14xBENGTSPWbZkHD6OCEGBJR6fWdVsR6a/view?usp=drive_link">MLS and TES data for tropical tropospheric ozone: a revealing test of vertical transport in GEOS-5 meteorological fields</a> <em>(Jennifer Logan, Harvard)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Zjsc8OYHs_Py_uy3y7jfE9oEOeVBrE8K/view?usp=drive_link">Trans-Pacific transport of carbon monoxide (CO) in the upper troposphere</a> <em>(Jianjun Jin, JPL/Caltech)</em>
-	</li>
-	<li>
-		Impact of decadal-scale weakening of the East Asian summer monsoon on aerosol concentrations in eastern China <em>(Jianlei Zhu, Chinese Academy of Sciences)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Hk11Hx0HbZ-FR7Q63xlE9wEznsLLcZCw/view?usp=drive_link">Lightning and dynamics Impacts on tropospheric ozone over the Southern Tropical Indian Ocean</a> <em>(Li Zhang, UCLA)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1C2oLUIVq1Ypt4r0S4w0b1_l5r3cPGMea/view?usp=drive_link">Characterizing the variability of stratosphere-troposphere exchange in the UTLS</a> <em>(Dave MacKenzie, Univ. Toronto)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1FWuG3VtBtk1-f8fYxrWqqVPg-UMns9NI/view?usp=drive_link">Transport analysis and source attribution of seasonal and interannual variability of CO in the tropical upper troposphere and lower stratosphere</a> <em>(Junhua Liu, Harvard)</em>
-	</li>
+ <li>
+  <a href="https://drive.google.com/file/d/1CYmVaTB_wpaREMopmW5RWZzDKsrVe74N/view?usp=drive_link">Seven slides about GEOS-5</a> <em>(Steven Pawson, NASA GMAO)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1By7ia8baNUgzwEHHYcJRtdlVzU1Mx0RM/view?usp=drive_link">Meteorological modes of variability for PM2.5 air quality and application to evaluate GEOS-Chem simulations of PM2.5 sensitivity to climate change</a> <em>(Amos P.K. Tai, Harvard)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/14xBENGTSPWbZkHD6OCEGBJR6fWdVsR6a/view?usp=drive_link">MLS and TES data for tropical tropospheric ozone: a revealing test of vertical transport in GEOS-5 meteorological fields</a> <em>(Jennifer Logan, Harvard)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1Zjsc8OYHs_Py_uy3y7jfE9oEOeVBrE8K/view?usp=drive_link">Trans-Pacific transport of carbon monoxide (CO) in the upper troposphere</a> <em>(Jianjun Jin, JPL/Caltech)</em>
+ </li>
+ <li>
+  Impact of decadal-scale weakening of the East Asian summer monsoon on aerosol concentrations in eastern China <em>(Jianlei Zhu, Chinese Academy of Sciences)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1Hk11Hx0HbZ-FR7Q63xlE9wEznsLLcZCw/view?usp=drive_link">Lightning and dynamics Impacts on tropospheric ozone over the Southern Tropical Indian Ocean</a> <em>(Li Zhang, UCLA)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1C2oLUIVq1Ypt4r0S4w0b1_l5r3cPGMea/view?usp=drive_link">Characterizing the variability of stratosphere-troposphere exchange in the UTLS</a> <em>(Dave MacKenzie, Univ. Toronto)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1FWuG3VtBtk1-f8fYxrWqqVPg-UMns9NI/view?usp=drive_link">Transport analysis and source attribution of seasonal and interannual variability of CO in the tropical upper troposphere and lower stratosphere</a> <em>(Junhua Liu, Harvard)</em>
+ </li>
 </ul>
 
-<h3>
-	Posters
-</h3>
+<h3>Posters</h3>
 
 <ul>
-	<li>
-		Impact of model errors on the variability of upper tropospheric CO and O3 in the Asian monsoon region <em>(Dylan Jones, Univ. Toronto)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1CZnhOqFhUQ55KOxnROqtBn2VTX63-Cmc/view?usp=drive_link">Evaluation of GEOS mixed-layer depths and implications for GEOS-Chem aerosol simulations</a> <em>(Sajeev Philip, Dalhousie)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1M8Wc0A8awDoqR69XVrqAvVkPG8r2ufE8/view?usp=drive_link">Examining the vertical distribution of pollutants</a> <em>(Bonne Ford, Colorado State Univ.)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1cKOU9F6g364v9ODwmw7gRibOOWsAmFGp/view?usp=drive_link">Preliminary results of GEOS-Chem/LETKF data assimilation system</a> <em>(Keiya Yumimoto, MRI, Japan)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1NORpQPXbNgndIEiyBhrEzvEtBmJzrfzy/view?usp=drive_link">The Weybourne atmospheric observatory — long-term composition measurements according to changing air mass origin</a>. <em>(Zoë Fleming, Univ. Leicester)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/16SIHjJBo-f2qWaQzHsqikv9TbChtG8LE/view?usp=drive_link">Numerical challenges in global atmospheric chemistry models.Â  A multi-scale perspective</a> <em>(Mauricio Santillana, Harvard)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1UxOxaTV6TGbIqM59rqqDYIDfzYaCDTzO/view?usp=drive_link">The impact of cumulus congestus clouds on mid-level ozone concentrations in the tropics</a> <em>(Matthew Cooper, Dalhousie)</em>
-	</li>
+ <li>
+  Impact of model errors on the variability of upper tropospheric CO and O3 in the Asian monsoon region <em>(Dylan Jones, Univ. Toronto)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1CZnhOqFhUQ55KOxnROqtBn2VTX63-Cmc/view?usp=drive_link">Evaluation of GEOS mixed-layer depths and implications for GEOS-Chem aerosol simulations</a> <em>(Sajeev Philip, Dalhousie)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1M8Wc0A8awDoqR69XVrqAvVkPG8r2ufE8/view?usp=drive_link">Examining the vertical distribution of pollutants</a> <em>(Bonne Ford, Colorado State Univ.)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1cKOU9F6g364v9ODwmw7gRibOOWsAmFGp/view?usp=drive_link">Preliminary results of GEOS-Chem/LETKF data assimilation system</a> <em>(Keiya Yumimoto, MRI, Japan)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1NORpQPXbNgndIEiyBhrEzvEtBmJzrfzy/view?usp=drive_link">The Weybourne atmospheric observatory — long-term composition measurements according to changing air mass origin</a>. <em>(Zoë Fleming, Univ. Leicester)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/16SIHjJBo-f2qWaQzHsqikv9TbChtG8LE/view?usp=drive_link">Numerical challenges in global atmospheric chemistry models.Â  A multi-scale perspective</a> <em>(Mauricio Santillana, Harvard)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1UxOxaTV6TGbIqM59rqqDYIDfzYaCDTzO/view?usp=drive_link">The impact of cumulus congestus clouds on mid-level ozone concentrations in the tropics</a> <em>(Matthew Cooper, Dalhousie)</em>
+ </li>
 </ul>
 
 <h2>
-	<a name="regaq" id="regaq"></a>Day 3, Session 2: Regional air quality (Chair: Yuhang Wang, Georgia Tech)
+ <a name="regaq" id="regaq"></a>Day 3, Session 2: Regional air quality (Chair: Yuhang Wang, Georgia Tech)
 </h2>
 
-<h3>
-	Presentations
-</h3>
+<h3>Presentations</h3>
 
 <ul>
-	<li>
-		<a href="https://drive.google.com/file/d/12_gxWVgqpBC6VhiIbgcZcAguCQyISkAd/view?usp=drive_link">Particulate air pollution in China in recent years and effectiveness of emission control</a> <em>(Jintai Lin, Peking University)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1n39rxeV7Lc4p5Eeuclk8q7uJ4SFGaWbO/view?usp=drive_link">Seasonal and spatial variability of surface ozone over China: contributions from background and domestic pollution</a> <em>(Yuxuan Wang, Tsinghua University)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1S23JsAyxyc76Pr3pN49uh7zxdfJ0JiCb/view?usp=drive_link">Sensitivity of China's ozone air quality to 2000-2050 global changes of climate and emissions</a> <em>(Lulu Shen, Tsinghua University)</em>
-	</li>
-	<li>
-		GEOS-Chem application and performance evaluation to support Policy Relevant Background ozone analyses over the US <em>(Chris Emery, ENVIRON Int'l Corp.)</em>
-	</li>
-	<li>
-		Modeling precursors of tropospheric ozone over Australasia <em>(Rebecca Buchholtz, Univ. Wolllongong)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1f2olqoHK0sDwLshoJqcKsNlIrv-hEOB_/view?usp=drive_link">Recent study of U.S. ozone background concentrations using GEOS-Chem</a> <em>(Joshua Fu, Univ. Tennessee)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1si97sYYF37j0lWBRhkgPwwNF4Umba9nF/view?usp=drive_link">2005-2008 inter-annual and inter-season simulations of North Hemisphere by GEOS-Chem</a> <em>(Yun-Fat Lam, Univ. Tennessee)</em>
-	</li>
+ <li>
+  <a href="https://drive.google.com/file/d/12_gxWVgqpBC6VhiIbgcZcAguCQyISkAd/view?usp=drive_link">Particulate air pollution in China in recent years and effectiveness of emission control</a> <em>(Jintai Lin, Peking University)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1n39rxeV7Lc4p5Eeuclk8q7uJ4SFGaWbO/view?usp=drive_link">Seasonal and spatial variability of surface ozone over China: contributions from background and domestic pollution</a> <em>(Yuxuan Wang, Tsinghua University)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1S23JsAyxyc76Pr3pN49uh7zxdfJ0JiCb/view?usp=drive_link">Sensitivity of China's ozone air quality to 2000-2050 global changes of climate and emissions</a> <em>(Lulu Shen, Tsinghua University)</em>
+ </li>
+ <li>
+  GEOS-Chem application and performance evaluation to support Policy Relevant Background ozone analyses over the US <em>(Chris Emery, ENVIRON Int'l Corp.)</em>
+ </li>
+ <li>
+  Modeling precursors of tropospheric ozone over Australasia <em>(Rebecca Buchholtz, Univ. Wolllongong)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1f2olqoHK0sDwLshoJqcKsNlIrv-hEOB_/view?usp=drive_link">Recent study of U.S. ozone background concentrations using GEOS-Chem</a> <em>(Joshua Fu, Univ. Tennessee)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1si97sYYF37j0lWBRhkgPwwNF4Umba9nF/view?usp=drive_link">2005-2008 inter-annual and inter-season simulations of North Hemisphere by GEOS-Chem</a> <em>(Yun-Fat Lam, Univ. Tennessee)</em>
+ </li>
 </ul>
 
-<h3>
-	Posters
-</h3>
+<h3>Posters</h3>
 
 <ul>
-	<li>
-		Ensemble projections of future wildfire and its impact on air quality over the western US <em>(Xu Yue, Harvard)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1RixdUQjKVcQvLN2PaA3OlKRYOeQOE5xI/view?usp=drive_link">Effect of changes in climate and emissions on future ozone and aerosol levels in China</a> <em>(Hui Jiang, Chinese Academy of Sciences)</em>
-	</li>
-	<li>
-		Effects of the observed climate variability on long-term regional air quality in East Asia <em>(Jaein Jeong, Seoul National Univ.)</em>
-	</li>
-	<li>
-		How much can we understand real pollutants by using idealized tracers? <em>(Yuanyuan Fang, Princeton)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1OZng4wQ8jidKQ2HScoj_ti5kXC99HSfy/view?usp=drive_link">Trends in tropospheric NO2 columns over Europe and the effect of the economic crisis observed from the Ozone Monitoring Instrument</a> <em>(Folkert Boersma, TU Eindhoven/KNMI)</em>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1ah8CgtL2f1sai28lITLh_Vm871wbGfv5/view?usp=drive_link">Multimodel estimates of the contribution of biomass Burning to air quality degradation in Southeast Asia</a> <em>(Miriam Marlier, Columbia Univ.)</em>
-	</li>
+ <li>
+  Ensemble projections of future wildfire and its impact on air quality over the western US <em>(Xu Yue, Harvard)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1RixdUQjKVcQvLN2PaA3OlKRYOeQOE5xI/view?usp=drive_link">Effect of changes in climate and emissions on future ozone and aerosol levels in China</a> <em>(Hui Jiang, Chinese Academy of Sciences)</em>
+ </li>
+ <li>
+  Effects of the observed climate variability on long-term regional air quality in East Asia <em>(Jaein Jeong, Seoul National Univ.)</em>
+ </li>
+ <li>
+  How much can we understand real pollutants by using idealized tracers? <em>(Yuanyuan Fang, Princeton)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1OZng4wQ8jidKQ2HScoj_ti5kXC99HSfy/view?usp=drive_link">Trends in tropospheric NO2 columns over Europe and the effect of the economic crisis observed from the Ozone Monitoring Instrument</a> <em>(Folkert Boersma, TU Eindhoven/KNMI)</em>
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1ah8CgtL2f1sai28lITLh_Vm871wbGfv5/view?usp=drive_link">Multimodel estimates of the contribution of biomass Burning to air quality degradation in Southeast Asia</a> <em>(Miriam Marlier, Columbia Univ.)</em>
+ </li>
 </ul>
 
 <h2>
-	<a name="breakout" id="breakout"></a>Day 3, Session 3: Working Group Breakout Sessions
+ <a name="breakout" id="breakout"></a>Day 3, Session 3: Working Group Breakout Sessions
 </h2>
 
-<p>
-	Discussions
-</p>
+<p> Discussions</p>
 
 <ul>
-	<li>
-		Aerosols Working Group
-	</li>
-	<li>
-		Carbon Gases and Organics Working Group
-	</li>
-	<li>
-		Sources and Sinks Working Group
-	</li>
-	<li>
-		Oxidants and Chemistry Working Group
-	</li>
-	<li>
-		Chemistry-Climate Working Group
-	</li>
-	<li>
-		Adjoint and Data Assimilation Working Group
-	</li>
-	<li>
-		Regional Air Quality Working Group
-	</li>
-	<li>
-		Hg and POPs Working Group
-	</li>
+ <li>
+  Aerosols Working Group
+ </li>
+ <li>
+  Carbon Gases and Organics Working Group
+ </li>
+ <li>
+  Sources and Sinks Working Group
+ </li>
+ <li>
+  Oxidants and Chemistry Working Group
+ </li>
+ <li>
+  Chemistry-Climate Working Group
+ </li>
+ <li>
+  Adjoint and Data Assimilation Working Group
+ </li>
+ <li>
+  Regional Air Quality Working Group
+ </li>
+ <li>
+  Hg and POPs Working Group
+ </li>
 </ul>
 
 <h2>
-	<a name="wgreports" id="wgreports"></a>Day 4, Session 1: Working group reports
+ <a name="wgreports" id="wgreports"></a>Day 4, Session 1: Working group reports
 </h2>
 
 <ul>
-	<li>
-		<a href="https://drive.google.com/file/d/1Nzj6p37Y6M_W0hnQlcGp1uroiWnLttCt/view?usp=drive_link">Aerosol Processes</a> (co-chairs: Colette Heald, Jun Wang)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1HxQDhtExRA8az10iK6BPRGSKB6VEDqtp/view?usp=drive_link">Carbon Gases and Organics</a> (co-chairs: Dylan Jones, Dylan Millet)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1m7_Z-KyCZRE41f9ZjR5RxQzfV7S-IAX9/view?usp=drive_link">Sources and Sinks</a> (co-chairs: Randall Martin, Qiang Zhang)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1B3neBEeFPtNVZFE3ARdvphBE2gqkO0IH/view?usp=drive_link">Oxidants and Chemistry</a> (co-chairs: Mat Evans, Jingqiu Mao)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/18G61Z-u55WMh7SMbCiKNO_glDW2LxgYw/view?usp=drive_link">Chemistry-Climate</a> (co-chairs: Jeffrey Pierce, Loretta Mickley)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1W3hQPhCdoRfj2HY9J4GcNkt1TYvRMwZZ/view?usp=drive_link">Model Adjoint</a> (co-chairs: Daven Henze, Kevin Bowman)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1QEV-MJmq8J8sCqA0azNoL9gTT7RmbIuM/view?usp=drive_link">Regional Air Quality</a> (co-chairs: Yuxuan Wang, Rokjin Park)
-	</li>
-	<li>
-		Hg and POPs (co-chairs: Lyatt Jaeglé, Noelle Selin)
-	</li>
+ <li>
+  <a href="https://drive.google.com/file/d/1Nzj6p37Y6M_W0hnQlcGp1uroiWnLttCt/view?usp=drive_link">Aerosol Processes</a> (co-chairs: Colette Heald, Jun Wang)
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1HxQDhtExRA8az10iK6BPRGSKB6VEDqtp/view?usp=drive_link">Carbon Gases and Organics</a> (co-chairs: Dylan Jones, Dylan Millet)
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1m7_Z-KyCZRE41f9ZjR5RxQzfV7S-IAX9/view?usp=drive_link">Sources and Sinks</a> (co-chairs: Randall Martin, Qiang Zhang)
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1B3neBEeFPtNVZFE3ARdvphBE2gqkO0IH/view?usp=drive_link">Oxidants and Chemistry</a> (co-chairs: Mat Evans, Jingqiu Mao)
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/18G61Z-u55WMh7SMbCiKNO_glDW2LxgYw/view?usp=drive_link">Chemistry-Climate</a> (co-chairs: Jeffrey Pierce, Loretta Mickley)
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1W3hQPhCdoRfj2HY9J4GcNkt1TYvRMwZZ/view?usp=drive_link">Model Adjoint</a> (co-chairs: Daven Henze, Kevin Bowman)
+ </li>
+ <li>
+  <a href="https://drive.google.com/file/d/1QEV-MJmq8J8sCqA0azNoL9gTT7RmbIuM/view?usp=drive_link">Regional Air Quality</a> (co-chairs: Yuxuan Wang, Rokjin Park)
+ </li>
+ <li>
+  Hg and POPs (co-chairs: Lyatt Jaeglé, Noelle Selin)
+ </li>
 </ul>
 
 <h2>
-	<a name="business" id="business"></a>Day 4, Session 2: Business meeting (Chair: Daniel Jacob, Harvard)
+ <a name="business" id="business"></a>Day 4, Session 2: Business meeting (Chair: Daniel Jacob, Harvard)
 </h2>
 
 <ul>
-	<li>
-		<a href="https://docs.google.com/spreadsheets/d/12F2-THNOsD9lPVZnyHx1WzbwQjOituBi/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true">Development priorities report</a>
-	</li>
+ <li>
+  <a href="https://docs.google.com/spreadsheets/d/12F2-THNOsD9lPVZnyHx1WzbwQjOituBi/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true">Development priorities report</a>
+ </li>
 </ul>
 
 <h2>
-	<a name="clinics" id="clinics"></a>Day 4, Session 3: Model Clinics
+ <a name="clinics" id="clinics"></a>Day 4, Session 3: Model Clinics
 </h2>
 
 <ul>
-	<li>
-		<a href="https://drive.google.com/file/d/1bWwXz9DDWGhhx2ZI70blGTi-32H77SpQ/view?usp=drive_link">GEOS-Chem model clinic</a> <em>(Bob Yantosca)</em>
-	</li>
-	<li>
-		GEOS-Chem adjoint model clinic <em>(Daven Henze)</em>
-	</li>
+ <li>
+  <a href="https://drive.google.com/file/d/1bWwXz9DDWGhhx2ZI70blGTi-32H77SpQ/view?usp=drive_link">GEOS-Chem model clinic</a> <em>(Bob Yantosca)</em>
+ </li>
+ <li>
+  GEOS-Chem adjoint model clinic <em>(Daven Henze)</em>
+ </li>
 </ul>
 
 </div>
@@ -871,64 +806,16 @@
 </div>
 </div>
 
-<!--footer region beg-->
+<!--footer-->
 <footer id="footer" class="clearfix" role="contentinfo">
-
-<!-- Three column 3x33 Gpanel -->
-<div class="at-panel gpanel panel-display footer clearfix">
-<div class="region region-footer">
-<div class="region-inner clearfix">
-<div id="block-boxes-1617037690" class="block block-boxes block-boxes-os_boxes_html no-title"  module="boxes" delta="1617037690">
-<div class="block-inner clearfix">  
-<div class="block-content content" ng-non-bindable="">  
-<div id='boxes-box-1617037690' class='boxes-box'>  
 <div class="boxes-box-content">
   <p style="text-align:center">
-    Copyright © 2023 by the International GEOS-Chem Community. All rights reserved.
+    Copyright © 2026 by the International GEOS-Chem Community. All rights reserved.
   </p>
 </div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-<div class="region region-footer-bottom">  
-<div class="region-inner clearfix">  
-<div id="block-boxes-1616879798" class="block block-boxes block-boxes-os_boxes_media no-title"  module="boxes" delta="1616879798">  
-<div class="block-inner clearfix">  
-<div class="block-content content"> 
-<div id='boxes-box-1616879798' class='boxes-box'> 
-<div class="boxes-box-content"> 
-<div id="file-3900146" class="file file-html file-html-embed">
-<h2 class="element-invisible"><a href="">css-brand</a></h2>
-<div class="content">
-<div class="file-info">
-</div>
-<div class="field field-name-field-html-code field-type-text-long field-label-hidden view-mode-full">
-<div class="field-items">
-<div class="field-item even">
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-
-<!--footer region end-->
 </footer>
-</div>
-</div>
 
-<!--page area ends-->
-<div id="extradiv"></div>
+</div>
 </div>
 
 </body>

--- a/igc5-presentations.html
+++ b/igc5-presentations.html
@@ -41,10 +41,8 @@
 <div class="block-content content" ng-non-bindable="">
 <div id='boxes-box-1630413211' class='boxes-box'>
 <div class="boxes-box-content">
-<img height="551" width="1101" style="float: right; width: 350px; height: 175px; margin-bottom: 1.5em;" alt="gca2 logo" class="media-element file-default file-os-files-xxlarge" src="img/igc-early-logo.png" title="" />
-<h2 class="css-brand--css-geos-meetings-header-h2-xxxlarge">
-  The 5th International GEOS-Chem Meeting (IGC5) May 2-5 2011
-</h2>
+<a href="https://geoschem.github.io/"><img height="600" width="1034" style="float: right; width: 350px; height: 203px;" class="media-element file-default file-os-files-xxlarge" src="img/GEOS-Chem_Logo_Square_Light_Background_Orig.png" alt="" title="" /></a>
+<h2 class="css-brand--css-geos-meetings-header-h2-xxxlarge">The 5th International GEOS-Chem Meeting (IGC5) May 2-5 2011</h2>
 </div>
 </div>
 </div>

--- a/igc5.html
+++ b/igc5.html
@@ -1,9 +1,4 @@
 <!DOCTYPE html>
-<!--[if IEMobile 7]><html class="iem7"  lang="en" dir="ltr"><![endif]-->
-<!--[if lte IE 6]><html class="lt-ie9 lt-ie8 lt-ie7"  lang="en" dir="ltr"><![endif]-->
-<!--[if (IE 7)&(!IEMobile)]><html class="lt-ie9 lt-ie8"  lang="en" dir="ltr"><![endif]-->
-<!--[if IE 8]><html class="lt-ie9"  lang="en" dir="ltr"><![endif]-->
-<!--[if (gte IE 9)|(gt IEMobile 7)]><!--><html  lang="en" dir="ltr"><!--<![endif]-->
 <head>
 <meta charset="utf-8" />
 <!--<base href="/igc5" />-->
@@ -18,23 +13,12 @@
 <title>The 5th International GEOS-Chem Meeting</title>
 <meta http-equiv="x-ua-compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<link type="text/css" rel="stylesheet" href="css/css_xE-rWrJf-fncB6ztZfd2huxqgxu4WO-qwma6Xer30m4%EF%B9%96m=1675397288.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_1kR8T1_c-l5pBT6ZwbDT7BFda-4fyqW9Jjum29_2IY8%EF%B9%96m=1675397312.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_YnlUIvHP13qgpYEqubzE8JyDwlSxUnVibfnVkSoSDb0%EF%B9%96m=1675397273.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_Ku-3OcT9qU9h7dnGig5e23q6EVryY8orK4wzVDxsweE%EF%B9%96m=1675397367.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_vprtFTrWyg23GbY50_zJZHWGYMNfS8vsrRS26i4-ISk%EF%B9%96m=1675397406.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_dW-aNNrctRhQNc-KECjtQd0PxuW-h19IEum-TX2MeEk%EF%B9%96m=1675397301.css" media="print" />
-<link type="text/css" rel="stylesheet" href="css/css_SH2Lx3Qprh0GZo_9xRp85U9NsWfkSXn_Bi-rJoMY1sw%EF%B9%96m=1675397273.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_uaIDKcYMUK5osSQXuirpr3ZleXtnnpBN-eiECm7N0M0%EF%B9%96m=1675397395.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/responsive.blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/geos-chem.css" media="all"/>
 <script type="text/javascript" src="dropdown-menu.js"></script>
-<!--[if lte IE 8]>
-<script type="text/javascript">
-  var os_c = document.createElement;os_c('header');os_c('nav');os_c('section');os_c('article');os_c('aside');os_c('footer');os_c('hgroup');os_c('figure');
-</script>
-<![endif]-->
 </head>
 
 <body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-1585687 node-type-page og-context og-context-node og-context-node-1585652 navbar-on">
@@ -76,10 +60,11 @@
 
 <!--main menu region beg-->
 <div id="menu-bar" class="nav region-menu-bar clearfix">
-<nav id="block-os-igc5-menu" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="igc5_menu">  
-<ul class="nice-menu nice-menu-down nice-menu-igc5_menu" id="nice-menu-igc5_menu">
-  <li class="menu-859829 menu-path-node-1587046  first   odd  "><a href="igc5.html"  class="active">Home</a></li>
-  <li class="menu-859880 menu-path-node-1587048   even   last "><a href="igc5-presentations.html" >Presentations and Posters</a></li>
+<nav id="block-os-igc5-menu" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="igc5_menu">
+<ul class="nice-menu nice-menu-down">
+  <li><a href="igc5.html" class="active">IGC5 Home</a></li>
+  <li><a href="igc5-presentations.html">Presentations and Posters</a></li>
+  <li><a href="index.html">GEOS-Chem Home</a></li>
 </ul>
 </nav>
 </div>
@@ -139,64 +124,16 @@
 </div>
 </div>
 
-<!--footer region beg-->
+<!--footer-->
 <footer id="footer" class="clearfix" role="contentinfo">
-
-<!-- Three column 3x33 Gpanel -->
-<div class="at-panel gpanel panel-display footer clearfix">
-<div class="region region-footer">
-<div class="region-inner clearfix">
-<div id="block-boxes-1617037690" class="block block-boxes block-boxes-os_boxes_html no-title"  module="boxes" delta="1617037690">
-<div class="block-inner clearfix">  
-<div class="block-content content" ng-non-bindable="">  
-<div id='boxes-box-1617037690' class='boxes-box'>  
 <div class="boxes-box-content">
   <p style="text-align:center">
-    Copyright © 2023 by the International GEOS-Chem Community. All rights reserved.
+    Copyright © 2026 by the International GEOS-Chem Community. All rights reserved.
   </p>
 </div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-<div class="region region-footer-bottom">  
-<div class="region-inner clearfix">  
-<div id="block-boxes-1616879798" class="block block-boxes block-boxes-os_boxes_media no-title"  module="boxes" delta="1616879798">  
-<div class="block-inner clearfix">  
-<div class="block-content content"> 
-<div id='boxes-box-1616879798' class='boxes-box'> 
-<div class="boxes-box-content"> 
-<div id="file-3900146" class="file file-html file-html-embed">
-<h2 class="element-invisible"><a href="">css-brand</a></h2>
-<div class="content">
-<div class="file-info">
-</div>
-<div class="field field-name-field-html-code field-type-text-long field-label-hidden view-mode-full">
-<div class="field-items">
-<div class="field-item even">
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-
-<!--footer region end-->
 </footer>
-</div>
-</div>
 
-<!--page area ends-->
-<div id="extradiv"></div>
+</div>
 </div>
 
 </body>

--- a/igc5.html
+++ b/igc5.html
@@ -41,10 +41,8 @@
 <div class="block-content content" ng-non-bindable="">
 <div id='boxes-box-1630413211' class='boxes-box'>
 <div class="boxes-box-content">
-<img height="551" width="1101" style="float: right; width: 350px; height: 175px; margin-bottom: 1.5em;" alt="gca2 logo" class="media-element file-default file-os-files-xxlarge" src="img/igc-early-logo.png" title="" />
-<h2 class="css-brand--css-geos-meetings-header-h2-xxxlarge">
-  The 5th International GEOS-Chem Meeting (IGC5) May 2-5 2011
-</h2>
+<a href="https://geoschem.github.io/"><img height="600" width="1034" style="float: right; width: 350px; height: 203px;" class="media-element file-default file-os-files-xxlarge" src="img/GEOS-Chem_Logo_Square_Light_Background_Orig.png" alt="" title="" /></a>
+<h2 class="css-brand--css-geos-meetings-header-h2-xxxlarge">The 5th International GEOS-Chem Meeting (IGC5) May 2-5 2011</h2>
 </div>
 </div>
 </div>

--- a/igc6-presentations.html
+++ b/igc6-presentations.html
@@ -1,9 +1,4 @@
 <!DOCTYPE html>
-<!--[if IEMobile 7]><html class="iem7"  lang="en" dir="ltr"><![endif]-->
-<!--[if lte IE 6]><html class="lt-ie9 lt-ie8 lt-ie7"  lang="en" dir="ltr"><![endif]-->
-<!--[if (IE 7)&(!IEMobile)]><html class="lt-ie9 lt-ie8"  lang="en" dir="ltr"><![endif]-->
-<!--[if IE 8]><html class="lt-ie9"  lang="en" dir="ltr"><![endif]-->
-<!--[if (gte IE 9)|(gt IEMobile 7)]><!--><html  lang="en" dir="ltr"><!--<![endif]-->
 <head>
 <meta charset="utf-8" />
 <!--<base href="/igc6-presentations" />-->
@@ -18,23 +13,12 @@
 <title>The 6th International GEOS-Chem Meeting</title>
 <meta http-equiv="x-ua-compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<link type="text/css" rel="stylesheet" href="css/css_xE-rWrJf-fncB6ztZfd2huxqgxu4WO-qwma6Xer30m4%EF%B9%96m=1675397288.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_1kR8T1_c-l5pBT6ZwbDT7BFda-4fyqW9Jjum29_2IY8%EF%B9%96m=1675397312.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_YnlUIvHP13qgpYEqubzE8JyDwlSxUnVibfnVkSoSDb0%EF%B9%96m=1675397273.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_Ku-3OcT9qU9h7dnGig5e23q6EVryY8orK4wzVDxsweE%EF%B9%96m=1675397367.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_vprtFTrWyg23GbY50_zJZHWGYMNfS8vsrRS26i4-ISk%EF%B9%96m=1675397406.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_dW-aNNrctRhQNc-KECjtQd0PxuW-h19IEum-TX2MeEk%EF%B9%96m=1675397301.css" media="print" />
-<link type="text/css" rel="stylesheet" href="css/css_SH2Lx3Qprh0GZo_9xRp85U9NsWfkSXn_Bi-rJoMY1sw%EF%B9%96m=1675397273.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_uaIDKcYMUK5osSQXuirpr3ZleXtnnpBN-eiECm7N0M0%EF%B9%96m=1675397395.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/responsive.blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/geos-chem.css" media="all"/>
 <script type="text/javascript" src="dropdown-menu.js"></script>
-<!--[if lte IE 8]>
-<script type="text/javascript">
-  var os_c = document.createElement;os_c('header');os_c('nav');os_c('section');os_c('article');os_c('aside');os_c('footer');os_c('hgroup');os_c('figure');
-</script>
-<![endif]-->
 </head>
 
 <body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-1585687 node-type-page og-context og-context-node og-context-node-1585652 navbar-on">
@@ -45,22 +29,20 @@
 <div id="page_wrap" class="page_wrap">
 <div id="page" class="container page header-main content-top footer-none">
 <div id="page-wrapper">
-		
+
 <!--header regions beg-->
 <header id="header" class="clearfix" role="banner">
 <div id="header-container">
 <div id="header-panels" class="at-panel gpanel panel-display three-col clearfix">
 <div class="region region-header-second"><div class="region-inner clearfix">
 <section id="block-boxes-1630413211" class="block block-boxes block-boxes-os_boxes_html"  module="boxes" delta="1630413211">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <h2 class="block-title" ng-non-bindable="">Site-Logo</h2>
 <div class="block-content content" ng-non-bindable="">
 <div id='boxes-box-1630413211' class='boxes-box'>
 <div class="boxes-box-content">
-<img height="551" width="1101" style="float: right; width: 350px; height: 175px; margin-bottom: 1.5em;" alt="gca2 logo" class="media-element file-default file-os-files-xxlarge" src="img/igc-early-logo.png" title="" />
-<h2 class="css-brand--css-geos-meetings-header-h2-xxxlarge">
-  The 6th International GEOS-Chem Meeting (IGC6) May 6-9 2013
-</h2>
+<a href="https://geoschem.github.io/"><img height="600" width="1034" style="float: right; width: 350px; height: 203px;" class="media-element file-default file-os-files-xxlarge" src="img/GEOS-Chem_Logo_Square_Light_Background_Orig.png" alt="" title="" /></a>
+<h2 class="css-brand--css-geos-meetings-header-h2-xxxlarge">The 6th International GEOS-Chem Meeting (IGC6) May 6-9 2013</h2>
 </div>
 </div>
 </div>
@@ -76,15 +58,16 @@
 
 <!--main menu region beg-->
 <div id="menu-bar" class="nav region-menu-bar clearfix">
-<nav id="block-os-igc6-menu" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="igc6_menu">  
-<ul class="nice-menu nice-menu-down nice-menu-igc6_menu" id="nice-menu-igc6_menu">
-  <li class="menu-859543 menu-path-node-1586997  first   odd  "><a href="igc6.html"  class="active">Home</a></li>
-  <li class="menu-859559 menu-path-node-1586998   even   last "><a href="igc6-presentations.html" >Presentations and Posters</a></li>
+<nav id="block-os-igc6-menu" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="igc6_menu">
+<ul class="nice-menu nice-menu-down">
+  <li><a href="igc6.html" class="active">IGC6 Home</a></li>
+  <li><a href="igc6-presentations.html">Presentations and Posters</a></li>
+  <li><a href="index.html">GEOS-Chem Home</a></li>
 </ul>
 </nav>
 </div>
 <!--main menu region end-->
-		
+
 <div id="columns" class="clearfix">
 <div class="hg-container">
 <div id="content-column" role="main">
@@ -94,13 +77,13 @@
 <a name="main-content"></a>
 <h1 id="page-title" ng-non-bindable="">Presentations and Posters</h1>
 </header>
-														
+
 <!--front panel regions beg-->
 <div id="content-panels" class="at-panel gpanel panel-display content clearfix">
 <div class="region region-content-top">
 <div class="region-inner clearfix">
 <div id="block-os-pages-main-content" class="block block-os-pages no-title"  module="os_pages" delta="main_content">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <div class="block-content content" ng-non-bindable="">
 <article id="node-1585687" class="node node-page article clearfix" role="article">
 <div class="node-content" ng-non-bindable="">
@@ -109,681 +92,666 @@
 <div class="field-item even">
 
 <p>
-	<strong>Mon 06 May 2013</strong>:  <a class="pdflink" href="#MonA">Model Overview</a> | <a href="#MonB">Working Groups</a> | <a href="#MonC">Aerosol Sources &amp; Chemistry </a>| <a href="#MonD">Black Carbon</a>
+  <strong>Mon 06 May 2013</strong>:  <a class="pdflink" href="#MonA">Model Overview</a> | <a href="#MonB">Working Groups</a> | <a href="#MonC">Aerosol Sources &amp; Chemistry </a>| <a href="#MonD">Black Carbon</a>
 </p>
 
 <p>
-	<strong>Tue 07 May 2013</strong>:  <a href="#TueA">Aerosol Effects on Climate &amp; Air Quality </a> | <a href="#TueB">Mercury and POPs</a> | <a href="#TueC">Chemistry-Climate</a>
+  <strong>Tue 07 May 2013</strong>:  <a href="#TueA">Aerosol Effects on Climate &amp; Air Quality </a> | <a href="#TueB">Mercury and POPs</a> | <a href="#TueC">Chemistry-Climate</a>
 </p>
 
 <p>
-	<strong>Wed 08 May 2013</strong>:  <a href="#WedA"> Sources &amp; Sinks: Nitrogen</a> | <a href="#WedB">CO2 fluxes</a> | <a href="#WedC">Sources of Other Carbon Gases</a>
+  <strong>Wed 08 May 2013</strong>:  <a href="#WedA"> Sources &amp; Sinks: Nitrogen</a> | <a href="#WedB">CO2 fluxes</a> | <a href="#WedC">Sources of Other Carbon Gases</a>
 </p>
 
 <p>
-	<strong>Thu 09 May 2013</strong>:  <a href="#ThuA">Tropospheric O3 and Photochemistry</a> | <a href="#ThuB">Regional Air Quality</a>
+  <strong>Thu 09 May 2013</strong>:  <a href="#ThuA">Tropospheric O3 and Photochemistry</a> | <a href="#ThuB">Regional Air Quality</a>
 </p>
 
-<h2>
-	Monday 06 May 2013
-</h2>
+<h2>Monday 06 May 2013</h2>
 
 <h3>
-	<a name="MonA" id="MonA"></a>Model Overview (Colette Heald, MIT, Chair)
+  <a name="MonA" id="MonA"></a>Model Overview (Colette Heald, MIT, Chair)
 </h3>
 
-<ul><li>
-		Welcome (Daniel Jacob, Harvard and Randall Martin, Dalhousie)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1YkGoDuLeoWjGFcxfSTrMoIboWLIkTg4J/view?usp=drive_link">GEOS-Chem model overview</a> (Daniel Jacob, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1VVX7Vc1LfiWelOTt0m31GCKkkeE9xcNg/view?usp=drive_link">GEOS-Chem Adjoint model overview</a> (Daven Henze, U. Colorado-Boulder)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/11_uuByb_4ueaoKG_HmVHteU6igyx9e41/view?usp=drive_link">GEOS Data Assimilation System (DAS) updates</a> (Andrea Molod, NASA GSFC)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1JahGdykoR3GFyP6YK2JSFYXbiJ7oR2E-/view?usp=drive_link">GEOS-Chem model engineer's report</a> (Bob Yantosca, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1_5OI4EzCQdKxq7-7kQVpcCFX7UFDMxhY/view?usp=drive_link">Grid-independent GEOS-Chem model</a> (Michael Long, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1uekIW3nNQfTacfInY6FOIJmQVExS-Cav/view?usp=drive_link">GEOS-Chem benchmarking procedure</a> (Melissa Payer, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/19uS-IUP2STkHASUepG8q0_5n2ArfTTzO/view?usp=drive_link">New GEOS-Chem emissions module</a> (Christoph Keller, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/14dbhh28xJdVtp9NZH9EVm2Fl1LZgWZxc/view?usp=drive_link">Advanced diagnostic tools for data assimilation with GEOS-Chem</a> (Nicolas Bousserez, CU Boulder)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1DKpZNiDE7pbYHAarEF-AbpwiaOyOPSWE/view?usp=drive_link">A 'GCGrid' network for distribution of GEOS data</a> (Jack Yatteau, Harvard)
-	</li>
+<ul>
+  <li>
+    Welcome (Daniel Jacob, Harvard and Randall Martin, Dalhousie)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1YkGoDuLeoWjGFcxfSTrMoIboWLIkTg4J/view?usp=drive_link">GEOS-Chem model overview</a> (Daniel Jacob, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1VVX7Vc1LfiWelOTt0m31GCKkkeE9xcNg/view?usp=drive_link">GEOS-Chem Adjoint model overview</a> (Daven Henze, U. Colorado-Boulder)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/11_uuByb_4ueaoKG_HmVHteU6igyx9e41/view?usp=drive_link">GEOS Data Assimilation System (DAS) updates</a> (Andrea Molod, NASA GSFC)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1JahGdykoR3GFyP6YK2JSFYXbiJ7oR2E-/view?usp=drive_link">GEOS-Chem model engineer's report</a> (Bob Yantosca, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1_5OI4EzCQdKxq7-7kQVpcCFX7UFDMxhY/view?usp=drive_link">Grid-independent GEOS-Chem model</a> (Michael Long, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1uekIW3nNQfTacfInY6FOIJmQVExS-Cav/view?usp=drive_link">GEOS-Chem benchmarking procedure</a> (Melissa Payer, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/19uS-IUP2STkHASUepG8q0_5n2ArfTTzO/view?usp=drive_link">New GEOS-Chem emissions module</a> (Christoph Keller, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/14dbhh28xJdVtp9NZH9EVm2Fl1LZgWZxc/view?usp=drive_link">Advanced diagnostic tools for data assimilation with GEOS-Chem</a> (Nicolas Bousserez, CU Boulder)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1DKpZNiDE7pbYHAarEF-AbpwiaOyOPSWE/view?usp=drive_link">A 'GCGrid' network for distribution of GEOS data</a> (Jack Yatteau, Harvard)
+  </li>
 </ul><h3>
-	<a name="MonB" id="MonB"></a>GEOS-Chem Working Group Introductions (Jun Wang, U. Nebraska, Chair)
+  <a name="MonB" id="MonB"></a>GEOS-Chem Working Group Introductions (Jun Wang, U. Nebraska, Chair)
 </h3>
 
 <ul><li>
-		<a href="https://drive.google.com/file/d/1R3WklApg5tRkPihML-7RVV_jEJ2DBq4C/view?usp=drive_link">Aerosol</a>s (Colette Heald, MIT and Jeff Pierce, Colorado State U.)
-	</li>
-	<li>
-		Carbon Gases and Organics (Dylan Millet, U. Minnesota and Ray Nassar, Environment Canada)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Iv69_rPzXRlFAy5c-ySZ2nPeb3QcGN4p/view?usp=drive_link">Chemistry-Climate</a> (Hong Liao, Chinese Academy of Sciences and Loretta Mickley, Harvard)
-	</li>
-	<li>
-		<a href="hhttps://drive.google.com/file/d/18etyXZYOR0cPxyl7HRgxVeaQjhdSNG38/view?usp=drive_link">Mercury and Persistent Organic Pollutants</a> (Lyatt Jaegle, U. Washington and Noelle Selin, MIT)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1cGjVwnPhq6BYYmUZYtTmZ7Io1YnKAU6t/view?usp=drive_link">Oxidants and Chemistry</a> (Mathew Evans, U. York and Jingqiu Mao, NOAA GFDL)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1sPOmC7cscjUuvXIe1Mh_a1ngzNSEyTZg/view?usp=drive_link">Nested Model</a> (Jun Wang, U. Nebraska and Yuxuan Wang, Tsinghua U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1-POnBMied0TYiV93YhvTUeCAp16Wndsk/view?usp=drive_link">Sources and Sinks</a> (Randall Martin, Dalhousie and Paul Palmer, U. Edinburgh)
-	</li>
+    <a href="https://drive.google.com/file/d/1R3WklApg5tRkPihML-7RVV_jEJ2DBq4C/view?usp=drive_link">Aerosol</a>s (Colette Heald, MIT and Jeff Pierce, Colorado State U.)
+  </li>
+  <li>
+    Carbon Gases and Organics (Dylan Millet, U. Minnesota and Ray Nassar, Environment Canada)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Iv69_rPzXRlFAy5c-ySZ2nPeb3QcGN4p/view?usp=drive_link">Chemistry-Climate</a> (Hong Liao, Chinese Academy of Sciences and Loretta Mickley, Harvard)
+  </li>
+  <li>
+    <a href="hhttps://drive.google.com/file/d/18etyXZYOR0cPxyl7HRgxVeaQjhdSNG38/view?usp=drive_link">Mercury and Persistent Organic Pollutants</a> (Lyatt Jaegle, U. Washington and Noelle Selin, MIT)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1cGjVwnPhq6BYYmUZYtTmZ7Io1YnKAU6t/view?usp=drive_link">Oxidants and Chemistry</a> (Mathew Evans, U. York and Jingqiu Mao, NOAA GFDL)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1sPOmC7cscjUuvXIe1Mh_a1ngzNSEyTZg/view?usp=drive_link">Nested Model</a> (Jun Wang, U. Nebraska and Yuxuan Wang, Tsinghua U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1-POnBMied0TYiV93YhvTUeCAp16Wndsk/view?usp=drive_link">Sources and Sinks</a> (Randall Martin, Dalhousie and Paul Palmer, U. Edinburgh)
+  </li>
 </ul><h3>
-	<a name="MonC" id="MonC"></a>Aerosol Sources and Chemistry (Nicholas Meskhidze, North Carolina State U., Chair)
+  <a name="MonC" id="MonC"></a>Aerosol Sources and Chemistry (Nicholas Meskhidze, North Carolina State U., Chair)
 </h3>
 
-<h4>
-	Presentations
-</h4>
+<h4>Presentations</h4>
 
 <ul><li>
-		<a href="https://drive.google.com/file/d/19FEPG3XncukjCF4b_wXLPCg5gyOtKhHC/view?usp=drive_link">Atmospheric input of soluble iron to the ocean: GEOS-Cl</a> (Matthew Johnson, NASA Ames)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/19o09Y0a9N1lfu-aGNCeso2iPA_Wxee0Q/view?usp=drive_link">Sulfate formation in the marine boundary layer</a> (Becky Alexander, U. Washington)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/10ESu1agj8TKETcvn44k2lmPLlFYu3kSP/view?usp=drive_link">Effect of secondary organic aerosol amount and condensational behavior on global aerosol size distributions</a> (Stephen D'Andrea, Dalhousie)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/13Wpicbi9-8vs5DvB81MZpxIOwpGZzc5O/view?usp=drive_link">From emission to deposition: understanding 30 years of African mineral dust aerosol with GEOS-Chem</a> (David Ridley, MIT)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1EP90YS2usVsHQZJwpp6mlprxwxZZa4c7/view?usp=drive_link">Global OM/OC inferred from AMS measurements with GEOS-Chem and OMI nitrogen oxide concentrations</a> (Sajeev Philip, Dalhousie)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/19NcwLzyJxNlkS-pxBM9WMk3f-FvfXYsW/view?usp=drive_link">Simulation of the oxygen content of organic aerosol using GEOS-Chem</a> (Qi Chen, MIT)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1oIEfb4pKglUPuQwoYegKafzjMJNSxHkq/view?usp=drive_link">New particle formation in GEOS-Chem-TOMAS: Evaluation, sensitivity, and particle number tagging</a> (Dan Westervelt, Carnegie Mellon)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/15WIZvX5X4ias6d4a-qXVemfAaP1KQbIY/view?usp=drive_link">Aerosol Loading in the Southeastern US</a> (Bonne Ford, Colorado State U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/16d64cyuegTYkFL210xyYbI8oRnU9KMTy/view?usp=drive_link">Adjoint inversion of aerosol emissions from satellite radiance observation with GEOS-Chem model</a> (Richard Xu, U. Nebraska-Lincoln)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/15qeh28tiEeQvMejE5MhxbJeMjtTNeY0p/view?usp=drive_link">GEOS-Chem evaluation of marine primary organic aerosol emission schemes</a> (Brett Gantt, North Carolina State U.)
-	</li>
-</ul><h4>
-	Posters
-</h4>
-
-<ul><li>
-		<a href="https://drive.google.com/file/d/1nts6r8k602oS3nXrfA1rIHt6KgKO6g0K/view?usp=drive_link">A parameterization of sub-grid particle formation in sulphur-rich plumes for global and regional scale models</a> (Robin Stevens, Dalhousie)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1RgKcx0aw0mO6rAzafcUmOGVvXHa9Uwgj/view?usp=drive_link">Composition and spatial and temporal patterns of measured PM2.5 in the United States: Important constraints on global model simulations</a> (Bret Schichtel, National Park Service)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1-100_wQOg-UYdtzUxjnxjEEVWDMMLWMs/view?usp=drive_link">Updated dust-iron dissolution mechanism in GEOS-Chem</a> (Nicholas Meskhidze, North Carolina State U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/10lW4a0FdyH6Lfw98l9JydPfAC_4UIHef/view?usp=drive_link">Particle formation and growth in urban and rural environment over Europe: nested GEOS-Chem/APM simulations and comparisons with observations</a> (Gan Luo, SUNY-Albany)
-	</li>
-</ul><h3>
-	<a name="MonD" id="MonD"></a>Black Carbon and Related Processes (Fangqun Yu, SUNY-Albany, Chair)
-</h3>
-
-<h4>
-	Presentations
-</h4>
-
-<ul><li>
-		Assessment of the sources and distribution black carbon aerosol over Asia using the adjoint of GEOS-Chem (Li Zhang, U. Colorado-Boulder)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1T_j24YeeUrQks5jtkdfMla7Wp7niaQVp/view?usp=drive_link">Global budget of black carbon: constraints from HIPPO</a> (Qiaoqiao Wang, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1AEUFgW-UiGnGBl6fOxApAbtBzpqz7nQd/view?usp=drive_link">Spatial and temporal distribution Arctic aerosols: comparison between remote sensing, in situ, and GEOS-Chem</a> (Maurizio di Pierro, U. Washington)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1aBnikAKnrGio58YFNw1V3D8wawy-C3vu/view?usp=drive_link">Sensitivity tests with GEOS-Chem aerosol optical properties in comparison with satellite and sunphotometer</a> (Gabriele Curci, U. L'Aquila)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1zZ3yFWFDBqKS9t8Q-LaSZfjpyWJia8bj/view?usp=drive_link">Validation of GEOS-Chem-APM simulated aerosol optical properties using A-Train satellite observations</a> (Xiaoyan Ma, SUNY-Albany)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1I08HBpLp9lqX4KYaeyCCLxEjFH7EZdin/view?usp=drive_link">Top-down estimates of biomass burning emissions of black carbon in the western United States</a> (Yuhao Mao, UCLA)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Bfn1bhtHOMXLaSt9YoSbaogezCledwAd/view?usp=drive_link">Assessment of black carbon in Russia using GEOS-Chem</a> (Joshua Fu, U.Tennessee)
-	</li>
-</ul><h4>
-	Posters
-</h4>
-
-<ul><li>
-		<a href="https://drive.google.com/file/d/18SrQKfVhYDYLcz6XpBi1ViviLtwVFz5z/view?usp=drive_link">Influence of aging and mixing state to black carbon radiative forcing</a> (Xuan Wang, MIT)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1vtVAyXxBSDsiRAGPNRDX8FJM2Btj7go0/view?usp=drive_link">Global simulation of brown carbon and its direct radiative forcing</a> (Duseong Jo, Seoul National U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1UqYdOoRgi6qffWiYqiSKvkeXvWXMUp7U/view?usp=drive_link">Missing black carbon emissions in Russia - new BC emissions for GEOS-Chem</a> (Kan Huang, U. Tennessee)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1UYuEU64gVj6lQNg-LOSLU2AslnLg_75i/view?usp=drive_link">Improving Aerosol Scavenging in GEOS-Chem</a> (Jessica Kunke, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1EyVtT5rklCsBl7QPoE3aG3HcwzaNi9pD/view?usp=drive_link">Contribution of agricultural burning to Arctic BC aerosols</a> (Ling Qi, UCLA)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1SNcKA9A8K3Ax6I3e-ZaPkYZUNvqkwjvk/view?usp=drive_link">Simulating the emission and transport of smoke related species in Southeast Asia using the GEOS-Chem nested grid model</a> (Shannon Koplitz, Harvard)
-	</li>
-</ul><h3>
-	Model Clinics
-</h3>
-
-<ul><li>
-		<a href="https://drive.google.com/file/d/1RBVySIKABH-v-jJG-Y1nO53YpCSkk0fv/view?usp=drive_link">GEOS-Chem model clinic</a> (Melissa Payer, Sajeev Philip)
-	</li>
-	<li>
-		Adjoint GEOS-Chem model clinic (Daven Henze, Yanko Davila)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1CE0duiCVIx8a5xbejaOZ-Ztwjph0_gUe/view?usp=drive_link">Q&amp;A for the GEOS DAS and the Grid-Independent GEOS-Chem</a> (Steven Pawson, Andrea Molod, Bob Yantosca, Mike Long)
-	</li>
-</ul><h2>
-	Tuesday 07 May 2013
-</h2>
-
-<h3>
-	<a name="TueA" id="TueA"></a>Aerosol Effects on Climate and Air Quality (May Fu, Peking U., Chair)
-</h3>
-
-<h4>
-	Presentations
-</h4>
-
-<ul><li>
-		<a href="https://drive.google.com/file/d/1ryO--neL4zg8Ozt18y1Fr3KYcF8pbh-I/view?usp=drive_link">Radiative impact of decadal trends in near-term climate forcers over the Arctic troposphere: A significant role for non-BC species</a> (Tom Breider, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Ti36ZJ9otZkHxVv0XmYKKaTbpvpeXnXD/view?usp=drive_link">Study of aerosol first indirect radiative forcing with GEOS-Chem</a> (Fangqun Yu, SUNY-Albany)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1gEfoADxMKxSrKWJcvZWXxMv-JrVMP7iy/view?usp=drive_link">Optimal estimation of high resolution global PM2.5 concentrations using GEOS-Chem and MODIS</a> (Aaron van Donkelaar, Dalhousie)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1j7P3omOyF0XcUICn36KS5YdhY3wHGEhj/view?usp=drive_link">Time series analysis of satellite derived PM2.5</a> (Brian Boys, Dalhousie)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/12xKKGyH9SNgWM75HRzOI2R7prkEgxtYU/view?usp=drive_link">Aerosol simulation over China</a> (Yuxuan Wang, Tsinghua U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1GT0s16Fb-LeQui3Xu8UDAzawvKiHs0Ib/view?usp=drive_link">Effects of the meteorological variability on aerosol trends in East Asia</a> (Rokjin Park, Seoul National U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1DiTOePsqcPlntBf5UsvIYjib5YhOWVVp/view?usp=drive_link">Sensitivity of global mortality to PM2.5 precursor emissions using the GEOS-Chem adjoint</a> (Colin Lee, Dalhousie)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1bg5uIMuHIJwF22gBjoWEBzaRdMBrHHET/view?usp=drive_link">Modeling of volcanic sulfate direct radiative forcing with Geos-Chem</a> (Cui Ge, U.Nebraska Lincoln)
-	</li>
-</ul><h4>
-	Posters
-</h4>
-
-<ul><li>
-		<a href="https://drive.google.com/file/d/17J8-qMMneWvEAszA076YDDR82CQnhhis/view?usp=drive_link">The perfect dust storm over South West Asia June 2008: causes determined from surface and satellite observations compared with high resolution DEAD emissions and GEOS-Chem output</a> (Kevin Bartlett, Air Force Institute of Technology)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1gZ1FJUn_LDeI3nCM_H-ZlC0j3QZovBJq/view?usp=drive_link">Insights on aerosol lifetimes and wet scavenging following the Fukushima nuclear accident</a> (Betty Croft, Dalhousie)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1dxPg8ZgLjs2FK_yLZOFTXuPHQjcIa0mB/view?usp=drive_link">Investigation into future radiative forcing sensitivities using GEOS-Chem and its adjoint based on RCPs</a> (Forrest Lacey, U. Colorado-Boulder)
-	</li>
-	<li>
-		A decade of global PM2.5 estimates (David Lary, U.Texas-Dallas)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1aMtWE1t2oiEt4pBSeByuhB4NfaHkgoUS/view?usp=drive_link">GEOS-Chem satellite simulator</a> (Jun Wang, U. Nebraska-Lincoln)
-	</li>
-</ul><h3>
-	<a name="TueB" id="TueB"></a>Mercury and Persistent Organic Pollutants (Chris Holmes, UC Irvine, Chair)
-</h3>
-
-<h4>
-	Presentations
-</h4>
-
-<ul><li>
-		<a href="https://drive.google.com/file/d/12B6yloTS701qV25i27s_66wg9wNNi9oJ/view?usp=drive_link">Influence of future emissions and climate on atmospheric PAH transport</a> (Carey Friedman, MIT)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1cj1FSN5r1ONz-lKdZo4ORG78SkG4ev4R/view?usp=drive_link">Impacts of recent changes in climate and emissions on mercury variability in the Arctic</a> (Jenny Fisher, U. Wollongong)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1KaciHbPX_WEObDupFsdiI8kv_mbTkfs2/view?usp=drive_link">Historical releases of mercury from wastewater: global importance and influence on atmospheric trends</a> (Helen Amos, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1cjpcaJLLnsyII1qLCFvB-CCbU5SG9lKi/view?usp=drive_link">Terrestrial Mercury Dynamics</a> (Bess Sturges Corbitt, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1VPaFQd3wOg9lwk-d0yQUn2w3WoztK2N0/view?usp=drive_link">Methylmercury in the Arctic Surface Ocean</a> (Anne Laerke Soerensen, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1LeUuWewkUShOku4bhlek-g4C6_QKcXSt/view?usp=drive_link">Quantifying uncertainties of the global mercury cycle using the GEOS-Chem model and observations</a> (Shaojije Song, MIT)
-	</li>
-</ul><h4>
-	Posters
-</h4>
-
-<ul><li>
-		<a href="https://drive.google.com/file/d/1YBs-y24xV8yO3umu8bahIk4A6LBieEth/view?usp=drive_link">Modeling the fate of mercury in products</a> (Hannah Horowitz, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1bUGhZycD3EhTm47aH8XTIXxVDRTs0aPx/view?usp=drive_link">Polynomial Chaos Expansion for chemical parameter uncertainty quantification in PAH simulations</a> (Colin Pike-Thackray, MIT)
-	</li>
-	<li>
-		Integrated assessment of the health impacts of the Mercury and Air Toxics Standards (Amanda Giang, MIT)
-	</li>
-</ul><h3>
-	<a name="TueC" id="TueC"></a>Chemistry-Climate (Lin Zhang, Peking U., Chair)
-</h3>
-
-<h4>
-	Presentations
-</h4>
-
-<ul><li>
-		<a href="https://drive.google.com/file/d/1xFSuuUIrwMdlFPr4IGsLrsSEFEBFflSD/view?usp=drive_link">Factors controlling variability in the oxidative capacity of the troposphere since the Last Glacial Maximum</a> (Lee Murray, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1PRGKEYGUWkCrhz3hse_xK3B-QCYeOmbm/view?usp=drive_link">Implications of climate change for intercontinental transport in the past decade</a> (Shiliang Wu, Michigan Tech)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/167RZN5AAleNM3gfviDdQJxkw8hL5bufT/view?usp=drive_link">Impact of 2000-2050 climate and vegetation changes on air quality: including CO inhibition of isoprene emissions in GEOS-Chem</a> (Amos Tai, MIT)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Lzar_xv4x_VIA_LiJJh4u7dUxLQJ0gdF/view?usp=drive_link">Australasian total column CO and HCHO, investigated with GEOS-Chem, FTIR measurements and the Earth System Model ACCESS</a> (Rebecca Buchholz, U. Wollongong)
-	</li>
-</ul><h4>
-	Posters
-</h4>
-
-<ul><li>
-		On-line simulation of tropospheric ozone with the climate-chemistry model BCC-AGCM- CHEM1.0 (Tongwen Wu, Beijing Climate Center)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/13g_-FpLrh4HiGc5d31zW-I7nIm05T4vL/view?usp=drive_link">Preparation for the SEAC4RS aircraft campaign</a> (Karen Yu, Harvard)
-	</li>
-	<li>
-		Calculating stratospheric chemistry and aerosols with GMI (Debra Weisenstein, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1JU83tw_V0IK1eMQ42jWCXd53TmRg_FLT/view?usp=drive_link">A statistical approach for downscaling GISS/GEOS-CHEM</a> (Konstantinos Varotsos, National and Kapodistrian U. of Athens / National Observatory of Athens)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1_R6ocMy6iW_DEtkDtHV5J6gcNBOIR0Tg/view?usp=drive_link">NOAA's Atmospheric Chemistry, Carbon Cycle, and Climate (AC4) competitive research program</a> (Monika Kopacz, NOAA Climate Program Office)
-	</li>
-	<li>
-		Evaluation of tropospheric composition in Yale-E2 (Hongyan Dang, Yale U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1En4N4BYhs9-h1TiFP8lmPNk2YiOBCGqp/view?usp=drive_link">Development of GEOS-Chem driven by CESM meteorological data: effects of future climate change on air quality</a> (Minjoong Kim, Seoul National U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/10Ol0AHVm69wc9Aa9oexro_MjUG-KfGJ3/view?usp=drive_link">Assessment of the sensitivity of sulfate isotopes to climate and chemistry on the glacial- interglacial timescale using GEOS-Chem</a> (Eric Sofen, U. Washington)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Nm_aFLW30lv0GRFr_zRl7i7kmIFQbzSO/view?usp=drive_link">Increasing the Efficiency of GEOS-Chem adjoint simulations using a Python Ensemble Manager</a> (Andre Perkins, U. Wisconsin-Madison)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1ffZxn7HwKcsbZf_OMM8vfP9hFjSWtxwT/view?usp=drive_link">Novel methods of understanding our atmosphere</a> (Dene Bowdalo, U. York)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/15Ch4j41C4zeg-mNV4njL2XyNKo3Unx5n/view?usp=drive_link">Attribution of direct ozone radiative forcing to spatially resolved emissions</a> (Kevin Bowman, JPL)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1120YRBJDLL7-dSztaylp3tgcLXrU12GV/view?usp=drive_link">Radiative forcing of early 20th-century US aerosols</a> (Eric Leibensperger, SUNY-Plattsburgh)
-	</li>
-</ul><h2>
-	Wednesday 08 May 2013
-</h2>
-
-<h3>
-	<a name="WedA" id="WedA"></a>Sources and Sinks: Nitrogen (Folkert Boersma, KNMI, Chair)
-</h3>
-
-<h4>
-	Presentations
-</h4>
-
-<ul><li>
-		<a href="https://drive.google.com/file/d/1u6QfROuUyLYKORZ5_H9UTriHUIK5I9c8/view?usp=drive_link">Top-down constraints on ship NOx emissions in European waters from OMI</a> (Geert Vinken, Eindhoven U. of Technology)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1btiGjXqaE1AKsBHWqzThxPfW4Y7kABHU/view?usp=drive_link">Top-down and bottom-up constraints on NH3 emissions</a> (Fabien Paulot, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1b8so3BJAi6pGSvYdmFwcIuRtPaHrTrhg/view?usp=drive_link">Present and future nitrogen deposition to US National Parks: Critical load exceedances</a> (Raluca Ellis, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1ijChE3xEtTCttRIkOLITODWZ1UhcejpK/view?usp=drive_link">Implementation of a plume-in-grid model into GEOS-Chem to improve sub-grid processes related to lightning NOx emissions</a> (Alicia Gressent, U. de Toulouse)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1XbaDUok7UoyXLqRp22vJsyGGUVEiq2kQ/view?usp=drive_link">Evaluation of ammonia bi-directional exchange with GEOS-Chem</a> (Juliet (Liye) Zhu, U. Colorado-Boulder)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1phRQT_lUh09avPxZ0yQP-PruEaWjUu2T/view?usp=drive_link">Investigating the sources of nitrate in Antarctica using GEOS-Chem and its adjoint </a>(Hyung-Min Lee, U.Colorado-Boulder)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1m42EJx0U8mDiSA2Z-mFdN3jq6JuVq9su/view?usp=drive_link">Refining nested GEOS-Chem emissions during the CalNex campaign by assimilation of TES ammonia observations</a> (Shannon Capps, US EPA AMAD)
-	</li>
-</ul><h4>
-	Posters
-</h4>
-
-<ul><li>
-		<a href="https://drive.google.com/file/d/1t2E3Anj1GjdMDCzyA6vzN_-FMhsctS7b/view?usp=drive_link">Investigating the impact of snowpack photodenitrification on polar atmospheric chemistry utilizing results from a snowpack radiative transfer model in GEOS-Chem</a> (Maria Zatko, U. Washington)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1GBxgU5g5ZHRNXKK_hLix27yem7SpnK0T/view?usp=drive_link">Analysis of NOx Emission Trend over East Asia - GEOS-Chem, Satellite and REAS emission</a> (Itsushi Uno, Kyushu U.)
-	</li>
-	<li>
-		How to quantify and avoid errors in evaluating CTMs with UV/Vis satellite retrievals (Folkert Boersma, KNMI / Eindhoven U. of Technology)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1SMLZOjw6OQB-4JQTvra0_cVME79bm9iC/view?usp=drive_link">Lightning NOx Statistics Derived by NASA Lightning Nitrogen Oxides Model (LNOM) Data Analyses</a> (William Koshak, NASA MSFC)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/15QWVaImpC3Riboxggko7y7AIF5A_wOxO/view?usp=drive_link">An investigation of ammonia and inorganic particulate matter in California during the CalNex campaign</a> (Luke Schiferl, MIT)
-	</li>
-	<li>
-		Daily ammonia maps from AIRS and comparison with GEOS-Chem (Juying Warner, AOSC/UMCP)
-	</li>
-	<li>
-		Fire emissions associated with future land use change in Indonesia (Miriam Marlier, Columbia)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1_Ms6Q83CjNADjrpNYRBXUmmvfIZikewN/view?usp=drive_link">NO2 and SO2 dry deposition inferred from satellite measurements</a> (Caroline Nowlan, Dalhousie)
-	</li>
-	<li>
-		Retrieving NOx from space: errors in satellite NO2 products and CTM simulations (Jintai Lin, Peking U.)
-	</li>
-</ul><h3>
-	<a name="WedB" id="WedB"></a>Carbon Dioxide Fluxes (Monika Kopacz, NOAA, Chair)
-</h3>
-
-<h4>
-	Presentations
-</h4>
-
-<ul><li>
-		<a href="https://drive.google.com/file/d/18JTUVmkSsqg1fVH9OkYTuBh-VwmnLMJs/view?usp=drive_link">Using GEOS-Chem within a grid-based EnKF system to estimate carbon fluxes from NOAA surface data and GOSAT data</a> (Andrew Schuh, Colorado State U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1IehMmn2LftVMOKz4zCPCLnH9pSwIt3A4/view?usp=drive_link">Attribution of atmospheric CO2 to surface fluxes with the Carbon Monitoring System Flux Pilot project</a> (Kevin Bowman, JPL)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1FNF3UEXdeHqbXbsJaI2XoRv3ZU0NrD6C/view?usp=drive_link">Quantifying the impact of model errors on top-down CO flux estimates</a> (Dylan Jones, U. Toronto)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/19p_ydcHX1RKQI0jGu9lWGsRUnGf4FL-o/view?usp=drive_link">Temporal and spatial scale factors for fossil fuel CO2</a> (Ray Nassar, Environment Canada)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/17m3LL77m_UW_EorUDO62v1YHMqTqYPly/view?usp=drive_link">Estimates of CO2 surface fluxes using an atmospheric inversion method</a> (Chen Zhaohui, Chinese Academy of Sciences)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1-OV_y20k23m08TrxtyNdksFEKWsEcXX1/view?usp=drive_link">Continental sources/sinks manifest the seasonal and latitudinal gradient of atmospheric CO over East Asia</a> (Changsub Shim, Korea Environment Institute)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1vcH6lFRfnlpayVKHoDON-lNNTZ2AEMEA/view?usp=drive_link">GEOS-Chem simulations of global CO2 concentrations at horizontal resolution of 0.5x0.666 degrees</a> (Liang Feng, U. Edinburgh)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Xmffs_7G6aRmKzUsPr9vAA9J6QkOlQ-Y/view?usp=drive_link">Interannual variability in atmospheric CO2 from generalized surface fluxes</a> (Gretchen Keppel-Aleks, UC Irvine)
-	</li>
-	<li>
-		Quantifying terrestrial carbon fluxes using surface and satellite observations (Feng Deng, U. Toronto)
-	</li>
-</ul><h4>
-	Posters
-</h4>
-
-<ul><li>
-		<a href="https://drive.google.com/file/d/1Z9K_1KyrCp6xTgb-OFMa_qCKLqQpd_Ks/view?usp=drive_link">Estimating surface CO2 flux with simulated ACOS-GOSAT observations</a> (Junjie Liu, JPL)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1eeBXG2G6LCzx57RdPV6Sp6YGDf7rfSU0/view?usp=drive_link">Understanding model errors of GEOS-Chem CO2 and CO simulations</a> (Helen Wang, Harvard-Smithsonian)
-	</li>
-	<li>
-		Constrain terrestrial surface CO2 fluxes by combing both atmospheric transport model and process-based terrestrial model (Qing Zhu, Purdue)
-	</li>
-	<li>
-		Inverse modeling of terrestrial ecosystem carbon sinks and sources over China (Hengmao Wang, Nanjing U.)
-	</li>
-</ul><h3>
-	<a name="WedC" id="WedC"></a>Sources of other Carbon Gases (Ray Nassar, Environment Canada, Chair)
-</h3>
-
-<h4>
-	Presentations
-</h4>
-
-<ul><li>
-		<a href="https://drive.google.com/file/d/1GCeqSWaNw2-1GurPrGWwHMp4ouLXGFGb/view?usp=drive_link">A uniform emissions pre-processor for GEOS-Chem</a> (Qiang Zhang, Tsinghua U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1PoGIGE48nNdUvhDEn-r0ZaQXTOdljny1/view?usp=drive_link">Nested Adjoint Inversion of Methane Sources in North America</a> (Kevin Wecht, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1FxkE3NEpXBNukrp_Squ4tGCc99nwq9N4/view?usp=drive_link">Top-down constraints on sources and impacts of atmospheric organic acids</a> (Dylan Millet, U. Minnesota)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1-yjlDBK1LVd8Xu7u56h_Ed0wDJngIJ3O/view?usp=drive_link">Quantifying surface emissions of methanol using observations from the Tropospheric Emission Spectrometer</a> (Kelley Wells, U. Minnesota)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Gco_JPMBssf_MGZ9LX15SejgYgbv25UZ/view?usp=drive_link">Methane in the 21st century: Projections for RCP scenarios in GEOS-Chem</a> (Chris Holmes, UC Irvine)
-	</li>
-	<li>
-		Estimate of tropical fire emissions from the 2006 Indonesian Peat fires using Aura TES CH4 and CO data and the GEOS-Chem model (John Worden, JPL/Caltech)
-	</li>
-	<li>
-		The methane emissions from Pan-Arctic lakes estimated using the adjoint of GEOS-Chem (Zeli Tan, Purdue)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1NwgCOLFqs8dCMWFCt-SJPc1J2idThIdC/view?usp=drive_link">Inverse estimate of long-term CO emission in China between 2005–2010 with Green's Function Method</a> (Keiya Yumimoto, Japan Meteorological Agency)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1jScSloGSjT4uN2-c0iBIdhOcvyO8-51F/view?usp=drive_link">Top-down isoprene emission estimates over the US Midwest using tall tower measurements and GEOS-Chem nested grid simulations</a> (Lu Hu, U. Minnesota)
-	</li>
-</ul><h4>
-	Posters
-</h4>
-
-<ul><li>
-		The potential of glyoxal as a second top-down constraint on NMVOC emissions (Chris Miller, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Uz6HbNyG94nISavhyiob_1NHjBSRREt1/view?usp=drive_link">Methane emissions from fracking</a> (Brian Nathan, U. Texas-Dallas)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1j5oZiifP-rkt3qClKqc-6nL-MFIQFLxS/view?usp=drive_link">Variability of formaldehyde over the Southeastern United States from space: Implications for isoprene emissions</a> (Lei Zhu, Harvard)
-	</li>
-	<li>
-		Regional data assimilation of multispectral MOPITT observations of CO over North America (Zhe Jiang, U. Toronto)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1rfCUqx4bY8REQ26DY-ae_Sp4_qq3cZum/view?usp=drive_link">Using GEOS-Chem to better understand isoprene nighttime chemistry</a> (Rebecca Schwantes, Caltech)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1mOsn0kLHAmFcoqyZX41VIwOZ6R7yf4Q0/view?usp=drive_link">Source attribution of observed CO variability during BORTAS-B using GEOS-Chem</a> (Douglas Finch, U. Edinburgh)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1sSu9CkhwltJMCsMoSLZ-GHnDs8hzK21c/view?usp=drive_link">Characterization of information content and errors in inverse models of methane</a> (Alex Turner, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1q5zJbFDphg1NNyj7r1Y-CmfgUUuk11aj/view?usp=drive_link">Global distribution of formic acid from TES: Retrieval evaluation and implications for sources</a> (Sreelekha Chaliyakunnel, U. Minnesota)
-	</li>
-	<li>
-		Vegetation change and biogenic trace gas emissions: potentials for modifying source terms for GEOS-Chem (Manuel Lerdau, U. Virginia)
-	</li>
-</ul><h2>
-	Thursday 09 May 2013
-</h2>
-
-<h3>
-	<a name="ThuA" id="ThuA"></a>Tropospheric Ozone and Photochemistry (Rokjin Park, Seoul National U., Chair)
-</h3>
-
-<h4>
-	Presentations
-</h4>
-
-<ul><li>
-		<a href="https://drive.google.com/file/d/1tK5L_1WOLC5a8OX-1Ztz8vPLtVEDbFh0/view?usp=drive_link">Global ozone-CO correlations from OMI and AIRS as constraints on ozone sources and transport</a> (Patrick Kim, Harvard)
-	</li>
-	<li>
-		The GEOS-Chem PAN simulation (Emily Fischer, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Cxy0I1KeLhd_1ogtO0nQBqmO3eT2FdXM/view?usp=drive_link">Ozone and organic nitrates over the eastern United States: sensitivity to isoprene chemistry</a> (Jingqiu Mao, NOAA GFDL)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1KIuBavTTiEZ58fhE7rg_aM98Zw25Ojl3/view?usp=drive_link">Assessing the atmospheric impacts of aviation with GEOS-Chem</a> (Steven Barrett, MIT)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1MEfZEEAAZrMp5wcdiazi5v1olU-vCMqS/view?usp=drive_link">Observing North American background ozone from geostationary orbit</a> (Peter Zoogman, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1IopY9B_PoOkjyHw10UucfuvL7m6YNdpa/view?usp=drive_link">Source attribution of North American background ozone concentrations in the Intermountain West</a> (Lin Zhang, Peking U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1bcZO6wkQTdkQTNAH8vCrf-W0x0C-iGiA/view?usp=drive_link">Integrating in situ and satellite observations with GEOS-Chem to constrain the influence of boreal biomass burning emissions on tropospheric oxidant chemistry</a> (Mark Parrington, U. Edinburgh)
-	</li>
-	<li>
-		Understanding the interannual variations of tropospheric O3 and aerosols using the GEOS-Chem model (Hong Liao, Chinese Academy of Sciences)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/19pQT4TURZxfsTAeFFEpJoJA69SyD8uW2/view?usp=drive_link">Impacts of aerosols on concentrations of tropospheric ozone in China through heterogeneous reactions and changes in photolysis rates</a> (Sijia Lou, Chinese Academy of Sciences)
-	</li>
+    <a href="https://drive.google.com/file/d/19FEPG3XncukjCF4b_wXLPCg5gyOtKhHC/view?usp=drive_link">Atmospheric input of soluble iron to the ocean: GEOS-Cl</a> (Matthew Johnson, NASA Ames)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/19o09Y0a9N1lfu-aGNCeso2iPA_Wxee0Q/view?usp=drive_link">Sulfate formation in the marine boundary layer</a> (Becky Alexander, U. Washington)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/10ESu1agj8TKETcvn44k2lmPLlFYu3kSP/view?usp=drive_link">Effect of secondary organic aerosol amount and condensational behavior on global aerosol size distributions</a> (Stephen D'Andrea, Dalhousie)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/13Wpicbi9-8vs5DvB81MZpxIOwpGZzc5O/view?usp=drive_link">From emission to deposition: understanding 30 years of African mineral dust aerosol with GEOS-Chem</a> (David Ridley, MIT)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1EP90YS2usVsHQZJwpp6mlprxwxZZa4c7/view?usp=drive_link">Global OM/OC inferred from AMS measurements with GEOS-Chem and OMI nitrogen oxide concentrations</a> (Sajeev Philip, Dalhousie)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/19NcwLzyJxNlkS-pxBM9WMk3f-FvfXYsW/view?usp=drive_link">Simulation of the oxygen content of organic aerosol using GEOS-Chem</a> (Qi Chen, MIT)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1oIEfb4pKglUPuQwoYegKafzjMJNSxHkq/view?usp=drive_link">New particle formation in GEOS-Chem-TOMAS: Evaluation, sensitivity, and particle number tagging</a> (Dan Westervelt, Carnegie Mellon)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/15WIZvX5X4ias6d4a-qXVemfAaP1KQbIY/view?usp=drive_link">Aerosol Loading in the Southeastern US</a> (Bonne Ford, Colorado State U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/16d64cyuegTYkFL210xyYbI8oRnU9KMTy/view?usp=drive_link">Adjoint inversion of aerosol emissions from satellite radiance observation with GEOS-Chem model</a> (Richard Xu, U. Nebraska-Lincoln)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/15qeh28tiEeQvMejE5MhxbJeMjtTNeY0p/view?usp=drive_link">GEOS-Chem evaluation of marine primary organic aerosol emission schemes</a> (Brett Gantt, North Carolina State U.)
+  </li>
 </ul>
 
-<h4>
-	Posters
-</h4>
+<h4>Posters</h4>
 
 <ul><li>
-		Characterizing the variability of STE in the UTLS (Dave MacKenzie, U. Toronto)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1u7S9fXrRaS-DaZwYpZ4EvFQkjX73uxB0/view?usp=drive_link">Dynamic effects of upper tropospheric ozone</a> (Matthew Cooper, Dalhousie)
-	</li>
-	<li>
-		Impact of meteorology and emissions on the interannual variation of tropospheric ozone over the South America and surrounding oceans (Junhua Liu, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1vK3FxdnteztbxkNlDXQ0XelQAXxcHMTk/view?usp=drive_link">Improved background ozone modeling with Geos-Chem</a> (Katherine Travis, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1S-uYh6SDbSOkNxWZ2VbSrJ4einHF-WTR/view?usp=drive_link">Meteorological modes driving surface O3 variability over the United States</a> (Lulu Shen, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1sOwYtB_x1ftUimuSHUuIM0nHQi7Hz3F_/view?usp=drive_link">Iodine in the troposphere</a> (Tomás Sherwen, U. York)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1yYx0y7OfxnQRCtLPSU_kv9CXNwxJgyZY/view?usp=drive_link">O-17 excess of nitrate and sulfate from last glacial period to preindustrial Holocene: implications for glacial-interglacial atmospheric oxidant change</a> (Lei Geng, U. Washington)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1btXfs9yQ_kW_hphgcIVASIRrDxTQr2DZ/view?usp=drive_link">Tropospheric O3 intraseasonal variability over South Asia: IASI observations and GEOS-Chem simulations</a> (Bastien Sauvage, U. Toulouse)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1AchEnX9ZoCVbbPz3mLjBs37xPmNfOcWU/view?usp=drive_link">Overview of the geophysical data derived from long-term FTIR monitoring at the Jungfraujoch NDACC site (46.5ºN)</a> (Emmanuel Mahieu, U. Liège -Belgium)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1N1cmXDFnb62hTaQkz4pxbSC7UzB_FRu0/view?usp=drive_link">Radical loss in the atmosphere from Cu-Fe redox coupling in aerosols</a> (Jingqiu Mao, NOAA GFDL)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/14VEcb6twqPTUU082E6U03FEMW47H4-CX/view?usp=drive_link"">Using the GEOS-Chem adjoint to determine source contributions to ozone exposure metric in the US</a> (Kateryna Lapina, U. Colorado-Boulder)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1dbHuRsIOUqlflpKAtNcTxJOxbCw-xxOY/view?usp=drive_link">An approach to select optimal GEOS-Chem timesteps</a> (Sajeev Philip, Dalhousie)
-	</li>
+    <a href="https://drive.google.com/file/d/1nts6r8k602oS3nXrfA1rIHt6KgKO6g0K/view?usp=drive_link">A parameterization of sub-grid particle formation in sulphur-rich plumes for global and regional scale models</a> (Robin Stevens, Dalhousie)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1RgKcx0aw0mO6rAzafcUmOGVvXHa9Uwgj/view?usp=drive_link">Composition and spatial and temporal patterns of measured PM2.5 in the United States: Important constraints on global model simulations</a> (Bret Schichtel, National Park Service)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1-100_wQOg-UYdtzUxjnxjEEVWDMMLWMs/view?usp=drive_link">Updated dust-iron dissolution mechanism in GEOS-Chem</a> (Nicholas Meskhidze, North Carolina State U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/10lW4a0FdyH6Lfw98l9JydPfAC_4UIHef/view?usp=drive_link">Particle formation and growth in urban and rural environment over Europe: nested GEOS-Chem/APM simulations and comparisons with observations</a> (Gan Luo, SUNY-Albany)
+  </li>
 </ul><h3>
-	<a name="ThuB" id="ThuB"></a>Regional Air Quality (Hiroshi Tanimoto, National Institute for Environmental Studies, Japan, Chair)
+  <a name="MonD" id="MonD"></a>Black Carbon and Related Processes (Fangqun Yu, SUNY-Albany, Chair)
 </h3>
 
-<h4>
-	Presentations
-</h4>
+<h4>Presentations</h4>
 
 <ul><li>
-		<a href="https://drive.google.com/file/d/1qimqe0LIpDlBOM-6l3iSZLZ8LR1B75_8/view?usp=drive_link">Two-way coupling of GEOS-Chem and its multiple nested models: impacts on regional and global atmospheric environment </a>(Jintai Lin, Peking U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1XBfqWPv6dNrPxwxjYKRNMJogNiIHvnDd/view?usp=drive_link">Health Effects of fires in SouthEast Asia estimated using nested-grid GEOS-Chem simulations</a> (Prasad Kasibhatla, Duke)
-	</li>
-	<li>
-		Sensitivity of summertime surface ozone to surface temperature over Southeastern U.S.: interannual variability during 1987-2010 as a diagnostic for model chemical mechanism (Tzung-May Fu, Peking U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Bvh-k3yE6IKUfLctIwtXQi9Y9v7Co6zn/view?usp=drive_link">Improving GEOS-Chem to better match satellite and aircraft observations in Nigeria</a> (Eloise Marais, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1PVVqEeo2QeKxxSD5HkZC9YKQhw5o9Gfs/view?usp=drive_link">Model intercomparison: GEOS-Chem and hemispheric CMAQ</a> (Xinyi Dong, U.Tennessee)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1KaCIi97NkuU38ZjGtm3YwMFQ1zjKKlxI/view?usp=drive_link">Analysis of Toronto pollution using GEOS-Chem and ground-based FTIR observations</a> (Cynthia Whaley, U. Toronto)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1WxtDHk--PSCasay8HtBf-kYGveSTYijc/view?usp=drive_link">Quantifying the contributions of wildfires to surface ozone in the western U.S. and its regional air quality impact</a> (Mei Gao, UCLA)
-	</li>
-</ul><h4>
-	Posters
-</h4>
+    Assessment of the sources and distribution black carbon aerosol over Asia using the adjoint of GEOS-Chem (Li Zhang, U. Colorado-Boulder)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1T_j24YeeUrQks5jtkdfMla7Wp7niaQVp/view?usp=drive_link">Global budget of black carbon: constraints from HIPPO</a> (Qiaoqiao Wang, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1AEUFgW-UiGnGBl6fOxApAbtBzpqz7nQd/view?usp=drive_link">Spatial and temporal distribution Arctic aerosols: comparison between remote sensing, in situ, and GEOS-Chem</a> (Maurizio di Pierro, U. Washington)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1aBnikAKnrGio58YFNw1V3D8wawy-C3vu/view?usp=drive_link">Sensitivity tests with GEOS-Chem aerosol optical properties in comparison with satellite and sunphotometer</a> (Gabriele Curci, U. L'Aquila)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1zZ3yFWFDBqKS9t8Q-LaSZfjpyWJia8bj/view?usp=drive_link">Validation of GEOS-Chem-APM simulated aerosol optical properties using A-Train satellite observations</a> (Xiaoyan Ma, SUNY-Albany)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1I08HBpLp9lqX4KYaeyCCLxEjFH7EZdin/view?usp=drive_link">Top-down estimates of biomass burning emissions of black carbon in the western United States</a> (Yuhao Mao, UCLA)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Bfn1bhtHOMXLaSt9YoSbaogezCledwAd/view?usp=drive_link">Assessment of black carbon in Russia using GEOS-Chem</a> (Joshua Fu, U.Tennessee)
+  </li>
+</ul>
+
+<h4>Posters</h4>
+
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/18SrQKfVhYDYLcz6XpBi1ViviLtwVFz5z/view?usp=drive_link">Influence of aging and mixing state to black carbon radiative forcing</a> (Xuan Wang, MIT)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1vtVAyXxBSDsiRAGPNRDX8FJM2Btj7go0/view?usp=drive_link">Global simulation of brown carbon and its direct radiative forcing</a> (Duseong Jo, Seoul National U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1UqYdOoRgi6qffWiYqiSKvkeXvWXMUp7U/view?usp=drive_link">Missing black carbon emissions in Russia - new BC emissions for GEOS-Chem</a> (Kan Huang, U. Tennessee)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1UYuEU64gVj6lQNg-LOSLU2AslnLg_75i/view?usp=drive_link">Improving Aerosol Scavenging in GEOS-Chem</a> (Jessica Kunke, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1EyVtT5rklCsBl7QPoE3aG3HcwzaNi9pD/view?usp=drive_link">Contribution of agricultural burning to Arctic BC aerosols</a> (Ling Qi, UCLA)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1SNcKA9A8K3Ax6I3e-ZaPkYZUNvqkwjvk/view?usp=drive_link">Simulating the emission and transport of smoke related species in Southeast Asia using the GEOS-Chem nested grid model</a> (Shannon Koplitz, Harvard)
+  </li>
+</ul>
+
+<h3>Model Clinics</h3>
 
 <ul><li>
-		<a href="https://drive.google.com/file/d/1n7--b68cpgma93Jj3x-XFrwJq-i-ezGD/view?usp=drive_link">Sources and transport pathways of pollution in Australasia</a> (Jenny Fisher, U. Wollongong)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1qFQiUUSPsL1qza4ie8DHu9pDHBio7xlW/view?usp=drive_link">Scaling relationship for NO2 pollution and population: A satellite perspective</a> (Lok Lamsal, NASA GSFC)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Es3ICtHQvRkrm8OCLxdvlyh3espd8SXg/view?usp=drive_link">Impact of southern California anthropogenic emissions on air quality in the Western US</a> (Min Huang, CalTech/JPL)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1CjPlif-G64TGdC-RZX-qwhos5sXsfw_q/view?usp=drive_link">Simulation of the interannual variations of PM2.5 in China: Role of meteorology</a> (Qing Mu, Chinese Academy of Sciences)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1jozfnTBTYzEPL64rgM7n3fsa5AXU3dUd/view?usp=drive_link">Recent regional variability of tropospheric composition in boundary layer and free troposphere over East Asia</a> (Ka-Ming Wai, Michigan Tech)
-	</li>
-	<li>
-		Nested GEOS-Chem adjoint (Irene Dedoussi, MIT)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/13sryUs1vYtz_fTm80Wor_5BWGaiLJeXB/view?usp=drive_link">Cargo ship monitoring of trace gases in Southeast Asia and comparison to GEOS-Chem model</a> (Hiroshi Tanimoto, National Institute for Environmental Studies, Japan)
-	</li>
-	<li>
-		OMI data for NOx, O3, and HCHO over the Amazon (Mike Kendall, U. Leicester)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1j1dssTgp9xnjwTDY5uyaXPzC7Hq-n44O/view?usp=drive_link">Extreme weather events and air quality by CESM and WRF/CMAQ</a> (Yang Gao, U.Tennessee)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Xwq__vcgBNztai68Y-P4tN3H6rV8NSYB/view?usp=drive_link">Variability of aerosol optical depths over North China during haze and non-haze events based on satellite retrieval and the GEOS-Chem model</a> (Libao Chai, Tsinghua U.)
-	</li>
+    <a href="https://drive.google.com/file/d/1RBVySIKABH-v-jJG-Y1nO53YpCSkk0fv/view?usp=drive_link">GEOS-Chem model clinic</a> (Melissa Payer, Sajeev Philip)
+  </li>
+  <li>
+    Adjoint GEOS-Chem model clinic (Daven Henze, Yanko Davila)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1CE0duiCVIx8a5xbejaOZ-Ztwjph0_gUe/view?usp=drive_link">Q&amp;A for the GEOS DAS and the Grid-Independent GEOS-Chem</a> (Steven Pawson, Andrea Molod, Bob Yantosca, Mike Long)
+  </li>
+</ul>
+
+<h2>Tuesday 07 May 2013</h2>
+
+<h3>
+  <a name="TueA" id="TueA"></a>Aerosol Effects on Climate and Air Quality (May Fu, Peking U., Chair)
+</h3>
+
+<h4>Presentations</h4>
+
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1ryO--neL4zg8Ozt18y1Fr3KYcF8pbh-I/view?usp=drive_link">Radiative impact of decadal trends in near-term climate forcers over the Arctic troposphere: A significant role for non-BC species</a> (Tom Breider, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Ti36ZJ9otZkHxVv0XmYKKaTbpvpeXnXD/view?usp=drive_link">Study of aerosol first indirect radiative forcing with GEOS-Chem</a> (Fangqun Yu, SUNY-Albany)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1gEfoADxMKxSrKWJcvZWXxMv-JrVMP7iy/view?usp=drive_link">Optimal estimation of high resolution global PM2.5 concentrations using GEOS-Chem and MODIS</a> (Aaron van Donkelaar, Dalhousie)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1j7P3omOyF0XcUICn36KS5YdhY3wHGEhj/view?usp=drive_link">Time series analysis of satellite derived PM2.5</a> (Brian Boys, Dalhousie)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/12xKKGyH9SNgWM75HRzOI2R7prkEgxtYU/view?usp=drive_link">Aerosol simulation over China</a> (Yuxuan Wang, Tsinghua U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1GT0s16Fb-LeQui3Xu8UDAzawvKiHs0Ib/view?usp=drive_link">Effects of the meteorological variability on aerosol trends in East Asia</a> (Rokjin Park, Seoul National U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1DiTOePsqcPlntBf5UsvIYjib5YhOWVVp/view?usp=drive_link">Sensitivity of global mortality to PM2.5 precursor emissions using the GEOS-Chem adjoint</a> (Colin Lee, Dalhousie)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1bg5uIMuHIJwF22gBjoWEBzaRdMBrHHET/view?usp=drive_link">Modeling of volcanic sulfate direct radiative forcing with Geos-Chem</a> (Cui Ge, U.Nebraska Lincoln)
+  </li>
+</ul>
+
+<h4>Posters</h4>
+
+<ul><li>
+    <a href="https://drive.google.com/file/d/17J8-qMMneWvEAszA076YDDR82CQnhhis/view?usp=drive_link">The perfect dust storm over South West Asia June 2008: causes determined from surface and satellite observations compared with high resolution DEAD emissions and GEOS-Chem output</a> (Kevin Bartlett, Air Force Institute of Technology)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1gZ1FJUn_LDeI3nCM_H-ZlC0j3QZovBJq/view?usp=drive_link">Insights on aerosol lifetimes and wet scavenging following the Fukushima nuclear accident</a> (Betty Croft, Dalhousie)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1dxPg8ZgLjs2FK_yLZOFTXuPHQjcIa0mB/view?usp=drive_link">Investigation into future radiative forcing sensitivities using GEOS-Chem and its adjoint based on RCPs</a> (Forrest Lacey, U. Colorado-Boulder)
+  </li>
+  <li>
+    A decade of global PM2.5 estimates (David Lary, U.Texas-Dallas)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1aMtWE1t2oiEt4pBSeByuhB4NfaHkgoUS/view?usp=drive_link">GEOS-Chem satellite simulator</a> (Jun Wang, U. Nebraska-Lincoln)
+  </li>
+</ul><h3>
+  <a name="TueB" id="TueB"></a>Mercury and Persistent Organic Pollutants (Chris Holmes, UC Irvine, Chair)
+</h3>
+
+<h4>Presentations</h4>
+
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/12B6yloTS701qV25i27s_66wg9wNNi9oJ/view?usp=drive_link">Influence of future emissions and climate on atmospheric PAH transport</a> (Carey Friedman, MIT)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1cj1FSN5r1ONz-lKdZo4ORG78SkG4ev4R/view?usp=drive_link">Impacts of recent changes in climate and emissions on mercury variability in the Arctic</a> (Jenny Fisher, U. Wollongong)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1KaciHbPX_WEObDupFsdiI8kv_mbTkfs2/view?usp=drive_link">Historical releases of mercury from wastewater: global importance and influence on atmospheric trends</a> (Helen Amos, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1cjpcaJLLnsyII1qLCFvB-CCbU5SG9lKi/view?usp=drive_link">Terrestrial Mercury Dynamics</a> (Bess Sturges Corbitt, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1VPaFQd3wOg9lwk-d0yQUn2w3WoztK2N0/view?usp=drive_link">Methylmercury in the Arctic Surface Ocean</a> (Anne Laerke Soerensen, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1LeUuWewkUShOku4bhlek-g4C6_QKcXSt/view?usp=drive_link">Quantifying uncertainties of the global mercury cycle using the GEOS-Chem model and observations</a> (Shaojije Song, MIT)
+  </li>
+</ul>
+<h4>Posters</h4>
+
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1YBs-y24xV8yO3umu8bahIk4A6LBieEth/view?usp=drive_link">Modeling the fate of mercury in products</a> (Hannah Horowitz, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1bUGhZycD3EhTm47aH8XTIXxVDRTs0aPx/view?usp=drive_link">Polynomial Chaos Expansion for chemical parameter uncertainty quantification in PAH simulations</a> (Colin Pike-Thackray, MIT)
+  </li>
+  <li>
+    Integrated assessment of the health impacts of the Mercury and Air Toxics Standards (Amanda Giang, MIT)
+  </li>
+</ul>
+
+<h3><a name="TueC" id="TueC"></a>Chemistry-Climate (Lin Zhang, Peking U., Chair)</h3>
+
+<h4>Presentations</h4>
+
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1xFSuuUIrwMdlFPr4IGsLrsSEFEBFflSD/view?usp=drive_link">Factors controlling variability in the oxidative capacity of the troposphere since the Last Glacial Maximum</a> (Lee Murray, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1PRGKEYGUWkCrhz3hse_xK3B-QCYeOmbm/view?usp=drive_link">Implications of climate change for intercontinental transport in the past decade</a> (Shiliang Wu, Michigan Tech)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/167RZN5AAleNM3gfviDdQJxkw8hL5bufT/view?usp=drive_link">Impact of 2000-2050 climate and vegetation changes on air quality: including CO inhibition of isoprene emissions in GEOS-Chem</a> (Amos Tai, MIT)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Lzar_xv4x_VIA_LiJJh4u7dUxLQJ0gdF/view?usp=drive_link">Australasian total column CO and HCHO, investigated with GEOS-Chem, FTIR measurements and the Earth System Model ACCESS</a> (Rebecca Buchholz, U. Wollongong)
+  </li>
+</ul>
+
+<h4>Posters</h4>
+
+<ul>
+  <li>
+    On-line simulation of tropospheric ozone with the climate-chemistry model BCC-AGCM- CHEM1.0 (Tongwen Wu, Beijing Climate Center)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/13g_-FpLrh4HiGc5d31zW-I7nIm05T4vL/view?usp=drive_link">Preparation for the SEAC4RS aircraft campaign</a> (Karen Yu, Harvard)
+  </li>
+  <li>
+    Calculating stratospheric chemistry and aerosols with GMI (Debra Weisenstein, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1JU83tw_V0IK1eMQ42jWCXd53TmRg_FLT/view?usp=drive_link">A statistical approach for downscaling GISS/GEOS-CHEM</a> (Konstantinos Varotsos, National and Kapodistrian U. of Athens / National Observatory of Athens)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1_R6ocMy6iW_DEtkDtHV5J6gcNBOIR0Tg/view?usp=drive_link">NOAA's Atmospheric Chemistry, Carbon Cycle, and Climate (AC4) competitive research program</a> (Monika Kopacz, NOAA Climate Program Office)
+  </li>
+  <li>
+    Evaluation of tropospheric composition in Yale-E2 (Hongyan Dang, Yale U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1En4N4BYhs9-h1TiFP8lmPNk2YiOBCGqp/view?usp=drive_link">Development of GEOS-Chem driven by CESM meteorological data: effects of future climate change on air quality</a> (Minjoong Kim, Seoul National U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/10Ol0AHVm69wc9Aa9oexro_MjUG-KfGJ3/view?usp=drive_link">Assessment of the sensitivity of sulfate isotopes to climate and chemistry on the glacial- interglacial timescale using GEOS-Chem</a> (Eric Sofen, U. Washington)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Nm_aFLW30lv0GRFr_zRl7i7kmIFQbzSO/view?usp=drive_link">Increasing the Efficiency of GEOS-Chem adjoint simulations using a Python Ensemble Manager</a> (Andre Perkins, U. Wisconsin-Madison)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1ffZxn7HwKcsbZf_OMM8vfP9hFjSWtxwT/view?usp=drive_link">Novel methods of understanding our atmosphere</a> (Dene Bowdalo, U. York)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/15Ch4j41C4zeg-mNV4njL2XyNKo3Unx5n/view?usp=drive_link">Attribution of direct ozone radiative forcing to spatially resolved emissions</a> (Kevin Bowman, JPL)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1120YRBJDLL7-dSztaylp3tgcLXrU12GV/view?usp=drive_link">Radiative forcing of early 20th-century US aerosols</a> (Eric Leibensperger, SUNY-Plattsburgh)
+  </li>
+</ul>
+
+<h2>Wednesday 08 May 2013</h2>
+
+<h3><a name="WedA" id="WedA"></a>Sources and Sinks: Nitrogen (Folkert Boersma, KNMI, Chair)</h3>
+
+<h4>Presentations</h4>
+
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1u6QfROuUyLYKORZ5_H9UTriHUIK5I9c8/view?usp=drive_link">Top-down constraints on ship NOx emissions in European waters from OMI</a> (Geert Vinken, Eindhoven U. of Technology)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1btiGjXqaE1AKsBHWqzThxPfW4Y7kABHU/view?usp=drive_link">Top-down and bottom-up constraints on NH3 emissions</a> (Fabien Paulot, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1b8so3BJAi6pGSvYdmFwcIuRtPaHrTrhg/view?usp=drive_link">Present and future nitrogen deposition to US National Parks: Critical load exceedances</a> (Raluca Ellis, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1ijChE3xEtTCttRIkOLITODWZ1UhcejpK/view?usp=drive_link">Implementation of a plume-in-grid model into GEOS-Chem to improve sub-grid processes related to lightning NOx emissions</a> (Alicia Gressent, U. de Toulouse)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1XbaDUok7UoyXLqRp22vJsyGGUVEiq2kQ/view?usp=drive_link">Evaluation of ammonia bi-directional exchange with GEOS-Chem</a> (Juliet (Liye) Zhu, U. Colorado-Boulder)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1phRQT_lUh09avPxZ0yQP-PruEaWjUu2T/view?usp=drive_link">Investigating the sources of nitrate in Antarctica using GEOS-Chem and its adjoint </a>(Hyung-Min Lee, U.Colorado-Boulder)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1m42EJx0U8mDiSA2Z-mFdN3jq6JuVq9su/view?usp=drive_link">Refining nested GEOS-Chem emissions during the CalNex campaign by assimilation of TES ammonia observations</a> (Shannon Capps, US EPA AMAD)
+  </li>
+</ul>
+
+<h4>Posters</h4>
+
+<ul><li>
+    <a href="https://drive.google.com/file/d/1t2E3Anj1GjdMDCzyA6vzN_-FMhsctS7b/view?usp=drive_link">Investigating the impact of snowpack photodenitrification on polar atmospheric chemistry utilizing results from a snowpack radiative transfer model in GEOS-Chem</a> (Maria Zatko, U. Washington)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1GBxgU5g5ZHRNXKK_hLix27yem7SpnK0T/view?usp=drive_link">Analysis of NOx Emission Trend over East Asia - GEOS-Chem, Satellite and REAS emission</a> (Itsushi Uno, Kyushu U.)
+  </li>
+  <li>
+    How to quantify and avoid errors in evaluating CTMs with UV/Vis satellite retrievals (Folkert Boersma, KNMI / Eindhoven U. of Technology)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1SMLZOjw6OQB-4JQTvra0_cVME79bm9iC/view?usp=drive_link">Lightning NOx Statistics Derived by NASA Lightning Nitrogen Oxides Model (LNOM) Data Analyses</a> (William Koshak, NASA MSFC)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/15QWVaImpC3Riboxggko7y7AIF5A_wOxO/view?usp=drive_link">An investigation of ammonia and inorganic particulate matter in California during the CalNex campaign</a> (Luke Schiferl, MIT)
+  </li>
+  <li>
+    Daily ammonia maps from AIRS and comparison with GEOS-Chem (Juying Warner, AOSC/UMCP)
+  </li>
+  <li>
+    Fire emissions associated with future land use change in Indonesia (Miriam Marlier, Columbia)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1_Ms6Q83CjNADjrpNYRBXUmmvfIZikewN/view?usp=drive_link">NO2 and SO2 dry deposition inferred from satellite measurements</a> (Caroline Nowlan, Dalhousie)
+  </li>
+  <li>
+    Retrieving NOx from space: errors in satellite NO2 products and CTM simulations (Jintai Lin, Peking U.)
+  </li>
+</ul><h3>
+  <a name="WedB" id="WedB"></a>Carbon Dioxide Fluxes (Monika Kopacz, NOAA, Chair)
+</h3>
+
+<h4>Presentations</h4>
+
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/18JTUVmkSsqg1fVH9OkYTuBh-VwmnLMJs/view?usp=drive_link">Using GEOS-Chem within a grid-based EnKF system to estimate carbon fluxes from NOAA surface data and GOSAT data</a> (Andrew Schuh, Colorado State U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1IehMmn2LftVMOKz4zCPCLnH9pSwIt3A4/view?usp=drive_link">Attribution of atmospheric CO2 to surface fluxes with the Carbon Monitoring System Flux Pilot project</a> (Kevin Bowman, JPL)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1FNF3UEXdeHqbXbsJaI2XoRv3ZU0NrD6C/view?usp=drive_link">Quantifying the impact of model errors on top-down CO flux estimates</a> (Dylan Jones, U. Toronto)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/19p_ydcHX1RKQI0jGu9lWGsRUnGf4FL-o/view?usp=drive_link">Temporal and spatial scale factors for fossil fuel CO2</a> (Ray Nassar, Environment Canada)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/17m3LL77m_UW_EorUDO62v1YHMqTqYPly/view?usp=drive_link">Estimates of CO2 surface fluxes using an atmospheric inversion method</a> (Chen Zhaohui, Chinese Academy of Sciences)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1-OV_y20k23m08TrxtyNdksFEKWsEcXX1/view?usp=drive_link">Continental sources/sinks manifest the seasonal and latitudinal gradient of atmospheric CO over East Asia</a> (Changsub Shim, Korea Environment Institute)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1vcH6lFRfnlpayVKHoDON-lNNTZ2AEMEA/view?usp=drive_link">GEOS-Chem simulations of global CO2 concentrations at horizontal resolution of 0.5x0.666 degrees</a> (Liang Feng, U. Edinburgh)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Xmffs_7G6aRmKzUsPr9vAA9J6QkOlQ-Y/view?usp=drive_link">Interannual variability in atmospheric CO2 from generalized surface fluxes</a> (Gretchen Keppel-Aleks, UC Irvine)
+  </li>
+  <li>
+    Quantifying terrestrial carbon fluxes using surface and satellite observations (Feng Deng, U. Toronto)
+  </li>
+</ul>
+
+<h4>Posters</h4>
+
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1Z9K_1KyrCp6xTgb-OFMa_qCKLqQpd_Ks/view?usp=drive_link">Estimating surface CO2 flux with simulated ACOS-GOSAT observations</a> (Junjie Liu, JPL)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1eeBXG2G6LCzx57RdPV6Sp6YGDf7rfSU0/view?usp=drive_link">Understanding model errors of GEOS-Chem CO2 and CO simulations</a> (Helen Wang, Harvard-Smithsonian)
+  </li>
+  <li>
+    Constrain terrestrial surface CO2 fluxes by combing both atmospheric transport model and process-based terrestrial model (Qing Zhu, Purdue)
+  </li>
+  <li>
+    Inverse modeling of terrestrial ecosystem carbon sinks and sources over China (Hengmao Wang, Nanjing U.)
+  </li>
+</ul><h3>
+  <a name="WedC" id="WedC"></a>Sources of other Carbon Gases (Ray Nassar, Environment Canada, Chair)
+</h3>
+
+<h4>Presentations</h4>
+
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1GCeqSWaNw2-1GurPrGWwHMp4ouLXGFGb/view?usp=drive_link">A uniform emissions pre-processor for GEOS-Chem</a> (Qiang Zhang, Tsinghua U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1PoGIGE48nNdUvhDEn-r0ZaQXTOdljny1/view?usp=drive_link">Nested Adjoint Inversion of Methane Sources in North America</a> (Kevin Wecht, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1FxkE3NEpXBNukrp_Squ4tGCc99nwq9N4/view?usp=drive_link">Top-down constraints on sources and impacts of atmospheric organic acids</a> (Dylan Millet, U. Minnesota)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1-yjlDBK1LVd8Xu7u56h_Ed0wDJngIJ3O/view?usp=drive_link">Quantifying surface emissions of methanol using observations from the Tropospheric Emission Spectrometer</a> (Kelley Wells, U. Minnesota)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Gco_JPMBssf_MGZ9LX15SejgYgbv25UZ/view?usp=drive_link">Methane in the 21st century: Projections for RCP scenarios in GEOS-Chem</a> (Chris Holmes, UC Irvine)
+  </li>
+  <li>
+    Estimate of tropical fire emissions from the 2006 Indonesian Peat fires using Aura TES CH4 and CO data and the GEOS-Chem model (John Worden, JPL/Caltech)
+  </li>
+  <li>
+    The methane emissions from Pan-Arctic lakes estimated using the adjoint of GEOS-Chem (Zeli Tan, Purdue)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1NwgCOLFqs8dCMWFCt-SJPc1J2idThIdC/view?usp=drive_link">Inverse estimate of long-term CO emission in China between 2005–2010 with Green's Function Method</a> (Keiya Yumimoto, Japan Meteorological Agency)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1jScSloGSjT4uN2-c0iBIdhOcvyO8-51F/view?usp=drive_link">Top-down isoprene emission estimates over the US Midwest using tall tower measurements and GEOS-Chem nested grid simulations</a> (Lu Hu, U. Minnesota)
+  </li>
+</ul>
+
+<h4>Posters</h4>
+
+<ul><li>
+    The potential of glyoxal as a second top-down constraint on NMVOC emissions (Chris Miller, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Uz6HbNyG94nISavhyiob_1NHjBSRREt1/view?usp=drive_link">Methane emissions from fracking</a> (Brian Nathan, U. Texas-Dallas)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1j5oZiifP-rkt3qClKqc-6nL-MFIQFLxS/view?usp=drive_link">Variability of formaldehyde over the Southeastern United States from space: Implications for isoprene emissions</a> (Lei Zhu, Harvard)
+  </li>
+  <li>
+    Regional data assimilation of multispectral MOPITT observations of CO over North America (Zhe Jiang, U. Toronto)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1rfCUqx4bY8REQ26DY-ae_Sp4_qq3cZum/view?usp=drive_link">Using GEOS-Chem to better understand isoprene nighttime chemistry</a> (Rebecca Schwantes, Caltech)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1mOsn0kLHAmFcoqyZX41VIwOZ6R7yf4Q0/view?usp=drive_link">Source attribution of observed CO variability during BORTAS-B using GEOS-Chem</a> (Douglas Finch, U. Edinburgh)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1sSu9CkhwltJMCsMoSLZ-GHnDs8hzK21c/view?usp=drive_link">Characterization of information content and errors in inverse models of methane</a> (Alex Turner, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1q5zJbFDphg1NNyj7r1Y-CmfgUUuk11aj/view?usp=drive_link">Global distribution of formic acid from TES: Retrieval evaluation and implications for sources</a> (Sreelekha Chaliyakunnel, U. Minnesota)
+  </li>
+  <li>
+    Vegetation change and biogenic trace gas emissions: potentials for modifying source terms for GEOS-Chem (Manuel Lerdau, U. Virginia)
+  </li>
+</ul>
+
+<h2>Thursday 09 May 2013</h2>
+
+<h3><a name="ThuA" id="ThuA"></a>Tropospheric Ozone and Photochemistry (Rokjin Park, Seoul National U., Chair)</h3>
+
+<h4>Presentations</h4>
+
+<ul><li>
+    <a href="https://drive.google.com/file/d/1tK5L_1WOLC5a8OX-1Ztz8vPLtVEDbFh0/view?usp=drive_link">Global ozone-CO correlations from OMI and AIRS as constraints on ozone sources and transport</a> (Patrick Kim, Harvard)
+  </li>
+  <li>
+    The GEOS-Chem PAN simulation (Emily Fischer, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Cxy0I1KeLhd_1ogtO0nQBqmO3eT2FdXM/view?usp=drive_link">Ozone and organic nitrates over the eastern United States: sensitivity to isoprene chemistry</a> (Jingqiu Mao, NOAA GFDL)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1KIuBavTTiEZ58fhE7rg_aM98Zw25Ojl3/view?usp=drive_link">Assessing the atmospheric impacts of aviation with GEOS-Chem</a> (Steven Barrett, MIT)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1MEfZEEAAZrMp5wcdiazi5v1olU-vCMqS/view?usp=drive_link">Observing North American background ozone from geostationary orbit</a> (Peter Zoogman, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1IopY9B_PoOkjyHw10UucfuvL7m6YNdpa/view?usp=drive_link">Source attribution of North American background ozone concentrations in the Intermountain West</a> (Lin Zhang, Peking U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1bcZO6wkQTdkQTNAH8vCrf-W0x0C-iGiA/view?usp=drive_link">Integrating in situ and satellite observations with GEOS-Chem to constrain the influence of boreal biomass burning emissions on tropospheric oxidant chemistry</a> (Mark Parrington, U. Edinburgh)
+  </li>
+  <li>
+    Understanding the interannual variations of tropospheric O3 and aerosols using the GEOS-Chem model (Hong Liao, Chinese Academy of Sciences)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/19pQT4TURZxfsTAeFFEpJoJA69SyD8uW2/view?usp=drive_link">Impacts of aerosols on concentrations of tropospheric ozone in China through heterogeneous reactions and changes in photolysis rates</a> (Sijia Lou, Chinese Academy of Sciences)
+  </li>
+</ul>
+
+<h4>Posters</h4>
+
+<ul>
+  <li>
+    Characterizing the variability of STE in the UTLS (Dave MacKenzie, U. Toronto)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1u7S9fXrRaS-DaZwYpZ4EvFQkjX73uxB0/view?usp=drive_link">Dynamic effects of upper tropospheric ozone</a> (Matthew Cooper, Dalhousie)
+  </li>
+  <li>
+    Impact of meteorology and emissions on the interannual variation of tropospheric ozone over the South America and surrounding oceans (Junhua Liu, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1vK3FxdnteztbxkNlDXQ0XelQAXxcHMTk/view?usp=drive_link">Improved background ozone modeling with Geos-Chem</a> (Katherine Travis, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1S-uYh6SDbSOkNxWZ2VbSrJ4einHF-WTR/view?usp=drive_link">Meteorological modes driving surface O3 variability over the United States</a> (Lulu Shen, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1sOwYtB_x1ftUimuSHUuIM0nHQi7Hz3F_/view?usp=drive_link">Iodine in the troposphere</a> (Tomás Sherwen, U. York)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1yYx0y7OfxnQRCtLPSU_kv9CXNwxJgyZY/view?usp=drive_link">O-17 excess of nitrate and sulfate from last glacial period to preindustrial Holocene: implications for glacial-interglacial atmospheric oxidant change</a> (Lei Geng, U. Washington)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1btXfs9yQ_kW_hphgcIVASIRrDxTQr2DZ/view?usp=drive_link">Tropospheric O3 intraseasonal variability over South Asia: IASI observations and GEOS-Chem simulations</a> (Bastien Sauvage, U. Toulouse)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1AchEnX9ZoCVbbPz3mLjBs37xPmNfOcWU/view?usp=drive_link">Overview of the geophysical data derived from long-term FTIR monitoring at the Jungfraujoch NDACC site (46.5ºN)</a> (Emmanuel Mahieu, U. Liège -Belgium)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1N1cmXDFnb62hTaQkz4pxbSC7UzB_FRu0/view?usp=drive_link">Radical loss in the atmosphere from Cu-Fe redox coupling in aerosols</a> (Jingqiu Mao, NOAA GFDL)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/14VEcb6twqPTUU082E6U03FEMW47H4-CX/view?usp=drive_link">Using the GEOS-Chem adjoint to determine source contributions to ozone exposure metric in the US</a> (Kateryna Lapina, U. Colorado-Boulder)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1dbHuRsIOUqlflpKAtNcTxJOxbCw-xxOY/view?usp=drive_link">An approach to select optimal GEOS-Chem timesteps</a> (Sajeev Philip, Dalhousie)
+  </li>
+</ul><h3>
+  <a name="ThuB" id="ThuB"></a>Regional Air Quality (Hiroshi Tanimoto, National Institute for Environmental Studies, Japan, Chair)
+</h3>
+
+<h4>Presentations</h4>
+
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1qimqe0LIpDlBOM-6l3iSZLZ8LR1B75_8/view?usp=drive_link">Two-way coupling of GEOS-Chem and its multiple nested models: impacts on regional and global atmospheric environment </a>(Jintai Lin, Peking U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1XBfqWPv6dNrPxwxjYKRNMJogNiIHvnDd/view?usp=drive_link">Health Effects of fires in SouthEast Asia estimated using nested-grid GEOS-Chem simulations</a> (Prasad Kasibhatla, Duke)
+  </li>
+  <li>
+    Sensitivity of summertime surface ozone to surface temperature over Southeastern U.S.: interannual variability during 1987-2010 as a diagnostic for model chemical mechanism (Tzung-May Fu, Peking U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Bvh-k3yE6IKUfLctIwtXQi9Y9v7Co6zn/view?usp=drive_link">Improving GEOS-Chem to better match satellite and aircraft observations in Nigeria</a> (Eloise Marais, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1PVVqEeo2QeKxxSD5HkZC9YKQhw5o9Gfs/view?usp=drive_link">Model intercomparison: GEOS-Chem and hemispheric CMAQ</a> (Xinyi Dong, U.Tennessee)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1KaCIi97NkuU38ZjGtm3YwMFQ1zjKKlxI/view?usp=drive_link">Analysis of Toronto pollution using GEOS-Chem and ground-based FTIR observations</a> (Cynthia Whaley, U. Toronto)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1WxtDHk--PSCasay8HtBf-kYGveSTYijc/view?usp=drive_link">Quantifying the contributions of wildfires to surface ozone in the western U.S. and its regional air quality impact</a> (Mei Gao, UCLA)
+  </li>
+</ul>
+
+<h4>Posters</h4>
+
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1n7--b68cpgma93Jj3x-XFrwJq-i-ezGD/view?usp=drive_link">Sources and transport pathways of pollution in Australasia</a> (Jenny Fisher, U. Wollongong)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1qFQiUUSPsL1qza4ie8DHu9pDHBio7xlW/view?usp=drive_link">Scaling relationship for NO2 pollution and population: A satellite perspective</a> (Lok Lamsal, NASA GSFC)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Es3ICtHQvRkrm8OCLxdvlyh3espd8SXg/view?usp=drive_link">Impact of southern California anthropogenic emissions on air quality in the Western US</a> (Min Huang, CalTech/JPL)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1CjPlif-G64TGdC-RZX-qwhos5sXsfw_q/view?usp=drive_link">Simulation of the interannual variations of PM2.5 in China: Role of meteorology</a> (Qing Mu, Chinese Academy of Sciences)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1jozfnTBTYzEPL64rgM7n3fsa5AXU3dUd/view?usp=drive_link">Recent regional variability of tropospheric composition in boundary layer and free troposphere over East Asia</a> (Ka-Ming Wai, Michigan Tech)
+  </li>
+  <li>
+    Nested GEOS-Chem adjoint (Irene Dedoussi, MIT)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/13sryUs1vYtz_fTm80Wor_5BWGaiLJeXB/view?usp=drive_link">Cargo ship monitoring of trace gases in Southeast Asia and comparison to GEOS-Chem model</a> (Hiroshi Tanimoto, National Institute for Environmental Studies, Japan)
+  </li>
+  <li>
+    OMI data for NOx, O3, and HCHO over the Amazon (Mike Kendall, U. Leicester)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1j1dssTgp9xnjwTDY5uyaXPzC7Hq-n44O/view?usp=drive_link">Extreme weather events and air quality by CESM and WRF/CMAQ</a> (Yang Gao, U.Tennessee)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Xwq__vcgBNztai68Y-P4tN3H6rV8NSYB/view?usp=drive_link">Variability of aerosol optical depths over North China during haze and non-haze events based on satellite retrieval and the GEOS-Chem model</a> (Libao Chai, Tsinghua U.)
+  </li>
 </ul>
 
 </div>
@@ -805,64 +773,16 @@
 </div>
 </div>
 
-<!--footer region beg-->
+<!--footer-->
 <footer id="footer" class="clearfix" role="contentinfo">
-
-<!-- Three column 3x33 Gpanel -->
-<div class="at-panel gpanel panel-display footer clearfix">
-<div class="region region-footer">
-<div class="region-inner clearfix">
-<div id="block-boxes-1617037690" class="block block-boxes block-boxes-os_boxes_html no-title"  module="boxes" delta="1617037690">
-<div class="block-inner clearfix">  
-<div class="block-content content" ng-non-bindable="">  
-<div id='boxes-box-1617037690' class='boxes-box'>  
 <div class="boxes-box-content">
   <p style="text-align:center">
-    Copyright © 2023 by the International GEOS-Chem Community. All rights reserved.
+    Copyright © 2026 by the International GEOS-Chem Community. All rights reserved.
   </p>
 </div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-<div class="region region-footer-bottom">  
-<div class="region-inner clearfix">  
-<div id="block-boxes-1616879798" class="block block-boxes block-boxes-os_boxes_media no-title"  module="boxes" delta="1616879798">  
-<div class="block-inner clearfix">  
-<div class="block-content content"> 
-<div id='boxes-box-1616879798' class='boxes-box'> 
-<div class="boxes-box-content"> 
-<div id="file-3900146" class="file file-html file-html-embed">
-<h2 class="element-invisible"><a href="">css-brand</a></h2>
-<div class="content">
-<div class="file-info">
-</div>
-<div class="field field-name-field-html-code field-type-text-long field-label-hidden view-mode-full">
-<div class="field-items">
-<div class="field-item even">
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-
-<!--footer region end-->
 </footer>
-</div>
-</div>
 
-<!--page area ends-->
-<div id="extradiv"></div>
+</div>
 </div>
 
 </body>

--- a/igc6.html
+++ b/igc6.html
@@ -1,9 +1,4 @@
 <!DOCTYPE html>
-<!--[if IEMobile 7]><html class="iem7"  lang="en" dir="ltr"><![endif]-->
-<!--[if lte IE 6]><html class="lt-ie9 lt-ie8 lt-ie7"  lang="en" dir="ltr"><![endif]-->
-<!--[if (IE 7)&(!IEMobile)]><html class="lt-ie9 lt-ie8"  lang="en" dir="ltr"><![endif]-->
-<!--[if IE 8]><html class="lt-ie9"  lang="en" dir="ltr"><![endif]-->
-<!--[if (gte IE 9)|(gt IEMobile 7)]><!--><html  lang="en" dir="ltr"><!--<![endif]-->
 <head>
 <meta charset="utf-8" />
 <!--<base href="/igc6" />-->
@@ -18,23 +13,12 @@
 <title>The 6th International GEOS-Chem Meeting</title>
 <meta http-equiv="x-ua-compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<link type="text/css" rel="stylesheet" href="css/css_xE-rWrJf-fncB6ztZfd2huxqgxu4WO-qwma6Xer30m4%EF%B9%96m=1675397288.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_1kR8T1_c-l5pBT6ZwbDT7BFda-4fyqW9Jjum29_2IY8%EF%B9%96m=1675397312.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_YnlUIvHP13qgpYEqubzE8JyDwlSxUnVibfnVkSoSDb0%EF%B9%96m=1675397273.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_Ku-3OcT9qU9h7dnGig5e23q6EVryY8orK4wzVDxsweE%EF%B9%96m=1675397367.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_vprtFTrWyg23GbY50_zJZHWGYMNfS8vsrRS26i4-ISk%EF%B9%96m=1675397406.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_dW-aNNrctRhQNc-KECjtQd0PxuW-h19IEum-TX2MeEk%EF%B9%96m=1675397301.css" media="print" />
-<link type="text/css" rel="stylesheet" href="css/css_SH2Lx3Qprh0GZo_9xRp85U9NsWfkSXn_Bi-rJoMY1sw%EF%B9%96m=1675397273.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_uaIDKcYMUK5osSQXuirpr3ZleXtnnpBN-eiECm7N0M0%EF%B9%96m=1675397395.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/responsive.blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/geos-chem.css" media="all"/>
 <script type="text/javascript" src="dropdown-menu.js"></script>
-<!--[if lte IE 8]>
-<script type="text/javascript">
-  var os_c = document.createElement;os_c('header');os_c('nav');os_c('section');os_c('article');os_c('aside');os_c('footer');os_c('hgroup');os_c('figure');
-</script>
-<![endif]-->
 </head>
 
 <body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-1585687 node-type-page og-context og-context-node og-context-node-1585652 navbar-on">
@@ -45,22 +29,20 @@
 <div id="page_wrap" class="page_wrap">
 <div id="page" class="container page header-main content-top footer-none">
 <div id="page-wrapper">
-		
+
 <!--header regions beg-->
 <header id="header" class="clearfix" role="banner">
 <div id="header-container">
 <div id="header-panels" class="at-panel gpanel panel-display three-col clearfix">
 <div class="region region-header-second"><div class="region-inner clearfix">
 <section id="block-boxes-1630413211" class="block block-boxes block-boxes-os_boxes_html"  module="boxes" delta="1630413211">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <h2 class="block-title" ng-non-bindable="">Site-Logo</h2>
 <div class="block-content content" ng-non-bindable="">
 <div id='boxes-box-1630413211' class='boxes-box'>
 <div class="boxes-box-content">
-<img height="551" width="1101" style="float: right; width: 350px; height: 175px; margin-bottom: 1.5em;" alt="gca2 logo" class="media-element file-default file-os-files-xxlarge" src="img/igc-early-logo.png" title="" />
-<h2 class="css-brand--css-geos-meetings-header-h2-xxxlarge">
-  The 6th International GEOS-Chem Meeting (IGC6) May 6-9 2013
-</h2>
+<a href="https://geoschem.github.io/"><img height="600" width="1034" style="float: right; width: 350px; height: 203px;" class="media-element file-default file-os-files-xxlarge" src="img/GEOS-Chem_Logo_Square_Light_Background_Orig.png" alt="" title="" /></a>
+<h2 class="css-brand--css-geos-meetings-header-h2-xxxlarge">The 6th International GEOS-Chem Meeting (IGC6) May 6-9 2013</h2>
 </div>
 </div>
 </div>
@@ -76,15 +58,16 @@
 
 <!--main menu region beg-->
 <div id="menu-bar" class="nav region-menu-bar clearfix">
-<nav id="block-os-igc6-menu" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="igc6_menu">  
-<ul class="nice-menu nice-menu-down nice-menu-igc6_menu" id="nice-menu-igc6_menu">
-  <li class="menu-859543 menu-path-node-1586997  first   odd  "><a href="igc6.html"  class="active">Home</a></li>
-  <li class="menu-859559 menu-path-node-1586998   even   last "><a href="igc6-presentations.html" >Presentations and Posters</a></li>
+<nav id="block-os-igc6-menu" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="igc6_menu">
+<ul class="nice-menu nice-menu-down">
+  <li><a href="igc6.html" class="active">IGC6 Home</a></li>
+  <li><a href="igc6-presentations.html">Presentations and Posters</a></li>
+  <li><a href="index.html">GEOS-Chem Home</a></li>
 </ul>
 </nav>
 </div>
 <!--main menu region end-->
-		
+
 <div id="columns" class="clearfix">
 <div class="hg-container">
 <div id="content-column" role="main">
@@ -94,13 +77,13 @@
 <a name="main-content"></a>
 <h1 id="page-title" ng-non-bindable="">Overview</h1>
 </header>
-														
+
 <!--front panel regions beg-->
 <div id="content-panels" class="at-panel gpanel panel-display content clearfix">
 <div class="region region-content-top">
 <div class="region-inner clearfix">
 <div id="block-os-pages-main-content" class="block block-os-pages no-title"  module="os_pages" delta="main_content">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <div class="block-content content" ng-non-bindable="">
 <article id="node-1585687" class="node node-page article clearfix" role="article">
 <div class="node-content" ng-non-bindable="">
@@ -135,64 +118,16 @@
 </div>
 </div>
 
-<!--footer region beg-->
+<!--footer-->
 <footer id="footer" class="clearfix" role="contentinfo">
-
-<!-- Three column 3x33 Gpanel -->
-<div class="at-panel gpanel panel-display footer clearfix">
-<div class="region region-footer">
-<div class="region-inner clearfix">
-<div id="block-boxes-1617037690" class="block block-boxes block-boxes-os_boxes_html no-title"  module="boxes" delta="1617037690">
-<div class="block-inner clearfix">  
-<div class="block-content content" ng-non-bindable="">  
-<div id='boxes-box-1617037690' class='boxes-box'>  
 <div class="boxes-box-content">
   <p style="text-align:center">
-    Copyright © 2023 by the International GEOS-Chem Community. All rights reserved.
+    Copyright © 2026 by the International GEOS-Chem Community. All rights reserved.
   </p>
 </div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-<div class="region region-footer-bottom">  
-<div class="region-inner clearfix">  
-<div id="block-boxes-1616879798" class="block block-boxes block-boxes-os_boxes_media no-title"  module="boxes" delta="1616879798">  
-<div class="block-inner clearfix">  
-<div class="block-content content"> 
-<div id='boxes-box-1616879798' class='boxes-box'> 
-<div class="boxes-box-content"> 
-<div id="file-3900146" class="file file-html file-html-embed">
-<h2 class="element-invisible"><a href="">css-brand</a></h2>
-<div class="content">
-<div class="file-info">
-</div>
-<div class="field field-name-field-html-code field-type-text-long field-label-hidden view-mode-full">
-<div class="field-items">
-<div class="field-item even">
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-
-<!--footer region end-->
 </footer>
-</div>
-</div>
 
-<!--page area ends-->
-<div id="extradiv"></div>
+</div>
 </div>
 
 </body>

--- a/igc7-presentations.html
+++ b/igc7-presentations.html
@@ -1,9 +1,4 @@
 <!DOCTYPE html>
-<!--[if IEMobile 7]><html class="iem7"  lang="en" dir="ltr"><![endif]-->
-<!--[if lte IE 6]><html class="lt-ie9 lt-ie8 lt-ie7"  lang="en" dir="ltr"><![endif]-->
-<!--[if (IE 7)&(!IEMobile)]><html class="lt-ie9 lt-ie8"  lang="en" dir="ltr"><![endif]-->
-<!--[if IE 8]><html class="lt-ie9"  lang="en" dir="ltr"><![endif]-->
-<!--[if (gte IE 9)|(gt IEMobile 7)]><!--><html  lang="en" dir="ltr"><!--<![endif]-->
 <head>
 <meta charset="utf-8" />
 <!--<base href="/igc7-presentations" />-->
@@ -18,23 +13,12 @@
 <title>The 7th International GEOS-Chem Meeting</title>
 <meta http-equiv="x-ua-compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<link type="text/css" rel="stylesheet" href="css/css_xE-rWrJf-fncB6ztZfd2huxqgxu4WO-qwma6Xer30m4%EF%B9%96m=1675397288.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_1kR8T1_c-l5pBT6ZwbDT7BFda-4fyqW9Jjum29_2IY8%EF%B9%96m=1675397312.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_YnlUIvHP13qgpYEqubzE8JyDwlSxUnVibfnVkSoSDb0%EF%B9%96m=1675397273.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_Ku-3OcT9qU9h7dnGig5e23q6EVryY8orK4wzVDxsweE%EF%B9%96m=1675397367.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_vprtFTrWyg23GbY50_zJZHWGYMNfS8vsrRS26i4-ISk%EF%B9%96m=1675397406.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_dW-aNNrctRhQNc-KECjtQd0PxuW-h19IEum-TX2MeEk%EF%B9%96m=1675397301.css" media="print" />
-<link type="text/css" rel="stylesheet" href="css/css_SH2Lx3Qprh0GZo_9xRp85U9NsWfkSXn_Bi-rJoMY1sw%EF%B9%96m=1675397273.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_uaIDKcYMUK5osSQXuirpr3ZleXtnnpBN-eiECm7N0M0%EF%B9%96m=1675397395.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/responsive.blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/geos-chem.css" media="all"/>
 <script type="text/javascript" src="dropdown-menu.js"></script>
-<!--[if lte IE 8]>
-<script type="text/javascript">
-  var os_c = document.createElement;os_c('header');os_c('nav');os_c('section');os_c('article');os_c('aside');os_c('footer');os_c('hgroup');os_c('figure');
-</script>
-<![endif]-->
 </head>
 
 <body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-1585687 node-type-page og-context og-context-node og-context-node-1585652 navbar-on">
@@ -45,7 +29,7 @@
 <div id="page_wrap" class="page_wrap">
 <div id="page" class="container page header-main content-top footer-none">
 <div id="page-wrapper">
-		
+
 <!--header regions beg-->
 <header id="header" class="clearfix" role="banner">
 <div id="header-container">
@@ -53,7 +37,7 @@
 <div class="region region-header-second">
 <div class="region-inner clearfix">
 <div id="block-boxes-1617807424" class="block block-boxes block-boxes-os_boxes_html no-title"  module="boxes" delta="1617807424">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <div class="block-content content" ng-non-bindable="">
 <div id='boxes-box-1617807424' class='boxes-box'>
 <div class="boxes-box-content">
@@ -75,15 +59,16 @@
 
 <!--main menu region beg-->
 <div id="menu-bar" class="nav region-menu-bar clearfix">
-<nav id="block-os-igc7-menu" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="igc7_menu">  
-<ul class="nice-menu nice-menu-down nice-menu-igc7_menu" id="nice-menu-igc7_menu">
-  <li class="menu-858765 menu-path-node-1586831  first   odd  "><a href="igc7.html"  class="active">Home</a></li>
-  <li class="menu-858776 menu-path-node-1586837   even   last "><a href="igc7-presentations.html" >Presentations and Posters</a></li>
+<nav id="block-os-igc7-menu" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="igc7_menu">
+<ul class="nice-menu nice-menu-down">
+  <li><a href="igc7.html" class="active">IGC7 Home</a></li>
+  <li><a href="igc7-presentations.html">Presentations and Posters</a></li>
+  <li><a href="index.html">GEOS-Chem Home</a></li>
 </ul>
 </nav>
 </div>
 <!--main menu region end-->
-		
+
 <div id="columns" class="clearfix">
 <div class="hg-container">
 <div id="content-column" role="main">
@@ -93,13 +78,13 @@
 <a name="main-content"></a>
 <h1 id="page-title" ng-non-bindable="">Presentations and Posters</h1>
 </header>
-														
+
 <!--front panel regions beg-->
 <div id="content-panels" class="at-panel gpanel panel-display content clearfix">
 <div class="region region-content-top">
 <div class="region-inner clearfix">
 <div id="block-os-pages-main-content" class="block block-os-pages no-title"  module="os_pages" delta="main_content">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <div class="block-content content" ng-non-bindable="">
 <article id="node-1585687" class="node node-page article clearfix" role="article">
 <div class="node-content" ng-non-bindable="">
@@ -108,593 +93,598 @@
 <div class="field-item even">
 
 <p align="justify">
-	Mon 04 May 2015: <a href="#MonA">Model Overview</a> | <a href="#MonB">GEOS-Chem Working Groups</a> | <a href="#MonC">Aerosol Chemistry and Microphysics</a> | <a href="#MonD">GEOS-Chem Model Clinics </a> | <a href="#MonE">Model Overview</a> | <a href="#MonP">Monday Posters</a><br class="clearfix" />Tue 05 May 2015: <a href="#TueA">Chemistry-Climate</a> | <a href="#TueB">Carbonaceous Aerosols</a> | <a href="#TueC">Carbon Cycle &amp; Organics</a> | <a href="#TueP">Tuesday Posters</a><br class="clearfix" />Wed 06 May 2015: <a href="#WedA">Mercury and Persistent Organic Pollutants</a> | <a href="#WedB">Regional and Global Air Quality</a> | <a href="#WedC">Sources and Sinks</a> | <a href="#WedP">Wednesday Posters</a><br class="clearfix" />Thu 07 May 2015: <a href="#ThuA">Tropospheric Ozone</a> | <a href="#ThuB">Nitrogen Cycle</a>
+  Mon 04 May 2015: <a href="#MonA">Model Overview</a> | <a href="#MonB">GEOS-Chem Working Groups</a> | <a href="#MonC">Aerosol Chemistry and Microphysics</a> | <a href="#MonD">GEOS-Chem Model Clinics </a> | <a href="#MonE">Model Overview</a> | <a href="#MonP">Monday Posters</a><br class="clearfix" />Tue 05 May 2015: <a href="#TueA">Chemistry-Climate</a> | <a href="#TueB">Carbonaceous Aerosols</a> | <a href="#TueC">Carbon Cycle &amp; Organics</a> | <a href="#TueP">Tuesday Posters</a><br class="clearfix" />Wed 06 May 2015: <a href="#WedA">Mercury and Persistent Organic Pollutants</a> | <a href="#WedB">Regional and Global Air Quality</a> | <a href="#WedC">Sources and Sinks</a> | <a href="#WedP">Wednesday Posters</a><br class="clearfix" />Thu 07 May 2015: <a href="#ThuA">Tropospheric Ozone</a> | <a href="#ThuB">Nitrogen Cycle</a>
 </p>
 
-<h2>
-	Monday, May 4
-</h2>
+<h2> Monday, May 4</h2>
 
-<h3>
-	<a name="MonA" id="MonA"></a>Model Overview (Yuhang Wang, Georgia Tech, Chair)
-</h3>
+<h3><a name="MonA" id="MonA"></a>Model Overview (Yuhang Wang, Georgia Tech, Chair)</h3>
 
-<ul><li>
-		<a href="#">Welcome</a> (Daniel Jacob, Harvard and Randall Martin, Dalhousie)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/17MaxSxs8oy90F3t7SMpFKULkBZ45gloN/view?usp=drive_link">GEOS-Chem model overview</a> (Daniel Jacob, Harvard)
-	</li>
-	<li>
-		GEOS-Chem adjoint model overview (Daven Henze, U. Colorado–Boulder)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1bpFi721CAcRXgnXkjV1uXh4w-4RjYBtl/view?usp=drive_link">GEOS-Chem Support Team activities</a> (Bob Yantosca, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1XgAX_e6YfJxntDWiW1wD87B7k1TVOvYD/view?usp=drive_link">HEMCO emissions module</a> (Christoph Keller, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1qu1L7ZTKVApZg29mqOQ1gHY2KsbCJcCw/view?usp=drive_link">GEOS-Chem in massively parallel and ESM</a> (GMAO) implementation (Michael Long, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1bUkTR5jVC7kvsql-tURQ4a6rBs0v7ln0/view?usp=drive_link">GMAO activities</a> (Steven Pawson, NASA/GMAO)
-	</li>
-	<li>
-		GEOS-5 CTM with GEOS-Chem chemistry module (Andrea Molod, NASA/GMAO)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1UowwpMV3goETFxQBxtDRrxrHAMMAUSmk/view?usp=drive_link">Accelerated chemical kinetics for GEOS-Chem with KPPA</a> (John Linford, ParaTools, Inc.)
-	</li>
-</ul><h3>
-	<a name="MonB" id="MonB"></a>GEOS-Chem Working Groups (Colette Heald, MIT, Chair)
-</h3>
+<ul>
+  <li>
+    <a href="#">Welcome</a> (Daniel Jacob, Harvard and Randall Martin, Dalhousie)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/17MaxSxs8oy90F3t7SMpFKULkBZ45gloN/view?usp=drive_link">GEOS-Chem model overview</a> (Daniel Jacob, Harvard)
+  </li>
+  <li>
+    GEOS-Chem adjoint model overview (Daven Henze, U. Colorado–Boulder)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1bpFi721CAcRXgnXkjV1uXh4w-4RjYBtl/view?usp=drive_link">GEOS-Chem Support Team activities</a> (Bob Yantosca, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1XgAX_e6YfJxntDWiW1wD87B7k1TVOvYD/view?usp=drive_link">HEMCO emissions module</a> (Christoph Keller, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1qu1L7ZTKVApZg29mqOQ1gHY2KsbCJcCw/view?usp=drive_link">GEOS-Chem in massively parallel and ESM</a> (GMAO) implementation (Michael Long, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1bUkTR5jVC7kvsql-tURQ4a6rBs0v7ln0/view?usp=drive_link">GMAO activities</a> (Steven Pawson, NASA/GMAO)
+  </li>
+  <li>
+    GEOS-5 CTM with GEOS-Chem chemistry module (Andrea Molod, NASA/GMAO)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1UowwpMV3goETFxQBxtDRrxrHAMMAUSmk/view?usp=drive_link">Accelerated chemical kinetics for GEOS-Chem with KPPA</a> (John Linford, ParaTools, Inc.)
+  </li>
+</ul>
 
-<ul><li>
-		<a href="https://drive.google.com/file/d/1_apcZaZFHn4HFM7Qna1SjsfU_KOI88-X/view?usp=drive_link">Aerosols Working Group</a> (Jeff Pierce, Colorado State U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1wrMW6b_h3CTccLJdXoUCrb9jEs_qjxqa/view?usp=drive_link">Carbon Cycle Working Group</a> (Ray Nassar, Environment Canada)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1qtmxUoc-BBwA9whSrymkCWbGqZtnz6zp/view?usp=drive_link">Chemistry - Climate Working Group</a> (Hong Liao, Chinese Academy of Sciences)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/15ARZ3RIGL-aeRY9dD5dIVeX1KmP1RGen/view?usp=drive_link">Data Assimilation and Adjoint Working Group</a> (Dylan Jones, U. Toronto)
-	</li>
-	<li>
-		Hg and POPs Working Group (Noelle Selin, MIT)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Xr39HbeRgiZlm_iJV28a74wN6FYTngD1/view?usp=drive_link">Organics Working Group</a> (Dylan Millet, U. Minnesota)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Za-TkclE4bW8q1Ej-WtlnrPJZZxlX-N1/view?usp=drive_link">Oxidants and Chemistry Working Group</a> (Mathew Evans, U. York)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1ETQoozOAa-THe1UUUl-xum3ixzNmklPo/view?usp=drive_link">Nested Working Group</a> (Lin Zhang, Peking U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/13-Ir_VnBDhirGYG9W-D5R0DS0gHL2zys/view?usp=drive_link">Sources and Sinks Working Group</a> (Qiang Zhang, Tsinghua)
-	</li>
-</ul><h3>
-	<a name="MonC" id="MonC"></a>Aerosol Chemistry and Microphysics (Fangqun Yu, SUNY-Albany, Chair)
-</h3>
+<h3><a name="MonB" id="MonB"></a>GEOS-Chem Working Groups (Colette Heald, MIT, Chair)</h3>
 
-<ul><li>
-		<a href="https://drive.google.com/file/d/1IhXMcbVasu1JsG8tuar7V2EXavEnnyag/view?usp=drive_link">Ammonia variability over the US and its influence on inorganic particulate matter</a> (Luke Schiferl, MIT)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1ophiNFdOUK-xkaKjGNT1rmViyb2uWCQ2/view?usp=drive_link">Aerosol microphysics at high spatial resolution</a> (Peter Adams, CMU)
-	</li>
-	<li>
-		Processes controlling the seasonal cycle of Arctic aerosol size and number (Betty Croft, Dalhousie)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1dbX32l7xVZxTT9TrfnlxTf1wRDMZ5fn0/view?usp=drive_link">Estimation of relative influences of emissions on cloud droplet number concentration</a> (Shannon Capps, U. Colorado–Boulder)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Vqyaxil67KJ4mvPCs98TZitnfFz-N_v5/view?usp=drive_link">Impact of large emissions reductions on fine particulate matter sensitivities to precursors</a> (Jareth Holt, MIT)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1tHOI49xN7mJB0BX55-HHzY2BWuwaOW71/view?usp=drive_link">Effects of size resolved aerosol microphysics on photochemistry and heterogeneous chemistry</a> (Gan Luo, SUNY-Albany)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1iw7ntaGaa97YZeAYyCE47FXgKfyxtn_4/view?usp=drive_link">MOSAIC: A flexible new aerosol model for GEOS-Chem</a> (Sebastian Eastham, MIT)
-	</li>
-</ul><h3>
-	<a name="MonD" id="MonD"></a>Photochemistry (Becky Alexander, U. Washington, Chair)
-</h3>
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1_apcZaZFHn4HFM7Qna1SjsfU_KOI88-X/view?usp=drive_link">Aerosols Working Group</a> (Jeff Pierce, Colorado State U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1wrMW6b_h3CTccLJdXoUCrb9jEs_qjxqa/view?usp=drive_link">Carbon Cycle Working Group</a> (Ray Nassar, Environment Canada)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1qtmxUoc-BBwA9whSrymkCWbGqZtnz6zp/view?usp=drive_link">Chemistry - Climate Working Group</a> (Hong Liao, Chinese Academy of Sciences)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/15ARZ3RIGL-aeRY9dD5dIVeX1KmP1RGen/view?usp=drive_link">Data Assimilation and Adjoint Working Group</a> (Dylan Jones, U. Toronto)
+  </li>
+  <li>
+    Hg and POPs Working Group (Noelle Selin, MIT)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Xr39HbeRgiZlm_iJV28a74wN6FYTngD1/view?usp=drive_link">Organics Working Group</a> (Dylan Millet, U. Minnesota)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Za-TkclE4bW8q1Ej-WtlnrPJZZxlX-N1/view?usp=drive_link">Oxidants and Chemistry Working Group</a> (Mathew Evans, U. York)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1ETQoozOAa-THe1UUUl-xum3ixzNmklPo/view?usp=drive_link">Nested Working Group</a> (Lin Zhang, Peking U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/13-Ir_VnBDhirGYG9W-D5R0DS0gHL2zys/view?usp=drive_link">Sources and Sinks Working Group</a> (Qiang Zhang, Tsinghua)
+  </li>
+</ul>
 
-<ul><li>
-		<a href="https://drive.google.com/file/d/1tcrbeQ9m1UVSBBLnhokH9FZs1rjvL81w/view?usp=drive_link">How accurate are the kinetics we rely on?</a> (Ben Newsome, U. York)
-	</li>
-	<li>
-		Process-oriented attribution of tropospheric OH variability using a space-based proxy and GEOS-Chem (Lee Murray, NASA GISS / LDEO)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Bcm0IrEzBrTrwJ3E52bGvfnyNFj-QaNk/view?usp=drive_link">Isoprene nitrate chemistry in the Southeast US: Constraints from GEOS-Chem &amp; SEAC4RS</a> (Jenny Fisher, U. Wollongong)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1qXMiAUvQFejMgEArrwfW1wqlgxaDARzo/view?usp=drive_link">Halogen chemistry in GEOS-Chem: Accounting for elevated BrO levels</a> (Johan Schmidt, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1jLRGAFjYcX0QQeCPweitYcGuPGg-HmLi/view?usp=drive_link">Sensitivity of radiative effect to chemistry</a> (Barron Henderson, U. Florida)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1DOUfEABphWeMEwvY8789RG9QguWRF9z0/view?usp=drive_link">Very Short-Lived Halogens over the Western Pacific</a> (Robyn Butler, U. Edinburgh)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1JucVvIowSKkHAyQKjjKF0-zFbGUmtobR/view?usp=drive_link">Iodine's impact on tropospheric oxidants</a> (Tomás Sherwen, U. York)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1c24cfiuqRPqOJgNTY21R4a-mMrSgd1yG/view?usp=drive_link">Impact of ozone photochemistry at the air-water interface using the global chemical transport model (GEOS-Chem)</a> (Jun Wang for Cui Ge, U. Nebraska-Lincoln)
-	</li>
-</ul><h3>
-	<a name="MonE" id="MonE"></a>GEOS-Chem Model Clinics
-</h3>
+<h3><a name="MonC" id="MonC"></a>Aerosol Chemistry and Microphysics (Fangqun Yu, SUNY-Albany, Chair)</h3>
 
-<ul><li>
-		<a href="https://drive.google.com/file/d/1k5208gLD6Pfh28CHLb4mBJEL7wenaz65/view?usp=drive_link">Clinic 1: GEOS-Chem for beginners</a> (Melissa Sulprizio, Harvard and Junwei Xu, Dalhousie)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1exvmdOwCLE4ffZcYIOcLah1AFpurEkPi/view?usp=drive_link">Clinic 2: GEOS-Chem for intermediate/advanced users and HEMCO</a> (Bob Yantosca and Christoph Keller, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1wz-tNhj30e7kdiAidNMdWBcUzAqFF2CQ/view?usp=drive_link">Clinic 3: GEOS-Chem in massively parallel and ESM environments, GEOS-5 CTM</a> (Michael Long, Harvard and Andrea Molod, NASA GMAO)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/14-UDfyC4y3csIYMWCgAl4pD6Ron-LNO4/view?usp=drive_link">Clinic 4: GEOS-Chem adjoint</a> (Daven Henze, U. Colorado-Boulder)
-	</li>
-</ul><h3>
-	<a name="MonP" id="MonP"></a>Posters
-</h3>
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1IhXMcbVasu1JsG8tuar7V2EXavEnnyag/view?usp=drive_link">Ammonia variability over the US and its influence on inorganic particulate matter</a> (Luke Schiferl, MIT)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1ophiNFdOUK-xkaKjGNT1rmViyb2uWCQ2/view?usp=drive_link">Aerosol microphysics at high spatial resolution</a> (Peter Adams, CMU)
+  </li>
+  <li>
+    Processes controlling the seasonal cycle of Arctic aerosol size and number (Betty Croft, Dalhousie)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1dbX32l7xVZxTT9TrfnlxTf1wRDMZ5fn0/view?usp=drive_link">Estimation of relative influences of emissions on cloud droplet number concentration</a> (Shannon Capps, U. Colorado–Boulder)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Vqyaxil67KJ4mvPCs98TZitnfFz-N_v5/view?usp=drive_link">Impact of large emissions reductions on fine particulate matter sensitivities to precursors</a> (Jareth Holt, MIT)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1tHOI49xN7mJB0BX55-HHzY2BWuwaOW71/view?usp=drive_link">Effects of size resolved aerosol microphysics on photochemistry and heterogeneous chemistry</a> (Gan Luo, SUNY-Albany)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1iw7ntaGaa97YZeAYyCE47FXgKfyxtn_4/view?usp=drive_link">MOSAIC: A flexible new aerosol model for GEOS-Chem</a> (Sebastian Eastham, MIT)
+  </li>
+</ul>
 
-<ul><li>
-		<a href="https://drive.google.com/file/d/13QMinw3vLOdPlXmapeFyvsPtC3IQF7EB/view?usp=drive_link">Plume-scale sulfur chemistry and aerosol physics in GEOS-Chem</a> (Jeff Pierce, Colorado State U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1cjhNbAWj-eNvyvlCGqnYvmNpN6KhI9E0/view?usp=drive_link">Improving aerosol scavenging in global models</a> (Jess Kunke, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1qBQx3f1ZLgDcSNnGx3d988YV9X8dEQws/view?usp=drive_link">Australian dust Transport</a> (Jesse Greenslade, U. Wollongong)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1TSgQ82WONSj20XEstVL-bpx4GjbWrfwR/view?usp=drive_link">Improving modeling of sulfate aerosols during the January 2013 haze episode in North China: Model evaluation and sensitivity study</a> (Meng Gao, U. Iowa)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1MBN2agt45E5AZjbOdKvLPoWWAE-hfsz0/view?usp=drive_link">Evaluating predicted AOD over the Middle East</a> (Nick Hoffman, MIT)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1ixjKd9VZVfev11hzLy9wmRAmfR-fVtYE/view?usp=drive_link">Examination of sulfate aerosol formation over Southern Ocean</a> (Qianjie Chen, U. Washington)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1B7NZYdiKXDR2PJhRIBuRiIsD17QcgmT_/view?usp=drive_link">Comparison of GEOS-Chem aerosol optical depth with AERONET and MISR data over the contiguous United States</a> (Shenshen Li, Chinese Academy of Sciences)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1RWNI-ZkPD-U3zCWgLId4G5ZsdTyVKUf7/view?usp=drive_link">Summer particulate matter simulation in China with high resolution nested GEOS-Chem model</a> (Yu Yao, Tsinghua)
-	</li>
-	<li>
-		Weathering of soil in semi-infinite atmospheric environment (J Rajaraman, AMET U., India)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1UCGx09mJb7wR-vd7ZXV_wD0pp_oxr93B/view?usp=drive_link">Improving East Asian dust emission by accounting for subgrid wind variability and implicit geomorphic dependence</a> (Amos Tai, Chinese U. Hong Kong)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1voAizAsMMIJJHx9_0ExhknKggIo-3RXW/view?usp=drive_link">Asian tropopause aerosol layer - observations, simulated composition and source apportionment with GEOS-Chem</a> (Hongyu Liu for Duncan Fairlie, NASA Langley)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Jvm8WzudZQTSBHN2RROyc3lEDK830F5a/view?usp=drive_link">Recent revisions to isoprene photooxodation chemistry based on Caltech chamber experiments</a> (Kelvin Bates, Caltech)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1KJed84nvKFMeo1Jb29QE-WO1ik0nIj1F/view?usp=drive_link">Global sensitivity of modeled ozone and HOx concentrations and production using the Morris Method</a> (Kenneth Christian, Penn State)
-	</li>
-	<li>
-		Bonds: a new way of thinking about ozone production (Mat Evans, U. York / NCAS)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1-MzaG8RX1znebc1WALVdYuAYDa1SZWeN/view?usp=drive_link">Spectral decomposition of ozone variability</a> (Dene Bowdalo, U. York)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1AN_CNf5NP0XhEiBsurzEeZbxPk_xuYIX/view?usp=drive_link">Trend and interannual variability of surface ozone in Europe during 1990-2010</a> (JinXuan Chen, Peking U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1sofSzAa6acBl59_W-S6p52z0VUuwjgIX/view?usp=drive_link">Interannual variations and trends of tropospheric ozone over Japan since 2002</a> (Kohei Ikeda, NIES Japan)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1G8wtWs5Z_AzFcRvknSuEG_hrZtbTezCt/view?usp=drive_link">Drivers of decadal variability in JJA ozone concentration in the United States</a> (Lu Shen, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1ze-lC9j1wxZXrfHnvh81z3hze1IcHJC-/view?usp=drive_link">Use of GEOS-Chem for the interpretation of long-term FTIR measurements at Jungfraujoch</a> (Manu Mahieu, U. Liege)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1EF-xzG426phmZZ2HFU6YncWwnnlJMT4y/view?usp=drive_link">Ozone, reactive nitrogen, and aerosol evolution in biomass burning plumes</a> (Matt Alvarado, AER)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/12pCRwi9n8sZCqWWkgxvq7-VZy9EM2jdt/view?usp=drive_link">The impact of trans-pacific transport on the ozone air quality in the western U.S.</a> (Mei Gao, UCLA)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1jVgUnP3ic_f6-1deq_ks24q51TbFH-4x/view?usp=drive_link">Influence of wildfire emissions on ozone concentration in the western US</a> (Xiao Lu, Peking U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1lvSbWod8uj7WkPJS8FReGmTbUFuyGfMb/view?usp=drive_link">Inter-regional transport of ozone pollution over China</a> (Jingyuan Shao, Peking U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1MZt1GyknfRcUBL-QkWXh3fzHYudFtvBq/view?usp=drive_link">Data assimilation of ozone derived from an AIRS-OMI multi-spectral retrieval</a> (Thomas Walker, Caltech/JPL)
-	</li>
-</ul><h2>
-	Tuesday, May 5
-</h2>
+<h3><a name="MonD" id="MonD"></a>Photochemistry (Becky Alexander, U. Washington, Chair)</h3>
 
-<h3>
-	<a name="TueA" id="TueA"></a>Chemistry-Climate (Loretta Mickley, Harvard, Chair)
-</h3>
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1tcrbeQ9m1UVSBBLnhokH9FZs1rjvL81w/view?usp=drive_link">How accurate are the kinetics we rely on?</a> (Ben Newsome, U. York)
+  </li>
+  <li>
+    Process-oriented attribution of tropospheric OH variability using a space-based proxy and GEOS-Chem (Lee Murray, NASA GISS / LDEO)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Bcm0IrEzBrTrwJ3E52bGvfnyNFj-QaNk/view?usp=drive_link">Isoprene nitrate chemistry in the Southeast US: Constraints from GEOS-Chem &amp; SEAC4RS</a> (Jenny Fisher, U. Wollongong)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1qXMiAUvQFejMgEArrwfW1wqlgxaDARzo/view?usp=drive_link">Halogen chemistry in GEOS-Chem: Accounting for elevated BrO levels</a> (Johan Schmidt, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1jLRGAFjYcX0QQeCPweitYcGuPGg-HmLi/view?usp=drive_link">Sensitivity of radiative effect to chemistry</a> (Barron Henderson, U. Florida)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1DOUfEABphWeMEwvY8789RG9QguWRF9z0/view?usp=drive_link">Very Short-Lived Halogens over the Western Pacific</a> (Robyn Butler, U. Edinburgh)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1JucVvIowSKkHAyQKjjKF0-zFbGUmtobR/view?usp=drive_link">Iodine's impact on tropospheric oxidants</a> (Tomás Sherwen, U. York)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1c24cfiuqRPqOJgNTY21R4a-mMrSgd1yG/view?usp=drive_link">Impact of ozone photochemistry at the air-water interface using the global chemical transport model (GEOS-Chem)</a> (Jun Wang for Cui Ge, U. Nebraska-Lincoln)
+  </li>
+</ul>
 
-<ul><li>
-		<a href="https://drive.google.com/file/d/11kfIe1QjM5irzmCrXr1LCNKooI78lBMC/view?usp=drive_link">Uncertainties in isoprene photochemistry and emissions: implications for the oxidative capacity of past and present atmospheres and for trends in climate forcing agents</a> (Ploy Achakulwisut, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1NapqT-Umge9sAuBrC862NCvp-rBFePux/view?usp=drive_link">A definition of the atmospheric equator and its implications for atmospheric chemistry</a> (Chris Holmes, Florida State U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1uBG0m2F1QugyGe6e386naSeAHoo-9v4i/view?usp=drive_link">Effects of historical climate and land cover changes on East Asian air quality</a> (Amos Tai, Chinese U. Hong Kong)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1plKSGoVMPgqHdpLdwBS_qbQCeVOA3w-u/view?usp=drive_link">Drought effects on ozone and PM2.5</a> (Yuxuan Wang, Texas A&amp;M and Tsinghua)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1QX70yFRqQ8GIrDiz3tvD9p5a7P0dfn7R/view?usp=drive_link">Arctic climate response to decadal changes in radiative forcing</a> (Tom Breider, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/13QQkTZ2nEI5ebWvUuSPzoal48bBQKG4T/view?usp=drive_link">A land use module for GEOS-Chem</a> (Jeffrey Geddes, Dalhousie)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1t0p2CZdli2bq2A0ENJcNiVtdZZDXwFsp/view?usp=drive_link">Using satellite observations of cloud vertical distribution to improve global model estimates of cloud radiative effect on key tropospheric oxidants</a> (Hongyu Liu, NIA / NASA Langley)
-	</li>
-</ul><h3>
-	<a name="TueB" id="TueB"></a>Carbonaceous Aerosols (Matthew Alvarado, AER, Chair)
-</h3>
+<h3><a name="MonE" id="MonE"></a>GEOS-Chem Model Clinics</h3>
 
-<ul><li>
-		<a href="https://drive.google.com/file/d/1Myz1Xh3o1FDvFGFpraoUwFvKUyrWnXjm/view?usp=drive_link">Investigating global aerosol and climate-forcing uncertainties due to biofuel emissions/properties in GEOS-Chem</a> (Jack Kodros, Colorado State U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1UDUD7NnR98xrxqTmnlbTxQPzRtcJdzsR/view?usp=drive_link">Elucidating the cause of decreasing organic aerosol over recent decades using the GEOS-Chem model</a> (David Ridley, MIT)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1n1bjPsvRRNwLAEQFXbBRLfXbmK2R6drX/view?usp=drive_link">Effect of atmospheric organics on iron bioavailability</a> (Nicholas Meskhidze, NC State)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1HNNauCI8nZCHqrzSIImUmVH40De4WB8K/view?usp=drive_link">Implementing marine organic aerosols into GEOS-Chem</a> (Matthew Johnson, NASA Ames)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/12GFXjGBhipxMkQHPDND2cqndwkxRQKbE/view?usp=drive_link">Improving black carbon aging scheme in GEOS-Chem based on aerosol microphysics: Constraints from HIPPO observations</a> (Cenlin He, UCLA)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1M71OT9UOwRCKTZTtpmu29POrEuyZGYuo/view?usp=drive_link">Factors controlling black carbon deposition in snow in the Arctic</a> (Ling Qi, UCLA)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1XJ49G_oo6lt5uGZksDYUvk24hAMl3ldD/view?usp=drive_link">Simulating brown carbon and its direct radiative forcing: from "bottom-up" to "top-down"</a> (Xuan Wang, MIT)
-	</li>
-</ul><h3>
-	<a name="TueC" id="TueC"></a>Carbon Cycle &amp; Organics (Ray Nassar, Environment Canada, Chair)
-</h3>
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1k5208gLD6Pfh28CHLb4mBJEL7wenaz65/view?usp=drive_link">Clinic 1: GEOS-Chem for beginners</a> (Melissa Sulprizio, Harvard and Junwei Xu, Dalhousie)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1exvmdOwCLE4ffZcYIOcLah1AFpurEkPi/view?usp=drive_link">Clinic 2: GEOS-Chem for intermediate/advanced users and HEMCO</a> (Bob Yantosca and Christoph Keller, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1wz-tNhj30e7kdiAidNMdWBcUzAqFF2CQ/view?usp=drive_link">Clinic 3: GEOS-Chem in massively parallel and ESM environments, GEOS-5 CTM</a> (Michael Long, Harvard and Andrea Molod, NASA GMAO)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/14-UDfyC4y3csIYMWCgAl4pD6Ron-LNO4/view?usp=drive_link">Clinic 4: GEOS-Chem adjoint</a> (Daven Henze, U. Colorado-Boulder)
+  </li>
+</ul>
 
-<ul><li>
-		Satellite-derived yields of isoprene organic aerosol (Eloïse Marais, Harvard)
-	</li>
-	<li>
-		A large and ubiquitous source of atmospheric formic acid (Dylan Millet, U. Minnesota)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1T4qrh9gNjbZ_PTzX_Hm0ol7MK5xkHVFD/view?usp=drive_link">Indirect validation of new OMI, GOME-2 and OMPS formaldehyde retrievals using SEAC4RS data</a> (Lei Zhu, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/14jps4RCsCfd54EUlxsZRrKtVvvfVb5Ux/view?usp=drive_link">The tropical drivers of the 2011-2010 atmospheric CO2 growth rate</a> (Kevin Bowman, JPL)
-	</li>
-	<li>
-		CO2 sinks and sources inferred from GOSAT XCO2 (Feng Deng, U. Toronto)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1SY5dPb4r10yZFwwvs81cKwbtIIY0b46t/view?usp=drive_link">Satellite data constraints on biogenic and pyrogenic carbon Fluxes</a> (Anthony Bloom, JPL/Caltech)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/19q7Stv_nNkRHiWfG9hoFqfOk_Gxn3aC1/view?usp=drive_link">Estimating global and North American methane emissions using GOSAT</a> (Alexander Turner, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1OzkA6dSuLc7vDDJonVGnIscOvHK_nPeW/view?usp=drive_link">Inverse modelling of North American methane emissions using GOSAT proxy and full-physics retrievals</a> (Ilya Stanevich, U. Toronto)
-	</li>
-</ul><h3>
-	<a name="TueP" id="TueP"></a>Posters
-</h3>
+<h3><a name="MonP" id="MonP"></a>Posters</h3>
 
-<ul><li>
-		<a href="https://drive.google.com/file/d/18IQRNWI-bAwsJiwBF5yxUYOlkTbVizPK/view?usp=drive_link">Impacts of extreme air pollution meteorology on air quality in in the context of global climate change</a> (Pei Hou, Michigan Tech)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1-7Y58lwfLiThJIdwc_0qvUmg3ucRZ90g/view?usp=drive_link">Sensitivity of tropospheric oxidants to climate as inferred from Greenland ice core records of nitrate isotopes</a> (Becky Alexander, U, Washington)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1GfgYmV44mtHMWkeqp-qTkcGwqV0JAj0l/view?usp=drive_link">Effects of trends in anthropogenic aerosols on drought risk in the United States</a> (Dan Cusworth, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1zSC0QvKdyJ7KFHvSFtv9STgN0ypAmU9_/view?usp=drive_link">Future changes in ozone and aerosols over China under the Representative Concentration Pathways (RCPs)</a> (Jia Zhu , Chinese Academy of Sciences)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1rcJF72Ar1jieRHHKQMa_CKq-X5luni3W/view?usp=drive_link">Influence of 2000-2050 climate change on PM2.5 concentrations in the United States</a> (Lu Shen, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1nrCkYhZqZcbrBKLqXH90xf85Oh5Wgs9E/view?usp=drive_link">Land use change over South East Asia: Observations and modeling</a> (Sam Silva, MIT)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1YbbZN1QBLEKeaS3LFwYA4li2TscFl29m/view?usp=drive_link">OMI-based volcanic SO2 emission into GEOS-Chem</a> (Jun Wang for Cui Ge, U. Nebraska-Lincoln)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1NT2t80YCQ0QhNZ7Bcjb_z1ns0wwoU1_6/view?usp=drive_link">Constraining black carbon aerosol over Asia using the GEOS-Chem adjoint and the assessment the long term Trend of OMI Aerosol Absorption Optical Depth</a> (Li Zhang, U. Colorado – Boulder)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/19a-fudvwK5xjfofJi2IKT7pHn3hHpx1q/view?usp=drive_link">A new moment-based parameterization for organic aerosols: application to a case study at Mt Tai in China</a> (Li Xing, Peking U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1HVx0N9-j46EQHT5Pwd2GjfJahpbJ0TBr/view?usp=drive_link">Simulation of influence of Biomass burning to aerosol optical properties in southwest China - Kunming</a> (Jun Zhu, IAP and U. Nebraska-Lincoln)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1y759CowWd9GWHwVhTSw2GqElZ6UvK4RF/view?usp=drive_link">Investigating the spectral dependence of absorption by organic aerosols in GEOS-Chem using simulations of the Ultraviolet Aerosol Index (UVAI)</a> (Melanie Hammer, Dalhousie)
-	</li>
-	<li>
-		WINTER-time representation of NOy (Jessica Haskins, U. Washington)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1r6I_DNbaUq4pyqf1QkwWhkPx6UOoWrSq/view?usp=drive_link">Satellite-based constraints on NOx emissions from anthropogenic area sources</a> (Meng Li, Tsinghua)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1N2pEhLB9Yh-FVYuhGScC4vFPGPdnVbMm/view?usp=drive_link">Satellite constraint for NOx emissions over China</a> (Zhen Qu, U. Colorado –Boulder)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/16YdXIAUNgK39GdLSvuS5UAX8KNV7TVWF/view?usp=drive_link">Ethane and propane emissions in the U.S. from oil and gas activities</a> (Zitely Tzompa, Colorado State U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1QtFr6KvvXPpBi1x8M3dpWqbEBAinfYY4/view?usp=drive_link">Modeling CO2 fluxes at East Trout Lake, Saskatchewan: What could be learned about the boreal forest carbon cycle with a new TCCON site?</a> (Brendan Byrne, U. Toronto)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1ECrgzzqyT1x5kmyOoH-6ozIgpzJPAdHK/view?usp=drive_link">A gridded (0.1°x0.1°), monthly resolved version of the US EPA national methane emissions inventory for use as a priori and reference in methane source inversions</a> (J.D. (Bram) Maasakkers, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Dh-p5_2Y2G60OdEzQsry8q-hJdPrTGNm/view?usp=drive_link">Comparison of TCCON and GEOS-Chem CH4 partial column variability</a> (Katherine Saad, Caltech)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1hw1fssPHpkD7noPPXJ8GTTK5laWYPLGv/view?usp=drive_link">Evaluation of CO distribution and transport in the UTLS from GMI and GEOS-Chem simulations by using Aura MLS observations</a> (Lei Huang, JPL/Caltech)
-	</li>
-	<li>
-		Understanding the atmospheric methane dynamics with a cooperated model of TEM and GEOS-Chem and satellite data (Licheng Liu, Purdue)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1cJkpU2Qy4_GO6Q8hbwnWEwrfPkgDMB5d/view?usp=drive_link">Isoprene emissions and impacts over an ecological transition region</a> (Lu Hu, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1LlJJbf0dkCpzoqg_7LjAUK8fh8lMZ2YC/view?usp=drive_link">Formic acid measurement from space : quantifying biomass burning sources of emissions of formic acid</a> (Sreelekha Chaliyakunnel, U. Minnesota)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1N-7wHns5ra_5FTZwVT4VR194926m0Tgt/view?usp=drive_link">Estimate CO2 seasonal and interannual variation in East Asia over 2004-2012</a> (Yu Fu, Chinese Academy of Sciences)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Y1CTgqbpCua3htya_fLfTmp8_wWlOsMP/view?usp=drive_link">Isoprene: Long-term measurement and modelling in Borneo</a> (Shani Garraway, U. York)
-	</li>
-</ul><h2>
-	Wednesday, May 6
-</h2>
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/13QMinw3vLOdPlXmapeFyvsPtC3IQF7EB/view?usp=drive_link">Plume-scale sulfur chemistry and aerosol physics in GEOS-Chem</a> (Jeff Pierce, Colorado State U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1cjhNbAWj-eNvyvlCGqnYvmNpN6KhI9E0/view?usp=drive_link">Improving aerosol scavenging in global models</a> (Jess Kunke, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1qBQx3f1ZLgDcSNnGx3d988YV9X8dEQws/view?usp=drive_link">Australian dust Transport</a> (Jesse Greenslade, U. Wollongong)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1TSgQ82WONSj20XEstVL-bpx4GjbWrfwR/view?usp=drive_link">Improving modeling of sulfate aerosols during the January 2013 haze episode in North China: Model evaluation and sensitivity study</a> (Meng Gao, U. Iowa)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1MBN2agt45E5AZjbOdKvLPoWWAE-hfsz0/view?usp=drive_link">Evaluating predicted AOD over the Middle East</a> (Nick Hoffman, MIT)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1ixjKd9VZVfev11hzLy9wmRAmfR-fVtYE/view?usp=drive_link">Examination of sulfate aerosol formation over Southern Ocean</a> (Qianjie Chen, U. Washington)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1B7NZYdiKXDR2PJhRIBuRiIsD17QcgmT_/view?usp=drive_link">Comparison of GEOS-Chem aerosol optical depth with AERONET and MISR data over the contiguous United States</a> (Shenshen Li, Chinese Academy of Sciences)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1RWNI-ZkPD-U3zCWgLId4G5ZsdTyVKUf7/view?usp=drive_link">Summer particulate matter simulation in China with high resolution nested GEOS-Chem model</a> (Yu Yao, Tsinghua)
+  </li>
+  <li>
+    Weathering of soil in semi-infinite atmospheric environment (J Rajaraman, AMET U., India)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1UCGx09mJb7wR-vd7ZXV_wD0pp_oxr93B/view?usp=drive_link">Improving East Asian dust emission by accounting for subgrid wind variability and implicit geomorphic dependence</a> (Amos Tai, Chinese U. Hong Kong)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1voAizAsMMIJJHx9_0ExhknKggIo-3RXW/view?usp=drive_link">Asian tropopause aerosol layer - observations, simulated composition and source apportionment with GEOS-Chem</a> (Hongyu Liu for Duncan Fairlie, NASA Langley)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Jvm8WzudZQTSBHN2RROyc3lEDK830F5a/view?usp=drive_link">Recent revisions to isoprene photooxodation chemistry based on Caltech chamber experiments</a> (Kelvin Bates, Caltech)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1KJed84nvKFMeo1Jb29QE-WO1ik0nIj1F/view?usp=drive_link">Global sensitivity of modeled ozone and HOx concentrations and production using the Morris Method</a> (Kenneth Christian, Penn State)
+  </li>
+  <li>
+    Bonds: a new way of thinking about ozone production (Mat Evans, U. York / NCAS)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1-MzaG8RX1znebc1WALVdYuAYDa1SZWeN/view?usp=drive_link">Spectral decomposition of ozone variability</a> (Dene Bowdalo, U. York)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1AN_CNf5NP0XhEiBsurzEeZbxPk_xuYIX/view?usp=drive_link">Trend and interannual variability of surface ozone in Europe during 1990-2010</a> (JinXuan Chen, Peking U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1sofSzAa6acBl59_W-S6p52z0VUuwjgIX/view?usp=drive_link">Interannual variations and trends of tropospheric ozone over Japan since 2002</a> (Kohei Ikeda, NIES Japan)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1G8wtWs5Z_AzFcRvknSuEG_hrZtbTezCt/view?usp=drive_link">Drivers of decadal variability in JJA ozone concentration in the United States</a> (Lu Shen, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1ze-lC9j1wxZXrfHnvh81z3hze1IcHJC-/view?usp=drive_link">Use of GEOS-Chem for the interpretation of long-term FTIR measurements at Jungfraujoch</a> (Manu Mahieu, U. Liege)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1EF-xzG426phmZZ2HFU6YncWwnnlJMT4y/view?usp=drive_link">Ozone, reactive nitrogen, and aerosol evolution in biomass burning plumes</a> (Matt Alvarado, AER)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/12pCRwi9n8sZCqWWkgxvq7-VZy9EM2jdt/view?usp=drive_link">The impact of trans-pacific transport on the ozone air quality in the western U.S.</a> (Mei Gao, UCLA)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1jVgUnP3ic_f6-1deq_ks24q51TbFH-4x/view?usp=drive_link">Influence of wildfire emissions on ozone concentration in the western US</a> (Xiao Lu, Peking U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1lvSbWod8uj7WkPJS8FReGmTbUFuyGfMb/view?usp=drive_link">Inter-regional transport of ozone pollution over China</a> (Jingyuan Shao, Peking U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1MZt1GyknfRcUBL-QkWXh3fzHYudFtvBq/view?usp=drive_link">Data assimilation of ozone derived from an AIRS-OMI multi-spectral retrieval</a> (Thomas Walker, Caltech/JPL)
+  </li>
+</ul>
 
-<h3>
-	<a name="WedA" id="WedA"></a>Mercury and Persistent Organic Pollutants (Leonard Levin, EPRI, Chair)
-</h3>
+<h2>Tuesday, May 5</h2>
+
+<h3><a name="TueA" id="TueA"></a>Chemistry-Climate (Loretta Mickley, Harvard, Chair)</h3>
+
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/11kfIe1QjM5irzmCrXr1LCNKooI78lBMC/view?usp=drive_link">Uncertainties in isoprene photochemistry and emissions: implications for the oxidative capacity of past and present atmospheres and for trends in climate forcing agents</a> (Ploy Achakulwisut, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1NapqT-Umge9sAuBrC862NCvp-rBFePux/view?usp=drive_link">A definition of the atmospheric equator and its implications for atmospheric chemistry</a> (Chris Holmes, Florida State U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1uBG0m2F1QugyGe6e386naSeAHoo-9v4i/view?usp=drive_link">Effects of historical climate and land cover changes on East Asian air quality</a> (Amos Tai, Chinese U. Hong Kong)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1plKSGoVMPgqHdpLdwBS_qbQCeVOA3w-u/view?usp=drive_link">Drought effects on ozone and PM2.5</a> (Yuxuan Wang, Texas A&amp;M and Tsinghua)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1QX70yFRqQ8GIrDiz3tvD9p5a7P0dfn7R/view?usp=drive_link">Arctic climate response to decadal changes in radiative forcing</a> (Tom Breider, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/13QQkTZ2nEI5ebWvUuSPzoal48bBQKG4T/view?usp=drive_link">A land use module for GEOS-Chem</a> (Jeffrey Geddes, Dalhousie)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1t0p2CZdli2bq2A0ENJcNiVtdZZDXwFsp/view?usp=drive_link">Using satellite observations of cloud vertical distribution to improve global model estimates of cloud radiative effect on key tropospheric oxidants</a> (Hongyu Liu, NIA / NASA Langley)
+  </li>
+</ul>
+
+<h3><a name="TueB" id="TueB"></a>Carbonaceous Aerosols (Matthew Alvarado, AER, Chair)</h3>
+
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1Myz1Xh3o1FDvFGFpraoUwFvKUyrWnXjm/view?usp=drive_link">Investigating global aerosol and climate-forcing uncertainties due to biofuel emissions/properties in GEOS-Chem</a> (Jack Kodros, Colorado State U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1UDUD7NnR98xrxqTmnlbTxQPzRtcJdzsR/view?usp=drive_link">Elucidating the cause of decreasing organic aerosol over recent decades using the GEOS-Chem model</a> (David Ridley, MIT)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1n1bjPsvRRNwLAEQFXbBRLfXbmK2R6drX/view?usp=drive_link">Effect of atmospheric organics on iron bioavailability</a> (Nicholas Meskhidze, NC State)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1HNNauCI8nZCHqrzSIImUmVH40De4WB8K/view?usp=drive_link">Implementing marine organic aerosols into GEOS-Chem</a> (Matthew Johnson, NASA Ames)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/12GFXjGBhipxMkQHPDND2cqndwkxRQKbE/view?usp=drive_link">Improving black carbon aging scheme in GEOS-Chem based on aerosol microphysics: Constraints from HIPPO observations</a> (Cenlin He, UCLA)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1M71OT9UOwRCKTZTtpmu29POrEuyZGYuo/view?usp=drive_link">Factors controlling black carbon deposition in snow in the Arctic</a> (Ling Qi, UCLA)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1XJ49G_oo6lt5uGZksDYUvk24hAMl3ldD/view?usp=drive_link">Simulating brown carbon and its direct radiative forcing: from "bottom-up" to "top-down"</a> (Xuan Wang, MIT)
+  </li>
+</ul>
+
+<h3><a name="TueC" id="TueC"></a>Carbon Cycle &amp; Organics (Ray Nassar, Environment Canada, Chair)</h3>
+
+<ul>
+  <li>
+    Satellite-derived yields of isoprene organic aerosol (Eloïse Marais, Harvard)
+  </li>
+  <li>
+    A large and ubiquitous source of atmospheric formic acid (Dylan Millet, U. Minnesota)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1T4qrh9gNjbZ_PTzX_Hm0ol7MK5xkHVFD/view?usp=drive_link">Indirect validation of new OMI, GOME-2 and OMPS formaldehyde retrievals using SEAC4RS data</a> (Lei Zhu, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/14jps4RCsCfd54EUlxsZRrKtVvvfVb5Ux/view?usp=drive_link">The tropical drivers of the 2011-2010 atmospheric CO2 growth rate</a> (Kevin Bowman, JPL)
+  </li>
+  <li>
+    CO2 sinks and sources inferred from GOSAT XCO2 (Feng Deng, U. Toronto)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1SY5dPb4r10yZFwwvs81cKwbtIIY0b46t/view?usp=drive_link">Satellite data constraints on biogenic and pyrogenic carbon Fluxes</a> (Anthony Bloom, JPL/Caltech)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/19q7Stv_nNkRHiWfG9hoFqfOk_Gxn3aC1/view?usp=drive_link">Estimating global and North American methane emissions using GOSAT</a> (Alexander Turner, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1OzkA6dSuLc7vDDJonVGnIscOvHK_nPeW/view?usp=drive_link">Inverse modelling of North American methane emissions using GOSAT proxy and full-physics retrievals</a> (Ilya Stanevich, U. Toronto)
+  </li>
+</ul>
+
+<h3><a name="TueP" id="TueP"></a>Posters</h3>
 
 <ul><li>
-		<a href="https://drive.google.com/file/d/1DOIk0u9Vj6iFT_-SIfKsMGr2PII5GuGM/view?usp=drive_link">Revisiting atmospheric Hg oxidation mechanisms in GEOS-Chem: constraints from observations</a> (Hannah Horowitz, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/15WZsiE1VJEVg6AcDYSyMBAcRPaCm2FoD/view?usp=drive_link">Constraining Hg oxidation and lifetime</a> (Noelle Selin, MIT)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1QGJitHIAqn0IZAsc-gI5nvfVEdPHRzAb/view?usp=drive_link">Global atmospheric transport and source-receptor relationships for arsenic</a> (Shiliang Wu, Michigan Tech)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1227wOKqUpC889ihyVfgvX1oF5WrfqYul/view?usp=drive_link">Using GEOS-Chem to investigate the effect of multimedia behavior on atmospheric transport of PCBs</a> (Carey Friedman, MIT)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1GL9jgr4MBRklvlmxRBg-AGyb_5uCU2Qm/view?usp=drive_link">Constraining mercury oxidation using the NOMADSS aircraft observations</a> (Viral Shah, U. Washington)
-	</li>
-	<li>
-		Effects of changes in climate and land use and land cover on atmospheric mercury (Huanxin Zhang, Michigan Tech)
-	</li>
-	<li>
-		Improving the parameterization of land-surface exchange in the in the GEOS-Chem Hg model (Shaojie Song, MIT)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1bkioUbA7B1ZlwE23dDvyQlBGFGSCH4Vm/view?usp=drive_link">A flat global trend suggests a more important role for domestic emission reduction for observed decrease for atmospheric mercury level over the United States</a> (Yanxu Zhang, Harvard)
-	</li>
-</ul><h3>
-	<a name="WedB" id="WedB"></a>Regional and Global Air Quality (Amos Tai, Chinese U. Hong Kong, Chair)
-</h3>
+    <a href="https://drive.google.com/file/d/18IQRNWI-bAwsJiwBF5yxUYOlkTbVizPK/view?usp=drive_link">Impacts of extreme air pollution meteorology on air quality in in the context of global climate change</a> (Pei Hou, Michigan Tech)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1-7Y58lwfLiThJIdwc_0qvUmg3ucRZ90g/view?usp=drive_link">Sensitivity of tropospheric oxidants to climate as inferred from Greenland ice core records of nitrate isotopes</a> (Becky Alexander, U, Washington)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1GfgYmV44mtHMWkeqp-qTkcGwqV0JAj0l/view?usp=drive_link">Effects of trends in anthropogenic aerosols on drought risk in the United States</a> (Dan Cusworth, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1zSC0QvKdyJ7KFHvSFtv9STgN0ypAmU9_/view?usp=drive_link">Future changes in ozone and aerosols over China under the Representative Concentration Pathways (RCPs)</a> (Jia Zhu , Chinese Academy of Sciences)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1rcJF72Ar1jieRHHKQMa_CKq-X5luni3W/view?usp=drive_link">Influence of 2000-2050 climate change on PM2.5 concentrations in the United States</a> (Lu Shen, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1nrCkYhZqZcbrBKLqXH90xf85Oh5Wgs9E/view?usp=drive_link">Land use change over South East Asia: Observations and modeling</a> (Sam Silva, MIT)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1YbbZN1QBLEKeaS3LFwYA4li2TscFl29m/view?usp=drive_link">OMI-based volcanic SO2 emission into GEOS-Chem</a> (Jun Wang for Cui Ge, U. Nebraska-Lincoln)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1NT2t80YCQ0QhNZ7Bcjb_z1ns0wwoU1_6/view?usp=drive_link">Constraining black carbon aerosol over Asia using the GEOS-Chem adjoint and the assessment the long term Trend of OMI Aerosol Absorption Optical Depth</a> (Li Zhang, U. Colorado – Boulder)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/19a-fudvwK5xjfofJi2IKT7pHn3hHpx1q/view?usp=drive_link">A new moment-based parameterization for organic aerosols: application to a case study at Mt Tai in China</a> (Li Xing, Peking U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1HVx0N9-j46EQHT5Pwd2GjfJahpbJ0TBr/view?usp=drive_link">Simulation of influence of Biomass burning to aerosol optical properties in southwest China - Kunming</a> (Jun Zhu, IAP and U. Nebraska-Lincoln)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1y759CowWd9GWHwVhTSw2GqElZ6UvK4RF/view?usp=drive_link">Investigating the spectral dependence of absorption by organic aerosols in GEOS-Chem using simulations of the Ultraviolet Aerosol Index (UVAI)</a> (Melanie Hammer, Dalhousie)
+  </li>
+  <li>
+    WINTER-time representation of NOy (Jessica Haskins, U. Washington)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1r6I_DNbaUq4pyqf1QkwWhkPx6UOoWrSq/view?usp=drive_link">Satellite-based constraints on NOx emissions from anthropogenic area sources</a> (Meng Li, Tsinghua)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1N2pEhLB9Yh-FVYuhGScC4vFPGPdnVbMm/view?usp=drive_link">Satellite constraint for NOx emissions over China</a> (Zhen Qu, U. Colorado –Boulder)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/16YdXIAUNgK39GdLSvuS5UAX8KNV7TVWF/view?usp=drive_link">Ethane and propane emissions in the U.S. from oil and gas activities</a> (Zitely Tzompa, Colorado State U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1QtFr6KvvXPpBi1x8M3dpWqbEBAinfYY4/view?usp=drive_link">Modeling CO2 fluxes at East Trout Lake, Saskatchewan: What could be learned about the boreal forest carbon cycle with a new TCCON site?</a> (Brendan Byrne, U. Toronto)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1ECrgzzqyT1x5kmyOoH-6ozIgpzJPAdHK/view?usp=drive_link">A gridded (0.1°x0.1°), monthly resolved version of the US EPA national methane emissions inventory for use as a priori and reference in methane source inversions</a> (J.D. (Bram) Maasakkers, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Dh-p5_2Y2G60OdEzQsry8q-hJdPrTGNm/view?usp=drive_link">Comparison of TCCON and GEOS-Chem CH4 partial column variability</a> (Katherine Saad, Caltech)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1hw1fssPHpkD7noPPXJ8GTTK5laWYPLGv/view?usp=drive_link">Evaluation of CO distribution and transport in the UTLS from GMI and GEOS-Chem simulations by using Aura MLS observations</a> (Lei Huang, JPL/Caltech)
+  </li>
+  <li>
+    Understanding the atmospheric methane dynamics with a cooperated model of TEM and GEOS-Chem and satellite data (Licheng Liu, Purdue)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1cJkpU2Qy4_GO6Q8hbwnWEwrfPkgDMB5d/view?usp=drive_link">Isoprene emissions and impacts over an ecological transition region</a> (Lu Hu, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1LlJJbf0dkCpzoqg_7LjAUK8fh8lMZ2YC/view?usp=drive_link">Formic acid measurement from space : quantifying biomass burning sources of emissions of formic acid</a> (Sreelekha Chaliyakunnel, U. Minnesota)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1N-7wHns5ra_5FTZwVT4VR194926m0Tgt/view?usp=drive_link">Estimate CO2 seasonal and interannual variation in East Asia over 2004-2012</a> (Yu Fu, Chinese Academy of Sciences)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Y1CTgqbpCua3htya_fLfTmp8_wWlOsMP/view?usp=drive_link">Isoprene: Long-term measurement and modelling in Borneo</a> (Shani Garraway, U. York)
+  </li>
+</ul>
 
-<ul><li>
-		<a href="https://drive.google.com/file/d/1fpxn13z_8OvmOH83HqfyxHSaESuaNn07/view?usp=drive_link">Regional and global impacts of Southeast Asian coal emissions on particulate matter and ozone</a> (Shannon Koplitz, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/18nTV-NWp-Zhj9_Oa9FssPr7hv-DVsJHy/view?usp=drive_link">Global pollution and transport</a> (Jintai Lin, Peking U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1WIQGKBAnl93pJlX7pbn7SuqhCtMiS2Xb/view?usp=drive_link">Space-based constraints on VOC emissions in the Pearl River Delta</a> (Christopher Miller, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1uTXl1VygE727xhNhED2McA3BtrAygJVV/view?usp=drive_link">Combining GEOS-Chem with satellite for improved PM2.5 population exposure estimates</a> (Aaron van Donkelaar, Dalhousie)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1A5Z5bhGP0Z2u4AruHdb3wOTOTFABjrwj/view?usp=drive_link">Uncertainties in estimating health effects of PM2.5 exposure</a> (Bonne Ford, Colorado State U.)
-	</li>
-	<li>
-		Evaluation the health and climate impacts of cookstove emissions using the GEOS-Chem adjoint model (Forrest Lacey, U. Colorado–Boulder)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1GDSQf9JBYybZGkOVQpKAkgjHKPz3Cnw8/view?usp=drive_link">’APEC Blue' in North China simulated with the high resolution nested GEOS-Chem model</a> (Yixuan Gu, Chinese Academy of Sciences)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1uLBrbnc78OAAdpNd5Jb1WJxMbsrfHsCy/view?usp=drive_link">Impacts of large-scale circulation patterns on winter haze over China: interannual variability and extreme events</a> (Beixi Jia, Tsinghua)
-	</li>
-</ul><h3>
-	<a name="WedC" id="WedC"></a>Sources and Sinks (Prasad Kasibhatla, Duke, Chair)
-</h3>
+<h2>Wednesday, May 6</h2>
 
-<ul><li>
-		<a href="https://drive.google.com/file/d/15y2QP1yJ1aiFIpboxfJ6zQhocj6dV27O/view?usp=drive_link">Source analysis of the ozone-induced vegetation loss in the U.S using the GEOS-Chem adjoint</a> (Kateryna Lapina, U. Colorado-Boulder)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1xqYSYPvObd9NBPfTCmL8tXIPPP1taASI/view?usp=drive_link">Aviation's impact on atmospheric composition</a> (Steven Barrett, MIT)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1qZt4vzprGEcPClgpLdWpEIvYpTtofzOz/view?usp=drive_link">Simulation of N2O sources and sinks with GEOS-Chem and its adjoint: evaluation of observational constraints</a> (Kelley Wells, U. Minnesota)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1s6uPxJkQFG7AZ1Z6t4R3BYhCJpY58DnP/view?usp=drive_link">A new multi-scale framework for atmospheric source inversion in high-dimensional 4D-Var systems</a> (Nicolas, Bousserez, U. Colorado-Boulder)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/10EtyfWFuheTl44E1uaHY0P5YRxWOdYxS/view?usp=drive_link">Weak constraint 4D-Var in CO emission estimation</a> (Martin Keller, U. Toronto)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1LZVASEfdhermbbp75H9EdoRLRqt06rmU/view?usp=drive_link">Source sector and region contributions to concentration and direct radiative forcing of black carbon in China</a> (Ke Li, Chinese Academy of Sciences)
-	</li>
-</ul><h3>
-	<a name="WedP" id="WedP"></a>Posters
-</h3>
+<h3><a name="WedA" id="WedA"></a>Mercury and Persistent Organic Pollutants (Leonard Levin, EPRI, Chair)</h3>
 
-<ul><li>
-		<a href="https://drive.google.com/file/d/1CfFiLskJtuPGn96ke3XlLBxSeJrhErNY/view?usp=drive_link">Parametric uncertainty quantification for PAH simulations</a> (Colin Thackray, MIT)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1s31PTuVRzSzUeLJ2dufGbNAx51f5FdGM/view?usp=drive_link">Impacts of land cover change on biomass burning emissions of mercury</a> (Aditya Kumar, Michigan Tech)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1K4xfOmKA0iiXyzvynpZA3nZLKr_aL5Un/view?usp=drive_link">Quantifying anthropogenic influences on mercury deposition to the Great Lakes and their uncertainty</a> (Amanda Giang, MIT)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1YYY4oc6zUmlcIsbrBX6y7SGtF4aCtjfr/view?usp=drive_link">New insights into mercury reactivity in Central Antarctica (Dome C)</a> (Helene Angot, LGGE, France)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Ky94rQt73LceAStZn5IQU7IrecXXISjr/view?usp=drive_link">Measurements of atmospheric mercury in the Southern Hemisphere: from mid-latitudes to the Pole</a> (Aurélien Dommergue, Grenoble U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1IC5gvi7i_2QZ3tM5nUpnBPPNGmrWCo-F/view?usp=drive_link">A comparison of future air quality scenarios using anthropogenic emissions from the IPCC's Representative Concentration Pathways and MIT's Emissions Prediction and Policy Analysis model</a> (Evan Couzo, MIT)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1gdKcySKokUjrzxOFJAPF2BQJf8BSp69r/view?usp=drive_link">Correlation and regression between meteorological variability and fine particulate matter (PM2.5) in the United States: Comparison between observation and simulation</a> (Aoxing Zhang, Peking U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1iJHhIrRj9HLLyL-R5ftVn9vrsw2jsqyc/view?usp=drive_link">GEOS-Chem Interpretation of SPARTAN: A Global Network to Evaluate and Enhance Satellite-Derived Estimates of PM2.5</a> (Crystal Weagle, Dalhousie)
-	</li>
-	<li>
-		Investigation of the cause of a severe haze event over the North China Plain in winter (Heng Tian, Peking U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/14Pmc-DedvASSElfsLc_4DZWPsLENFSFP/view?usp=drive_link">Feedback of products outsourcing on regional atmosphere pollution in China</a> (Hongyan Zhao, Tsinghua)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1rPW3JJipl8PF-tkFbuX7JyVUfsJ-xTg4/view?usp=drive_link">Estimating ground-level PM2.5 in China using aerosol optical depth determined from the GOCI satellite instrument</a> (Junwei Xu, Dalhousie)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1gik7l3nMYq6gMtOxmWfO9EKYHAvxkCHm/view?usp=drive_link">An investigation of source–receptor relationships for air pollutants in East Asia</a> (Keiya Yumimoto, Meteorological Research Institute/JMA, Japan)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1OPBQs3QS6MFeSnngIxI1N7MinqG6cB4n/view?usp=drive_link">Quantifying the import and export of population-weighted PM2.5 in the Western Hemisphere using satellite-constrained adjoint sensitivity analysis</a> (Luke Reed, U. Colorado–Boulder)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1sdESEhpswAV_tJXPaEgcO6uGs3jZE-FZ/view?usp=drive_link">Impact of future Chinese emissions on trans-Pacific ozone and aerosols</a> (Mingwei Li, MIT)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1llwF1oZhdRmPJeJZ9FnvzYIEDnyD6KQQ/view?usp=drive_link">Analyses of China PM2.5 distributions using the GEOS-Chem model and surface observations</a> (Ping Kang, U. Colorado–Boulder)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1ReSjlxUElU3P5awKMtA85RcnyGTanqXq/view?usp=drive_link">Modeling the meteorological sensitivities of extreme pollution events</a> (Will Porter, MIT)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1rVZqKf2hS_D_z6mWfsh1YN6xU4zRY4MQ/view?usp=drive_link">Global estimates of CO and NOx emissions using multiple species approach (MOPITT CO, TES O3, OMI NO2 and HCHO)</a> (Xuesong Zhang U. Toronto)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1WQLVab90h5sCAAPt8RGy5FHhmDV7wGD-/view?usp=drive_link">Trend and variability of visibility in the North China Plain: observations and model simulations</a> (Yaping Ma, Peking U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1uAxl7Vcr9RHi-H1hzPjqhDX6F6LYNEKn/view?usp=drive_link">Assessment of global environmental impact of supersonic aviation using the GEOS-Chem adjoint</a> (Irene Dedoussi, MIT)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/15Q-XQkHVrttumojs8M0QmRMqFE5huM08/view?usp=drive_link">Parameterizing the near-source chemistry of biomass burning smoke plumes</a> (Chantelle Lonsdale, AER)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1jSfX4VlBamKA-h9CDoUdUXbyn5HkBmZz/view?usp=drive_link">Role of the Madden-Julian Oscillation in severe smoke events over Singapore and Kuala Lumpur: Implications for human health in the Malay Peninsula</a> (Shannon Koplitz, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Liqb8J5WJyfuwNHrJXPNeXDdSHGB6EyO/view?usp=drive_link">Constraining dust sources with the MODIS and MISR observations</a> (Jun Wang for Xiaoguang Xu, U. Nebraska-Lincoln)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/19tfCW1HKUYL4TCFQvO1BVtYsbuNI-4yl/view?usp=drive_link">GEOS-Chem adjoint inversion of SO2 emissions with OMI SO2 observations over China</a> (Yi Wang, U. Nebraska-Lincoln)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Drio1rPwESQnppkP_UIrAkQKWwPV5oUb/view?usp=drive_link">Adjoint inversion of NMVOC sources in China using space-based observations of formaldehyde and glyoxal</a> (Hansen Cao, Peking U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1MU9NPCrX82P6lRMlT4CEOGTKOUA-6jdi/view?usp=drive_link">Improving constraints on sources and distribution of sea salt aerosols in polar regions with GEOS-Chem</a> (Jiayue Huang, U.Washington)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1dbvNxx2iKTcwEjyp9PNEk3ISx34X2OO4/view?usp=drive_link">Global budget of carbonyl sulfide from model and observation</a> (Le(Elva) Kuai, UCLA/JPL)
-	</li>
-</ul><h2>
-	Thursday, May 7
-</h2>
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1DOIk0u9Vj6iFT_-SIfKsMGr2PII5GuGM/view?usp=drive_link">Revisiting atmospheric Hg oxidation mechanisms in GEOS-Chem: constraints from observations</a> (Hannah Horowitz, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/15WZsiE1VJEVg6AcDYSyMBAcRPaCm2FoD/view?usp=drive_link">Constraining Hg oxidation and lifetime</a> (Noelle Selin, MIT)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1QGJitHIAqn0IZAsc-gI5nvfVEdPHRzAb/view?usp=drive_link">Global atmospheric transport and source-receptor relationships for arsenic</a> (Shiliang Wu, Michigan Tech)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1227wOKqUpC889ihyVfgvX1oF5WrfqYul/view?usp=drive_link">Using GEOS-Chem to investigate the effect of multimedia behavior on atmospheric transport of PCBs</a> (Carey Friedman, MIT)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1GL9jgr4MBRklvlmxRBg-AGyb_5uCU2Qm/view?usp=drive_link">Constraining mercury oxidation using the NOMADSS aircraft observations</a> (Viral Shah, U. Washington)
+  </li>
+  <li>
+    Effects of changes in climate and land use and land cover on atmospheric mercury (Huanxin Zhang, Michigan Tech)
+  </li>
+  <li>
+    Improving the parameterization of land-surface exchange in the in the GEOS-Chem Hg model (Shaojie Song, MIT)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1bkioUbA7B1ZlwE23dDvyQlBGFGSCH4Vm/view?usp=drive_link">A flat global trend suggests a more important role for domestic emission reduction for observed decrease for atmospheric mercury level over the United States</a> (Yanxu Zhang, Harvard)
+  </li>
+</ul>
 
-<h3>
-	<a name="ThuA" id="ThuA"></a>Tropospheric Ozone (Hiroshi Tanimoto, NIES Japan, Chair)
-</h3>
+<h3><a name="WedB" id="WedB"></a>Regional and Global Air Quality (Amos Tai, Chinese U. Hong Kong, Chair)</h3>
 
-<ul><li>
-		<a href="https://drive.google.com/file/d/1F-TMd_E5oW51HoORwkm6PR825LbcrFr_/view?usp=drive_link">Novel global evaluation of surface ozone in GEOS-Chem</a> (Eric Sofen, U. York)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/17RqCXnXwKa5ZwcTCCxF532CftCux7bSe/view?usp=drive_link">Chemical transformations of pollutants during winter: Initial analysis of the WINTER 2015 aircraft campaign</a> (Lyatt Jaeglé, U. Washington)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/123BCFbTqbjQpK4EsD5g2g2vhOgiVwDaf/view?usp=drive_link">Declining NOx in the Southeast U.S. and implications for ozone-NOx-VOC chemistry</a> (Katie Travis, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1wmRRfrlAld3QCtZEj-f6S1dd59Jmg3kA/view?usp=drive_link">Impact of grid resolution on tropospheric chemistry simulation constrained by observations from the SEAC4RS aircraft campaign</a> (Karen Yu, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1lFiiGV_3ZQ4CwGy6xE9sVX321IqDvndI/view?usp=drive_link">Ozone production in biomass burning plumes</a> (Douglas Finch, U. Edinburgh)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/15XIrpX1Rnr082j-CrMDvHup8Htr2K2g5/view?usp=drive_link">Factors controlling global tropospheric ozone: roles of convection, halogens, lightning, and isoprene</a> (Lu Hu, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1AYhwBn5XOsm8HdrWRV3gHk2L-jG2FMgO/view?usp=drive_link">Tropospheric ozone by the two-way coupled model of GEOS-Chem</a> (Yingying Yan, Peking U.)
-	</li>
-</ul><h3>
-	<a name="ThuB" id="ThuB"></a>Nitrogen Cycle (Jenny Fisher, U. Wollongong, Chair)
-</h3>
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1fpxn13z_8OvmOH83HqfyxHSaESuaNn07/view?usp=drive_link">Regional and global impacts of Southeast Asian coal emissions on particulate matter and ozone</a> (Shannon Koplitz, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/18nTV-NWp-Zhj9_Oa9FssPr7hv-DVsJHy/view?usp=drive_link">Global pollution and transport</a> (Jintai Lin, Peking U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1WIQGKBAnl93pJlX7pbn7SuqhCtMiS2Xb/view?usp=drive_link">Space-based constraints on VOC emissions in the Pearl River Delta</a> (Christopher Miller, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1uTXl1VygE727xhNhED2McA3BtrAygJVV/view?usp=drive_link">Combining GEOS-Chem with satellite for improved PM2.5 population exposure estimates</a> (Aaron van Donkelaar, Dalhousie)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1A5Z5bhGP0Z2u4AruHdb3wOTOTFABjrwj/view?usp=drive_link">Uncertainties in estimating health effects of PM2.5 exposure</a> (Bonne Ford, Colorado State U.)
+  </li>
+  <li>
+    Evaluation the health and climate impacts of cookstove emissions using the GEOS-Chem adjoint model (Forrest Lacey, U. Colorado–Boulder)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1GDSQf9JBYybZGkOVQpKAkgjHKPz3Cnw8/view?usp=drive_link">’APEC Blue' in North China simulated with the high resolution nested GEOS-Chem model</a> (Yixuan Gu, Chinese Academy of Sciences)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1uLBrbnc78OAAdpNd5Jb1WJxMbsrfHsCy/view?usp=drive_link">Impacts of large-scale circulation patterns on winter haze over China: interannual variability and extreme events</a> (Beixi Jia, Tsinghua)
+  </li>
+</ul>
 
-<ul><li>
-		<a href="https://drive.google.com/file/d/1Ui2cvpuHaQdE0yXysnN8Yz0ycEiPaLfN/view?usp=drive_link">Assessing the parameterization of NOx emissions by lightning in GEOS-Chem with HNO3 Columns from IASI</a> (Matthew Cooper, Dalhousie)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1A9T7E9qJcUTr4ONLj8bpX4zeUCbn_F8j/view?usp=drive_link">Modeling of gaseous methylamines in the global atmosphere</a> (Fangqun Yu, SUNY-Albany)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1t2XRKZJ-ENdgytOsW3RuWYAal7fC0R3T/view?usp=drive_link">Modeling of lightning related plumes of NOy into the chemical transport GEOS-Chem global model: impact on the upper tropospheric chemistry</a> (Alicia Gressent, LA/U. Paul Sabatier)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1fBM74xGrxNHFuGUs_9KuWaf7ICGVfWyt/view?usp=drive_link">Atmospheric nitrogen deposition to the northwestern Pacific: seasonal variation and source attribution</a> (Yuanhong Zhao, Peking U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/15N51E76g86Z1L9nHTmkYltKmCYLW5onH/view?usp=drive_link">Incorporation of a snow NOx source into a global chemical transport model: impact on boundary layer chemistry and implications for ice core records in Antarctica and Greenland</a> (Maria Zatko, U. Washington)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Ap_q4amHf-gB5RifQZd07aE3QeVj9n1c/view?usp=drive_link">Assessment of the sources and distribution of PAN over Northern Eurasia using GEOS-Chem and new measurements from TES</a> (Juliet Zhu, Colorado State U.)
-	</li>
+<h3><a name="WedC" id="WedC"></a>Sources and Sinks (Prasad Kasibhatla, Duke, Chair)</h3>
+
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/15y2QP1yJ1aiFIpboxfJ6zQhocj6dV27O/view?usp=drive_link">Source analysis of the ozone-induced vegetation loss in the U.S using the GEOS-Chem adjoint</a> (Kateryna Lapina, U. Colorado-Boulder)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1xqYSYPvObd9NBPfTCmL8tXIPPP1taASI/view?usp=drive_link">Aviation's impact on atmospheric composition</a> (Steven Barrett, MIT)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1qZt4vzprGEcPClgpLdWpEIvYpTtofzOz/view?usp=drive_link">Simulation of N2O sources and sinks with GEOS-Chem and its adjoint: evaluation of observational constraints</a> (Kelley Wells, U. Minnesota)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1s6uPxJkQFG7AZ1Z6t4R3BYhCJpY58DnP/view?usp=drive_link">A new multi-scale framework for atmospheric source inversion in high-dimensional 4D-Var systems</a> (Nicolas, Bousserez, U. Colorado-Boulder)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/10EtyfWFuheTl44E1uaHY0P5YRxWOdYxS/view?usp=drive_link">Weak constraint 4D-Var in CO emission estimation</a> (Martin Keller, U. Toronto)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1LZVASEfdhermbbp75H9EdoRLRqt06rmU/view?usp=drive_link">Source sector and region contributions to concentration and direct radiative forcing of black carbon in China</a> (Ke Li, Chinese Academy of Sciences)
+  </li>
+</ul>
+
+<h3><a name="WedP" id="WedP"></a>Posters</h3>
+
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1CfFiLskJtuPGn96ke3XlLBxSeJrhErNY/view?usp=drive_link">Parametric uncertainty quantification for PAH simulations</a> (Colin Thackray, MIT)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1s31PTuVRzSzUeLJ2dufGbNAx51f5FdGM/view?usp=drive_link">Impacts of land cover change on biomass burning emissions of mercury</a> (Aditya Kumar, Michigan Tech)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1K4xfOmKA0iiXyzvynpZA3nZLKr_aL5Un/view?usp=drive_link">Quantifying anthropogenic influences on mercury deposition to the Great Lakes and their uncertainty</a> (Amanda Giang, MIT)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1YYY4oc6zUmlcIsbrBX6y7SGtF4aCtjfr/view?usp=drive_link">New insights into mercury reactivity in Central Antarctica (Dome C)</a> (Helene Angot, LGGE, France)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Ky94rQt73LceAStZn5IQU7IrecXXISjr/view?usp=drive_link">Measurements of atmospheric mercury in the Southern Hemisphere: from mid-latitudes to the Pole</a> (Aurélien Dommergue, Grenoble U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1IC5gvi7i_2QZ3tM5nUpnBPPNGmrWCo-F/view?usp=drive_link">A comparison of future air quality scenarios using anthropogenic emissions from the IPCC's Representative Concentration Pathways and MIT's Emissions Prediction and Policy Analysis model</a> (Evan Couzo, MIT)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1gdKcySKokUjrzxOFJAPF2BQJf8BSp69r/view?usp=drive_link">Correlation and regression between meteorological variability and fine particulate matter (PM2.5) in the United States: Comparison between observation and simulation</a> (Aoxing Zhang, Peking U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1iJHhIrRj9HLLyL-R5ftVn9vrsw2jsqyc/view?usp=drive_link">GEOS-Chem Interpretation of SPARTAN: A Global Network to Evaluate and Enhance Satellite-Derived Estimates of PM2.5</a> (Crystal Weagle, Dalhousie)
+  </li>
+  <li>
+    Investigation of the cause of a severe haze event over the North China Plain in winter (Heng Tian, Peking U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/14Pmc-DedvASSElfsLc_4DZWPsLENFSFP/view?usp=drive_link">Feedback of products outsourcing on regional atmosphere pollution in China</a> (Hongyan Zhao, Tsinghua)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1rPW3JJipl8PF-tkFbuX7JyVUfsJ-xTg4/view?usp=drive_link">Estimating ground-level PM2.5 in China using aerosol optical depth determined from the GOCI satellite instrument</a> (Junwei Xu, Dalhousie)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1gik7l3nMYq6gMtOxmWfO9EKYHAvxkCHm/view?usp=drive_link">An investigation of source–receptor relationships for air pollutants in East Asia</a> (Keiya Yumimoto, Meteorological Research Institute/JMA, Japan)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1OPBQs3QS6MFeSnngIxI1N7MinqG6cB4n/view?usp=drive_link">Quantifying the import and export of population-weighted PM2.5 in the Western Hemisphere using satellite-constrained adjoint sensitivity analysis</a> (Luke Reed, U. Colorado–Boulder)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1sdESEhpswAV_tJXPaEgcO6uGs3jZE-FZ/view?usp=drive_link">Impact of future Chinese emissions on trans-Pacific ozone and aerosols</a> (Mingwei Li, MIT)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1llwF1oZhdRmPJeJZ9FnvzYIEDnyD6KQQ/view?usp=drive_link">Analyses of China PM2.5 distributions using the GEOS-Chem model and surface observations</a> (Ping Kang, U. Colorado–Boulder)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1ReSjlxUElU3P5awKMtA85RcnyGTanqXq/view?usp=drive_link">Modeling the meteorological sensitivities of extreme pollution events</a> (Will Porter, MIT)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1rVZqKf2hS_D_z6mWfsh1YN6xU4zRY4MQ/view?usp=drive_link">Global estimates of CO and NOx emissions using multiple species approach (MOPITT CO, TES O3, OMI NO2 and HCHO)</a> (Xuesong Zhang U. Toronto)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1WQLVab90h5sCAAPt8RGy5FHhmDV7wGD-/view?usp=drive_link">Trend and variability of visibility in the North China Plain: observations and model simulations</a> (Yaping Ma, Peking U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1uAxl7Vcr9RHi-H1hzPjqhDX6F6LYNEKn/view?usp=drive_link">Assessment of global environmental impact of supersonic aviation using the GEOS-Chem adjoint</a> (Irene Dedoussi, MIT)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/15Q-XQkHVrttumojs8M0QmRMqFE5huM08/view?usp=drive_link">Parameterizing the near-source chemistry of biomass burning smoke plumes</a> (Chantelle Lonsdale, AER)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1jSfX4VlBamKA-h9CDoUdUXbyn5HkBmZz/view?usp=drive_link">Role of the Madden-Julian Oscillation in severe smoke events over Singapore and Kuala Lumpur: Implications for human health in the Malay Peninsula</a> (Shannon Koplitz, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Liqb8J5WJyfuwNHrJXPNeXDdSHGB6EyO/view?usp=drive_link">Constraining dust sources with the MODIS and MISR observations</a> (Jun Wang for Xiaoguang Xu, U. Nebraska-Lincoln)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/19tfCW1HKUYL4TCFQvO1BVtYsbuNI-4yl/view?usp=drive_link">GEOS-Chem adjoint inversion of SO2 emissions with OMI SO2 observations over China</a> (Yi Wang, U. Nebraska-Lincoln)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Drio1rPwESQnppkP_UIrAkQKWwPV5oUb/view?usp=drive_link">Adjoint inversion of NMVOC sources in China using space-based observations of formaldehyde and glyoxal</a> (Hansen Cao, Peking U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1MU9NPCrX82P6lRMlT4CEOGTKOUA-6jdi/view?usp=drive_link">Improving constraints on sources and distribution of sea salt aerosols in polar regions with GEOS-Chem</a> (Jiayue Huang, U.Washington)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1dbvNxx2iKTcwEjyp9PNEk3ISx34X2OO4/view?usp=drive_link">Global budget of carbonyl sulfide from model and observation</a> (Le(Elva) Kuai, UCLA/JPL)
+  </li>
+</ul>
+
+<h2>Thursday, May 7</h2>
+
+<h3><a name="ThuA" id="ThuA"></a>Tropospheric Ozone (Hiroshi Tanimoto, NIES Japan, Chair)</h3>
+
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1F-TMd_E5oW51HoORwkm6PR825LbcrFr_/view?usp=drive_link">Novel global evaluation of surface ozone in GEOS-Chem</a> (Eric Sofen, U. York)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/17RqCXnXwKa5ZwcTCCxF532CftCux7bSe/view?usp=drive_link">Chemical transformations of pollutants during winter: Initial analysis of the WINTER 2015 aircraft campaign</a> (Lyatt Jaeglé, U. Washington)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/123BCFbTqbjQpK4EsD5g2g2vhOgiVwDaf/view?usp=drive_link">Declining NOx in the Southeast U.S. and implications for ozone-NOx-VOC chemistry</a> (Katie Travis, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1wmRRfrlAld3QCtZEj-f6S1dd59Jmg3kA/view?usp=drive_link">Impact of grid resolution on tropospheric chemistry simulation constrained by observations from the SEAC4RS aircraft campaign</a> (Karen Yu, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1lFiiGV_3ZQ4CwGy6xE9sVX321IqDvndI/view?usp=drive_link">Ozone production in biomass burning plumes</a> (Douglas Finch, U. Edinburgh)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/15XIrpX1Rnr082j-CrMDvHup8Htr2K2g5/view?usp=drive_link">Factors controlling global tropospheric ozone: roles of convection, halogens, lightning, and isoprene</a> (Lu Hu, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1AYhwBn5XOsm8HdrWRV3gHk2L-jG2FMgO/view?usp=drive_link">Tropospheric ozone by the two-way coupled model of GEOS-Chem</a> (Yingying Yan, Peking U.)
+  </li>
+</ul>
+
+<h3><a name="ThuB" id="ThuB"></a>Nitrogen Cycle (Jenny Fisher, U. Wollongong, Chair)</h3>
+
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1Ui2cvpuHaQdE0yXysnN8Yz0ycEiPaLfN/view?usp=drive_link">Assessing the parameterization of NOx emissions by lightning in GEOS-Chem with HNO3 Columns from IASI</a> (Matthew Cooper, Dalhousie)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1A9T7E9qJcUTr4ONLj8bpX4zeUCbn_F8j/view?usp=drive_link">Modeling of gaseous methylamines in the global atmosphere</a> (Fangqun Yu, SUNY-Albany)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1t2XRKZJ-ENdgytOsW3RuWYAal7fC0R3T/view?usp=drive_link">Modeling of lightning related plumes of NOy into the chemical transport GEOS-Chem global model: impact on the upper tropospheric chemistry</a> (Alicia Gressent, LA/U. Paul Sabatier)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1fBM74xGrxNHFuGUs_9KuWaf7ICGVfWyt/view?usp=drive_link">Atmospheric nitrogen deposition to the northwestern Pacific: seasonal variation and source attribution</a> (Yuanhong Zhao, Peking U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/15N51E76g86Z1L9nHTmkYltKmCYLW5onH/view?usp=drive_link">Incorporation of a snow NOx source into a global chemical transport model: impact on boundary layer chemistry and implications for ice core records in Antarctica and Greenland</a> (Maria Zatko, U. Washington)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Ap_q4amHf-gB5RifQZd07aE3QeVj9n1c/view?usp=drive_link">Assessment of the sources and distribution of PAN over Northern Eurasia using GEOS-Chem and new measurements from TES</a> (Juliet Zhu, Colorado State U.)
+  </li>
 </ul>
 
 </div>
@@ -716,64 +706,16 @@
 </div>
 </div>
 
-<!--footer region beg-->
+<!--footer-->
 <footer id="footer" class="clearfix" role="contentinfo">
-
-<!-- Three column 3x33 Gpanel -->
-<div class="at-panel gpanel panel-display footer clearfix">
-<div class="region region-footer">
-<div class="region-inner clearfix">
-<div id="block-boxes-1617037690" class="block block-boxes block-boxes-os_boxes_html no-title"  module="boxes" delta="1617037690">
-<div class="block-inner clearfix">  
-<div class="block-content content" ng-non-bindable="">  
-<div id='boxes-box-1617037690' class='boxes-box'>  
 <div class="boxes-box-content">
   <p style="text-align:center">
-    Copyright © 2023 by the International GEOS-Chem Community. All rights reserved.
+    Copyright © 2026 by the International GEOS-Chem Community. All rights reserved.
   </p>
 </div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-<div class="region region-footer-bottom">  
-<div class="region-inner clearfix">  
-<div id="block-boxes-1616879798" class="block block-boxes block-boxes-os_boxes_media no-title"  module="boxes" delta="1616879798">  
-<div class="block-inner clearfix">  
-<div class="block-content content"> 
-<div id='boxes-box-1616879798' class='boxes-box'> 
-<div class="boxes-box-content"> 
-<div id="file-3900146" class="file file-html file-html-embed">
-<h2 class="element-invisible"><a href="">css-brand</a></h2>
-<div class="content">
-<div class="file-info">
-</div>
-<div class="field field-name-field-html-code field-type-text-long field-label-hidden view-mode-full">
-<div class="field-items">
-<div class="field-item even">
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-
-<!--footer region end-->
 </footer>
-</div>
-</div>
 
-<!--page area ends-->
-<div id="extradiv"></div>
+</div>
 </div>
 
 </body>

--- a/igc7.html
+++ b/igc7.html
@@ -1,9 +1,4 @@
 <!DOCTYPE html>
-<!--[if IEMobile 7]><html class="iem7"  lang="en" dir="ltr"><![endif]-->
-<!--[if lte IE 6]><html class="lt-ie9 lt-ie8 lt-ie7"  lang="en" dir="ltr"><![endif]-->
-<!--[if (IE 7)&(!IEMobile)]><html class="lt-ie9 lt-ie8"  lang="en" dir="ltr"><![endif]-->
-<!--[if IE 8]><html class="lt-ie9"  lang="en" dir="ltr"><![endif]-->
-<!--[if (gte IE 9)|(gt IEMobile 7)]><!--><html  lang="en" dir="ltr"><!--<![endif]-->
 <head>
 <meta charset="utf-8" />
 <!--<base href="/igc7" />-->
@@ -18,23 +13,12 @@
 <title>The 7th International GEOS-Chem Meeting</title>
 <meta http-equiv="x-ua-compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<link type="text/css" rel="stylesheet" href="css/css_xE-rWrJf-fncB6ztZfd2huxqgxu4WO-qwma6Xer30m4%EF%B9%96m=1675397288.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_1kR8T1_c-l5pBT6ZwbDT7BFda-4fyqW9Jjum29_2IY8%EF%B9%96m=1675397312.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_YnlUIvHP13qgpYEqubzE8JyDwlSxUnVibfnVkSoSDb0%EF%B9%96m=1675397273.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_Ku-3OcT9qU9h7dnGig5e23q6EVryY8orK4wzVDxsweE%EF%B9%96m=1675397367.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_vprtFTrWyg23GbY50_zJZHWGYMNfS8vsrRS26i4-ISk%EF%B9%96m=1675397406.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_dW-aNNrctRhQNc-KECjtQd0PxuW-h19IEum-TX2MeEk%EF%B9%96m=1675397301.css" media="print" />
-<link type="text/css" rel="stylesheet" href="css/css_SH2Lx3Qprh0GZo_9xRp85U9NsWfkSXn_Bi-rJoMY1sw%EF%B9%96m=1675397273.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_uaIDKcYMUK5osSQXuirpr3ZleXtnnpBN-eiECm7N0M0%EF%B9%96m=1675397395.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/responsive.blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/geos-chem.css" media="all"/>
 <script type="text/javascript" src="dropdown-menu.js"></script>
-<!--[if lte IE 8]>
-<script type="text/javascript">
-  var os_c = document.createElement;os_c('header');os_c('nav');os_c('section');os_c('article');os_c('aside');os_c('footer');os_c('hgroup');os_c('figure');
-</script>
-<![endif]-->
 </head>
 
 <body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-1585687 node-type-page og-context og-context-node og-context-node-1585652 navbar-on">
@@ -76,10 +60,11 @@ The 7th International GEOS-Chem Meeting (IGC7)
 
 <!--main menu region beg-->
 <div id="menu-bar" class="nav region-menu-bar clearfix">
-<nav id="block-os-igc7-menu" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="igc7_menu">  
-<ul class="nice-menu nice-menu-down nice-menu-igc7_menu" id="nice-menu-igc7_menu">
-  <li class="menu-858765 menu-path-node-1586831  first   odd  "><a href="igc7.html"  class="active">Home</a></li>
-  <li class="menu-858776 menu-path-node-1586837   even   last "><a href="igc7-presentations.html" >Presentations and Posters</a></li>
+<nav id="block-os-igc7-menu" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="igc7_menu">
+<ul class="nice-menu nice-menu-down">
+  <li><a href="igc7.html" class="active">IGC7 Home</a></li>
+  <li><a href="igc7-presentations.html">Presentations and Posters</a></li>
+  <li><a href="index.html">GEOS-Chem Home</a></li>
 </ul>
 </nav>
 </div>
@@ -108,8 +93,7 @@ The 7th International GEOS-Chem Meeting (IGC7)
 <div class="field-items">
 <div class="field-item even">
 
-<p>
-	The 7th International GEOS-Chem Meeting (IGC7) was held at Harvard University (Cambridge, MA, USA) from May 4–7, 2015. Please see our <a href="igc7-presentations.html" title="">Presentations and Posters</a> page to view the presentations and posters from the meeting.
+<p>The 7th International GEOS-Chem Meeting (IGC7) was held at Harvard University (Cambridge, MA, USA) from May 4–7, 2015. Please see our <a href="igc7-presentations.html" title="">Presentations and Posters</a> page to view the presentations and posters from the meeting.
 </p>
 
 </div>
@@ -131,64 +115,16 @@ The 7th International GEOS-Chem Meeting (IGC7)
 </div>
 </div>
 
-<!--footer region beg-->
+<!--footer-->
 <footer id="footer" class="clearfix" role="contentinfo">
-
-<!-- Three column 3x33 Gpanel -->
-<div class="at-panel gpanel panel-display footer clearfix">
-<div class="region region-footer">
-<div class="region-inner clearfix">
-<div id="block-boxes-1617037690" class="block block-boxes block-boxes-os_boxes_html no-title"  module="boxes" delta="1617037690">
-<div class="block-inner clearfix">  
-<div class="block-content content" ng-non-bindable="">  
-<div id='boxes-box-1617037690' class='boxes-box'>  
 <div class="boxes-box-content">
   <p style="text-align:center">
-    Copyright © 2023 by the International GEOS-Chem Community. All rights reserved.
+    Copyright © 2026 by the International GEOS-Chem Community. All rights reserved.
   </p>
 </div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-<div class="region region-footer-bottom">  
-<div class="region-inner clearfix">  
-<div id="block-boxes-1616879798" class="block block-boxes block-boxes-os_boxes_media no-title"  module="boxes" delta="1616879798">  
-<div class="block-inner clearfix">  
-<div class="block-content content"> 
-<div id='boxes-box-1616879798' class='boxes-box'> 
-<div class="boxes-box-content"> 
-<div id="file-3900146" class="file file-html file-html-embed">
-<h2 class="element-invisible"><a href="">css-brand</a></h2>
-<div class="content">
-<div class="file-info">
-</div>
-<div class="field field-name-field-html-code field-type-text-long field-label-hidden view-mode-full">
-<div class="field-items">
-<div class="field-item even">
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-
-<!--footer region end-->
 </footer>
-</div>
-</div>
 
-<!--page area ends-->
-<div id="extradiv"></div>
+</div>
 </div>
 
 </body>

--- a/igc8-presentations.html
+++ b/igc8-presentations.html
@@ -1,9 +1,4 @@
 <!DOCTYPE html>
-<!--[if IEMobile 7]><html class="iem7"  lang="en" dir="ltr"><![endif]-->
-<!--[if lte IE 6]><html class="lt-ie9 lt-ie8 lt-ie7"  lang="en" dir="ltr"><![endif]-->
-<!--[if (IE 7)&(!IEMobile)]><html class="lt-ie9 lt-ie8"  lang="en" dir="ltr"><![endif]-->
-<!--[if IE 8]><html class="lt-ie9"  lang="en" dir="ltr"><![endif]-->
-<!--[if (gte IE 9)|(gt IEMobile 7)]><!--><html  lang="en" dir="ltr"><!--<![endif]-->
 <head>
 <meta charset="utf-8" />
 <!--<base href="/igc8-presentations" />-->
@@ -18,23 +13,12 @@
 <title>The 8th International GEOS-Chem Meeting</title>
 <meta http-equiv="x-ua-compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<link type="text/css" rel="stylesheet" href="css/css_xE-rWrJf-fncB6ztZfd2huxqgxu4WO-qwma6Xer30m4%EF%B9%96m=1675397288.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_1kR8T1_c-l5pBT6ZwbDT7BFda-4fyqW9Jjum29_2IY8%EF%B9%96m=1675397312.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_YnlUIvHP13qgpYEqubzE8JyDwlSxUnVibfnVkSoSDb0%EF%B9%96m=1675397273.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_Ku-3OcT9qU9h7dnGig5e23q6EVryY8orK4wzVDxsweE%EF%B9%96m=1675397367.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_vprtFTrWyg23GbY50_zJZHWGYMNfS8vsrRS26i4-ISk%EF%B9%96m=1675397406.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_dW-aNNrctRhQNc-KECjtQd0PxuW-h19IEum-TX2MeEk%EF%B9%96m=1675397301.css" media="print" />
-<link type="text/css" rel="stylesheet" href="css/css_SH2Lx3Qprh0GZo_9xRp85U9NsWfkSXn_Bi-rJoMY1sw%EF%B9%96m=1675397273.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_uaIDKcYMUK5osSQXuirpr3ZleXtnnpBN-eiECm7N0M0%EF%B9%96m=1675397395.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/responsive.blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/geos-chem.css" media="all"/>
 <script type="text/javascript" src="dropdown-menu.js"></script>
-<!--[if lte IE 8]>
-<script type="text/javascript">
-  var os_c = document.createElement;os_c('header');os_c('nav');os_c('section');os_c('article');os_c('aside');os_c('footer');os_c('hgroup');os_c('figure');
-</script>
-<![endif]-->
 </head>
 
 <body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-1585687 node-type-page og-context og-context-node og-context-node-1585652 navbar-on">
@@ -45,7 +29,7 @@
 <div id="page_wrap" class="page_wrap">
 <div id="page" class="container page header-main content-top footer-none">
 <div id="page-wrapper">
-		
+
 <!--header regions beg-->
 <header id="header" class="clearfix" role="banner">
 <div id="header-container">
@@ -53,7 +37,7 @@
 <div class="region region-header-second">
 <div class="region-inner clearfix">
 <div id="block-boxes-1617807424" class="block block-boxes block-boxes-os_boxes_html no-title"  module="boxes" delta="1617807424">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <div class="block-content content" ng-non-bindable="">
 <div id='boxes-box-1617807424' class='boxes-box'>
 <div class="boxes-box-content">
@@ -76,16 +60,16 @@ The 8th International GEOS-Chem Meeting<br />May 1-4, 2017
 
 <!--main menu region beg-->
 <div id="menu-bar" class="nav region-menu-bar clearfix">
-<nav id="block-os-igc8-menu" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="igc8_menu">  
-<ul class="nice-menu nice-menu-down nice-menu-igc8_menu" id="nice-menu-igc8_menu">
-  <li class="menu-858656 menu-path-node-1586817  first   odd  "><a href="igc8.html"  class="active">Home</a></li>
-  <li class="menu-858670 menu-path-node-1586819   even  "><a href="igc8-presentations.html" >Presentations and Posters</a></li>
-  <li class="menu-858665 menu-path-node-1586818   odd   last "><a href="igc8-webcast.html" >Webcast Archive</a></li>
+<nav id="block-os-igc8-menu" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="igc8_menu">
+<ul class="nice-menu nice-menu-down">
+  <li><a href="igc8.html" class="active">IGC8 Home</a></li>
+  <li><a href="igc8-presentations.html">Presentations and Posters</a></li>
+  <li><a href="index.html">GEOS-Chem Home</a></li>
 </ul>
 </nav>
 </div>
 <!--main menu region end-->
-		
+
 <div id="columns" class="clearfix">
 <div class="hg-container">
 <div id="content-column" role="main">
@@ -101,7 +85,7 @@ The 8th International GEOS-Chem Meeting<br />May 1-4, 2017
 <div class="region region-content-top">
 <div class="region-inner clearfix">
 <div id="block-os-pages-main-content" class="block block-os-pages no-title"  module="os_pages" delta="main_content">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <div class="block-content content" ng-non-bindable="">
 <article id="node-1585687" class="node node-page article clearfix" role="article">
 <div class="node-content" ng-non-bindable="">
@@ -109,610 +93,618 @@ The 8th International GEOS-Chem Meeting<br />May 1-4, 2017
 <div class="field-items">
 <div class="field-item even">
 <p align="justify">
-	Monday, May 1: <a href="#MonA">Model Overview</a> | <a href="#MonB">Working Groups</a> | <a href="#MonD">Chemistry</a> | <a href="#MonE">Carbon Gases</a> | <a href="#MonC">Model Clinics</a> | <a href="#MonP">Posters</a><br class="clearfix" />Tuesday, May 2: <a href="#TueA">Aerosols</a> | <a href="#TueB">Aerosol Microphysics</a> | <a href="#TueD">Transport</a> | <a href="#TueE">Sources &amp; Sinks</a> | <a href="#TueC">Model Clinics</a> | <a href="#TueP">Posters</a><br class="clearfix" />Wednesday, May 3: <a href="#WedA">Chem-Ecosys-Clim</a> | <a href="#WedB">Air Quality Implications</a> | <a href="#WedC">Air Quality Science</a> | <a href="#WedD">Model Clinics</a> | <a href="#WedP">Posters</a><br class="clearfix" />Thursday, May 4: <a href="#ThuA">Future Directions</a>
+  Monday, May 1: <a href="#MonA">Model Overview</a> | <a href="#MonB">Working Groups</a> | <a href="#MonD">Chemistry</a> | <a href="#MonE">Carbon Gases</a> | <a href="#MonC">Model Clinics</a> | <a href="#MonP">Posters</a><br class="clearfix" />Tuesday, May 2: <a href="#TueA">Aerosols</a> | <a href="#TueB">Aerosol Microphysics</a> | <a href="#TueD">Transport</a> | <a href="#TueE">Sources &amp; Sinks</a> | <a href="#TueC">Model Clinics</a> | <a href="#TueP">Posters</a><br class="clearfix" />Wednesday, May 3: <a href="#WedA">Chem-Ecosys-Clim</a> | <a href="#WedB">Air Quality Implications</a> | <a href="#WedC">Air Quality Science</a> | <a href="#WedD">Model Clinics</a> | <a href="#WedP">Posters</a><br class="clearfix" />Thursday, May 4: <a href="#ThuA">Future Directions</a>
 </p>
 
-<h2>
-	Monday, May 1
-</h2>
+<h2>Monday, May 1</h2>
 
-<h3>
-	<a name="MonA" id="MonA"></a>Model Overview (Daniel Jacob, Harvard, Chair)
-</h3>
+<h3><a name="MonA" id="MonA"></a>Model Overview (Daniel Jacob, Harvard, Chair)</h3>
 
-<ul><li>
-		<a href="https://drive.google.com/file/d/1X5JJMi3dwjUyQZX9lir7NFGhSBldDSGB/view?usp=drive_link" target="_blank">Welcome and GEOS-Chem overview</a> (Daniel Jacob, Harvard and Randall Martin, Dalhousie)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1E2hRhfDjHePpEE1NTO5LGm-A2rmlGnEc/view?usp=drive_link" target="_blank">High-performance GEOS-Chem (GCHP) and flexible chemistry (FlexChem)</a> (Michael Long, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1YsjYRF1z3CVr6Y_AMXgSiu3Ue2IAKEEQ/view?usp=drive_link" target="_blank">The GEOS-Chem adjoint model</a> (Daven Henze, CU-Boulder)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1bpjzTD0Ju1RHPTw3-FQg-Wonuki0vzQ_/view?usp=drive_link" target="_blank">GEOS-Chem Support Team activities</a> (Bob Yantosca, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Z4OwlhxU5JkWBal_B9X871HPbOqS8H9W/view?usp=drive_link" target="_blank">Update on GMAO Forward Processing System</a> (Andrea Molod, NASA GSFC – GMAO)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1QV5qBfJmlg-w90nu3hhV8lwar3p-iQQb/view?usp=drive_link" target="_blank">Towards chemical forecasting with the GMAO's GEOS models </a>(Steven Pawson, NASA GSFC – GMAO)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1uwyLA1sHZlNx3w31ApcVCQzyEmpLa_3S/view?usp=drive_link" target="_blank">The GEOS-5 nature run with tropospheric chemistry</a> (Christoph Keller, NASA GSFC – GMAO)
-	</li>
-</ul><h3>
-	<a name="MonB" id="MonB"></a>GEOS-Chem Working Groups (Amos Tai, CUHK, Chair)
-</h3>
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1X5JJMi3dwjUyQZX9lir7NFGhSBldDSGB/view?usp=drive_link" target="_blank">Welcome and GEOS-Chem overview</a> (Daniel Jacob, Harvard and Randall Martin, Dalhousie)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1E2hRhfDjHePpEE1NTO5LGm-A2rmlGnEc/view?usp=drive_link" target="_blank">High-performance GEOS-Chem (GCHP) and flexible chemistry (FlexChem)</a> (Michael Long, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1YsjYRF1z3CVr6Y_AMXgSiu3Ue2IAKEEQ/view?usp=drive_link" target="_blank">The GEOS-Chem adjoint model</a> (Daven Henze, CU-Boulder)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1bpjzTD0Ju1RHPTw3-FQg-Wonuki0vzQ_/view?usp=drive_link" target="_blank">GEOS-Chem Support Team activities</a> (Bob Yantosca, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Z4OwlhxU5JkWBal_B9X871HPbOqS8H9W/view?usp=drive_link" target="_blank">Update on GMAO Forward Processing System</a> (Andrea Molod, NASA GSFC – GMAO)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1QV5qBfJmlg-w90nu3hhV8lwar3p-iQQb/view?usp=drive_link" target="_blank">Towards chemical forecasting with the GMAO's GEOS models </a>(Steven Pawson, NASA GSFC – GMAO)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1uwyLA1sHZlNx3w31ApcVCQzyEmpLa_3S/view?usp=drive_link" target="_blank">The GEOS-5 nature run with tropospheric chemistry</a> (Christoph Keller, NASA GSFC – GMAO)
+  </li>
+</ul>
 
-<ul><li>
-		<a href="https://drive.google.com/file/d/1JSW1FuWPeKY6GwXWKBzNHt0aTcKnVIxQ/view?usp=drive_link" target="_blank">Transport Working Group</a> (Hongyu Liu, NIA/NASA Langley and Andrea Molod, NASA GSFC – GMAO)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1A5G7GKVPQnGxKbCMkeCkTQSHuYo_Wr0G/view?usp=drive_link" target="_blank">Chemistry and Organics Working Group</a> (Mat Evans, U. York; Barron Henderson, US EPA; Emily Fischer, CSU; Dylan Millet, U. Minnesota)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1T5tXoLzzhPxkdE0bIcEPzlq4Fd3qQJgA/view?usp=drive_link" target="_blank">Aerosols Working Group</a> (Colette Heald, MIT and Jeff Pierce, CSU)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1vD3LFYgVHn4U7x3u4Kq14aYedq-Vd6W7/view?usp=drive_link" target="_blank">Sources and surface sinks Working Group</a> (Jintai Lin, PKU and Qiang Zhang, Tsinghua)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1L8dB6cTN1taT7kBX48Sj48sBBbA5HeGt/view?usp=drive_link" target="_blank">Chemistry-Climate Working Group</a> (Shiliang Wu, Michigan Tech)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1AbRU4P94KmbtpjDck3wL71Z3T6CMzVJn/view?usp=drive_link" target="_blank">Carbon Cycle and Data Assimilation Working Group</a> (Kevin Bowman, JPL and Dylan Jones, U. Toronto)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1b-gBwUcQngVvwmpLsmXmvb2GgDwtLiSu/view?usp=drive_link" target="_blank">Nested Model Working Group</a> (Yuxuan Wang, U. Houston; Jun Wang, U. Iowa; Lin Zhang, PKU)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/19izON1I3y82Ex7Oo00y6vksKe1Vsey3J/view?usp=drive_link" target="_blank">Mercury and POPs Working Group</a> (Jenny Fisher, U. Wollongong and Chris Holmes, FSU)
-	</li>
-</ul><h3>
-	<a name="MonD" id="MonD"></a>Chemistry (Barron Henderson, US EPA, Chair)
-</h3>
+<h3><a name="MonB" id="MonB"></a>GEOS-Chem Working Groups (Amos Tai, CUHK, Chair)</h3>
 
-<ul><li>
-		<a href="https://drive.google.com/file/d/1OCSUMDypuONErkJiWUSGZT0qqfldx-fm/view?usp=drive_link" target="_blank"><b>KEYNOTE:</b> GEOS-Chem implementation of the Caltech isoprene mechanism</a> (Paul Wennberg, Caltech)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Nh2SaT7X18OBDq1i9E1k23mZ412TOOfW/view?usp=drive_link" target="_blank">Updated isoprene chemistry in GEOS-Chem: mechanisms and impacts</a> (Kelvin Bates, Caltech)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1BsTeOc4ZluXt6Nn3vZGYKSmRDkpAwZYf/view?usp=drive_link" target="_blank">Rights and wrongs with the GEOS-Chem PAN Simulation</a> (Emily Fischer, CSU)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1OZgPbsnfL9vTKRxVWre1CWONCZz3MRUl/view?usp=drive_link" target="_blank">Alkyl nitrate impacts on the NOx budget: insights from aircraft observations and GEOS-Chem</a> (Jenny Fisher, U. Wollongong)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1JSiN3ZnJAN7cBH7NUL7ihd4krEAmlMYq/view?usp=drive_link" target="_blank">Wintertime emissions and chemistry over the NE US: Role of oxidants and heterogeneous chemistry</a> (Lyatt Jaegle, U. Washington)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1tYi3CX07honLFAD1We8k_CrDqWn_HHwL/view?usp=drive_link" target="_blank">Halogen chemistry in GEOS-Chem</a> (Mat Evans, U. York)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1TV5OrkMOvOIqiM9xqzIDCMMXRDIoeTPK/view?usp=drive_link" target="_blank">Using OMI cloud-sliced NO2 and GEOS-Chem to better understand dynamics of upper troposphere NOx</a> (Eloise Marais, U. Birmingham)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1YkufvGlL8kGxEjRJlUQ9gIsK486tHD44/view?usp=drive_link" target="_blank">The reactive organic carbon budget</a> (Sarah Safieddine, MIT)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Q-F6X3pLyb_AjAFPw20VU2FLYGrics4K/view?usp=drive_link" target="_blank">Global budget of tropospheric ozone: long term trend and recent model advances</a> (Lu Hu, U. Montana)
-	</li>
-</ul><h3>
-	<a name="MonE" id="MonE"></a>Carbon Gases (Emily Fischer, CSU, Chair)
-</h3>
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1JSW1FuWPeKY6GwXWKBzNHt0aTcKnVIxQ/view?usp=drive_link" target="_blank">Transport Working Group</a> (Hongyu Liu, NIA/NASA Langley and Andrea Molod, NASA GSFC – GMAO)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1A5G7GKVPQnGxKbCMkeCkTQSHuYo_Wr0G/view?usp=drive_link" target="_blank">Chemistry and Organics Working Group</a> (Mat Evans, U. York; Barron Henderson, US EPA; Emily Fischer, CSU; Dylan Millet, U. Minnesota)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1T5tXoLzzhPxkdE0bIcEPzlq4Fd3qQJgA/view?usp=drive_link" target="_blank">Aerosols Working Group</a> (Colette Heald, MIT and Jeff Pierce, CSU)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1vD3LFYgVHn4U7x3u4Kq14aYedq-Vd6W7/view?usp=drive_link" target="_blank">Sources and surface sinks Working Group</a> (Jintai Lin, PKU and Qiang Zhang, Tsinghua)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1L8dB6cTN1taT7kBX48Sj48sBBbA5HeGt/view?usp=drive_link" target="_blank">Chemistry-Climate Working Group</a> (Shiliang Wu, Michigan Tech)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1AbRU4P94KmbtpjDck3wL71Z3T6CMzVJn/view?usp=drive_link" target="_blank">Carbon Cycle and Data Assimilation Working Group</a> (Kevin Bowman, JPL and Dylan Jones, U. Toronto)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1b-gBwUcQngVvwmpLsmXmvb2GgDwtLiSu/view?usp=drive_link" target="_blank">Nested Model Working Group</a> (Yuxuan Wang, U. Houston; Jun Wang, U. Iowa; Lin Zhang, PKU)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/19izON1I3y82Ex7Oo00y6vksKe1Vsey3J/view?usp=drive_link" target="_blank">Mercury and POPs Working Group</a> (Jenny Fisher, U. Wollongong and Chris Holmes, FSU)
+  </li>
+</ul>
 
-<ul><li>
-		<a href="https://drive.google.com/file/d/1eVz1ckmey_n0qx83nzqyF4wYZuoHhpsq/view?usp=drive_link" target="_blank">Response of the carbon cycle to climate variability</a> (Kevin Bowman, JPL)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1-edBObxIZF9ZHzWszw4PkAaoRpFUmRot/view?usp=drive_link" target="_blank">Using GEOS-Chem to characterize the effect of transport uncertainty in atmospheric flux inversions of OCO-2 column averaged CO2</a> (Andrew Schuh, CSU)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1cYQdW3V9cb1DWZBgZ-CGc_uCIk7h-ebX/view?usp=drive_link" target="_blank">Incorporating GEOS-Chem in CarbonTracker: model developments, transport comparison to TM5, and tracer conservation</a> (Andy Jacobson, NOAA/ESRL)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1BdLvT7Kk-HbDh10LIIkVCHbmpHI31cyL/view?usp=drive_link" target="_blank">Characterizing the information that space-based observations provide on the spatial distribution of atmospheric CO2</a> (Dylan Jones, U. Toronto)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1ijrJ7YdBiOZsrbDiH6wdejN8VL1WYorJ/view?usp=drive_link" target="_blank">Coupled stratosphere-troposphere chemistry raises the methane global warming potential</a> (Chris Holmes, FSU)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1efMGCZEhZ2NZbRBeT2RzX2oytvpOAIHc/view?usp=drive_link target="_blank">A sensitivity analysis of key natural factors in the modeled global acetone budget</a> (Jared Brewer, CSU)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1QZRlKA3cA-S69f6fPIXxTtdkLbbZ38Nj/view?usp=drive_link" target="_blank">Efficient tuning of transport and prior error statistics in high-dimensional source inversions using the adjoint of GEOS-Chem</a> (Nicolas Bousserez, CU – Boulder)
-	</li>
-</ul><h3>
-	<a name="MonC" id="MonC"></a>GEOS-Chem Model Clinics
-</h3>
+<h3><a name="MonD" id="MonD"></a>Chemistry (Barron Henderson, US EPA, Chair)</h3>
 
-<ul><li>
-		<a href="https://drive.google.com/file/d/133ZINPJgYYId_JaNGF_NDBGtKyWoQzHQ/view?usp=drive_link" target="_blank">GEOS-Chem for beginners</a> (Melissa Sulprizio, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1vpO_jPUJV1iQ-JPUJLpiI9mGQUVg54Mz/view?usp=drive_link" target="_blank">GEOS-Chem for advanced users</a> (Bob Yantosca, Harvard)
-	</li>
-	<li>
-		<a href="https://prezi.com/g1hlt6u1pr8u/adjoint-clinic-2017/?utm_campaign=share&amp;utm_medium=copy" target="_blank">GEOS-Chem adjoint</a>; <a href="https://drive.google.com/file/d/18ZrS-pnsIyyFhzb8MnkdmaaIdJ0XBfQX/view?usp=drive_link" target="_blank">handout</a> (Daven Henze and Yanko Davila U. CU-Boulder)
-	</li>
-</ul><h3>
-	<a name="MonP" id="MonP"></a>Posters
-</h3>
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1OCSUMDypuONErkJiWUSGZT0qqfldx-fm/view?usp=drive_link" target="_blank"><b>KEYNOTE:</b> GEOS-Chem implementation of the Caltech isoprene mechanism</a> (Paul Wennberg, Caltech)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Nh2SaT7X18OBDq1i9E1k23mZ412TOOfW/view?usp=drive_link" target="_blank">Updated isoprene chemistry in GEOS-Chem: mechanisms and impacts</a> (Kelvin Bates, Caltech)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1BsTeOc4ZluXt6Nn3vZGYKSmRDkpAwZYf/view?usp=drive_link" target="_blank">Rights and wrongs with the GEOS-Chem PAN Simulation</a> (Emily Fischer, CSU)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1OZgPbsnfL9vTKRxVWre1CWONCZz3MRUl/view?usp=drive_link" target="_blank">Alkyl nitrate impacts on the NOx budget: insights from aircraft observations and GEOS-Chem</a> (Jenny Fisher, U. Wollongong)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1JSiN3ZnJAN7cBH7NUL7ihd4krEAmlMYq/view?usp=drive_link" target="_blank">Wintertime emissions and chemistry over the NE US: Role of oxidants and heterogeneous chemistry</a> (Lyatt Jaegle, U. Washington)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1tYi3CX07honLFAD1We8k_CrDqWn_HHwL/view?usp=drive_link" target="_blank">Halogen chemistry in GEOS-Chem</a> (Mat Evans, U. York)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1TV5OrkMOvOIqiM9xqzIDCMMXRDIoeTPK/view?usp=drive_link" target="_blank">Using OMI cloud-sliced NO2 and GEOS-Chem to better understand dynamics of upper troposphere NOx</a> (Eloise Marais, U. Birmingham)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1YkufvGlL8kGxEjRJlUQ9gIsK486tHD44/view?usp=drive_link" target="_blank">The reactive organic carbon budget</a> (Sarah Safieddine, MIT)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Q-F6X3pLyb_AjAFPw20VU2FLYGrics4K/view?usp=drive_link" target="_blank">Global budget of tropospheric ozone: long term trend and recent model advances</a> (Lu Hu, U. Montana)
+  </li>
+</ul>
 
-<ul><li>
-		<a href="https://drive.google.com/file/d/1KiMTjkUdj7HaILlIgRqsUE1CJd6-Ll7c/view?usp=drive_link" target="_blank">Cloud radiative effects on key tropospheric oxidants in GEOS-Chem</a> (Hongyu Liu, NIA/NASA Langley)
-	</li>
-	<li>
-		Formaldehyde (HCHO) column measurements from airborne instruments: Comparison with airborne in-situ measurements, model, and satellites (Hyeong-Ahn Kwon, Seoul National U.)
-	</li>
-	<li>
-		Pinpointing inaccuracies in isoprene emission estimates (Jen Kaiser, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1vZPDPhxbVnXU1PwMZqGZ9iRePe3D0W88/view?usp=drive_link" target="_blank">Formaldehyde yields used to derive isoprene emissions in Australia with OMI measurements</a> (Jesse Greenslade, U. Wollongong)
-	</li>
-	<li>
-		Modelled and observed HCHO columns over India (Luke Surl, U. Edinburgh)
-	</li>
-	<li>
-		Constraining hydrocarbon emissions over the Indian subcontinent based on HCHO observations from OMI and GOME-2 (Sreleekha Chaliyakunnel, U. Minnesota)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/15Qs5BXEq99u1XGu4sdhb6THYjcMBFmq6/view?usp=drive_link" target="_blank">Adjoint inversion of Chinese non-methane volatile organic compounds sources using space-based observations of formaldehyde and glyoxal</a> (Hansen Cao, Peking U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1aIXE9LZqfW5IbujaY9B3o7RIzNECAc1Y/view?usp=drive_link" target="_blank">Sources and fate of reactive carbon over North America: constraints from recent aircraft campaigns</a> (Xin Chen, U. Minnesota)
-	</li>
-	<li>
-		Impacts of updated aromatic and monoterpene chemistry (William Porter, MIT)
-	</li>
-	<li>
-		Observing formaldehyde (HCHO) from space: trend analysis and public health implications (Lei Zhu, Harvard)
-	</li>
-	<li>
-		A decadal (2004-2014) analysis of global-to-regional tropospheric ozone column trends using OMI observations and GFDL-AM3 model simulations (Guanyu Huang, Harvard-Smithsonian CFA)
-	</li>
-	<li>
-		How to explain the bias associated with the NOy distribution in the upper troposphere in global chemical transport models? (Alicia Gressent, MIT)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/17LTadIq5frpcIpS95v4VMG7bLE3aA6DV/view?usp=drive_link" target="_blank">Reconciling upper tropospheric NO2 measurements for the interpretation of satellite observations</a> (Rachel Silvern, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1cmi3pqLcA62LlcmqyDRlZXFgMLx-TpIx/view?usp=drive_link" target="_blank">Summary of RS-HDMR sensitivity analyses of modeled ozone and hydrogen oxides for six NASA field campaigns</a> (Ken Christian, Penn State)
-	</li>
-	<li>
-		Infer surface fluxes of bromoform and dibromomethane from aircraft and in-situ observations using tagged VSLS simulations (Liang Feng, U. Edinburgh)
-	</li>
-	<li>
-		Assimilating satellite observed CO2 using GEOS-Chem (Feng Deng, U. Toronto)
-	</li>
-	<li>
-		Arctic CO2 in a changing climate: constraints on fluxes and transport from in situ measurements, modeling, and remote sensing (Kelly Graham, FSU)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1M8X8WPMjxRZ8OssXY0lx9Q76v0VqX_3N/view?usp=drive_link" target="_blank">Evaluation of GEOS-Chem-simulated biospheric carbon dioxide fluxes and atmospheric concentrations using observations</a> (Sajeev Philip, NASA-Ames)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1KQYNytxJEYirgdtQzHy7X92y8L5Dt8IX/view?usp=drive_link" target="_blank">GEOS-Chem simulations of greenhouse gas measurements (CO2, CH4 and CO) from moving platforms in and around Australia</a> (Beata Bukosa, U. Wollongong)
-	</li>
-	<li>
-		Diagnosing GEOS-Chem model biases using GOSAT CH4 retrievals and Weak Constraint 4D-Var Data Assimilation (WC 4D-Var) (Ilya Stanevich, U. Toronto)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1nn988TXGxcYk46blGw7wnVr8z_WMaX6z/view?usp=drive_link" target="_blank">Understanding the sources and sinks of atmospheric methane</a> (Alex Turner, Harvard)
-	</li>
-	<li>
-		Methane trends in North America observed by GOSAT: contributions from different source types (Jianxiong Sheng, Harvard)
-	</li>
-	<li>
-		Improving understanding of U.S. methane emissions using a new gridded inventory (Joannes Maasakkers, Harvard)
-	</li>
-	<li>
-		Spatial attribution of decadal changes in methane and ozone radiative forcing constrained by satellite observations (Thomas Walker, JPL/Caltech)
-	</li>
-	<li>
-		Optimization of CO assimilation using weak constraint (Tailong He, U. Toronto)
-	</li>
-	<li>
-		Development of a tropospheric chemistry data assimilation system: GEOS-Chem-EnKF (Kayuzuki Miyazaki, JAMSTEC/JPL)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1m9AaO5tcuBh3ds6M-mc4q-8xtG8qOsX5/view?usp=drive_link" target="_blank">GEOS-Chem on cloud computing platforms</a> (Jiawei Zhuang, Harvard)
-	</li>
-	<li>
-		On the development of the UCX GEOS-Chem adjoint (Irene Dedoussi, MIT)
-	</li>
-</ul><h2>
-	Tuesday, May 2
-</h2>
+<h3><a name="MonE" id="MonE"></a>Carbon Gases (Emily Fischer, CSU, Chair)</h3>
 
-<h3>
-	<a name="TueA" id="TueA"></a>Aerosols (Becky Alexander, U. Washington, Chair)
-</h3>
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1eVz1ckmey_n0qx83nzqyF4wYZuoHhpsq/view?usp=drive_link" target="_blank">Response of the carbon cycle to climate variability</a> (Kevin Bowman, JPL)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1-edBObxIZF9ZHzWszw4PkAaoRpFUmRot/view?usp=drive_link" target="_blank">Using GEOS-Chem to characterize the effect of transport uncertainty in atmospheric flux inversions of OCO-2 column averaged CO2</a> (Andrew Schuh, CSU)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1cYQdW3V9cb1DWZBgZ-CGc_uCIk7h-ebX/view?usp=drive_link" target="_blank">Incorporating GEOS-Chem in CarbonTracker: model developments, transport comparison to TM5, and tracer conservation</a> (Andy Jacobson, NOAA/ESRL)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1BdLvT7Kk-HbDh10LIIkVCHbmpHI31cyL/view?usp=drive_link" target="_blank">Characterizing the information that space-based observations provide on the spatial distribution of atmospheric CO2</a> (Dylan Jones, U. Toronto)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1ijrJ7YdBiOZsrbDiH6wdejN8VL1WYorJ/view?usp=drive_link" target="_blank">Coupled stratosphere-troposphere chemistry raises the methane global warming potential</a> (Chris Holmes, FSU)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1efMGCZEhZ2NZbRBeT2RzX2oytvpOAIHc/view?usp=drive_link" target="_blank">A sensitivity analysis of key natural factors in the modeled global acetone budget</a> (Jared Brewer, CSU)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1QZRlKA3cA-S69f6fPIXxTtdkLbbZ38Nj/view?usp=drive_link" target="_blank">Efficient tuning of transport and prior error statistics in high-dimensional source inversions using the adjoint of GEOS-Chem</a> (Nicolas Bousserez, CU – Boulder)
+  </li>
+</ul>
 
-<ul><li>
-		<a href="https://drive.google.com/file/d/1H8VJ6aQ_x1U3lp3i_AKzh9SNOrj55PLk/view?usp=drive_link" target="_blank"><b>KEYNOTE:</b> Recent aerosol field and lab results and implications for modeling</a> (Jose Jimenez, CU – Boulder)
-	</li>
-	<li>
-		Insight into the global distribution and chemical composition of PM2.5 from the SPARTAN Global Aerosol Network (Crystal Weagle, Dalhousie)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1APxL5SBarA5MCt6fHEmBEMhBfU-ucXll/view?usp=drive_link" target="_blank">Effect of seasalt nitrate photolysis on global NOx, O3, and OH</a> (Prasad Kasibhatla, Duke)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1GJs3ZDWgsPbQrm_6BOTjSazJfZn_vtry/view?usp=drive_link" target="_blank">Distribution and sources of submicron aerosols during the WINTER 2015 aircraft campaign</a> (Viral Shah, U. Washington)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1-ljAzOMQlTx4a6mErsnbad9HnmzPL4_1/view?usp=drive_link" target="_blank">Trends in chemical composition of global and regional population-weighted fine particulate matter over the recent 25 years</a> (Chi Li, Dalhousie)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1YWdiBnc_ovq0x7K3CJfwBSFVyA9mZ2yS/view?usp=drive_link" target="_blank">Impacts of sulfur oxidation by reactive halogen on both sulfur and reactive halogen budgets</a> (Qianjie Chen, U. Washington)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1w1Okn3D1kqlzS5pq87E0gMVczvYV5EM2/view?usp=drive_link" target="_blank">Inconsistency of ammonium-sulfate aerosol ratios with thermodynamic models in the eastern US: a possible role of organic aerosol</a> (Rachel Silvern, Harvard)
-	</li>
-</ul><h3>
-	<a name="TueB" id="TueB"></a>Aerosol Microphysics and Radiative Forcing (Jeff Pierce, CSU, Chair)
-</h3>
+<h3><a name="MonC" id="MonC"></a>GEOS-Chem Model Clinics</h3>
 
-<ul><li>
-		<a href="https://drive.google.com/file/d/1j1rWX7I6XvnYpW1NUiBeXfHhqc-mIu8K/view?usp=drive_link" target="_blank">Applying observations of the OMI Ultraviolet Aerosol Index to understand trends in aerosol absorption</a> (Melanie Hammer, Dalhousie)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/17QGeRM_8-EgYCdZ3kAwG1kxIiUyf0pKt/view?usp=drive_link" target="_blank">The impact of aerosol size distribution representation on aerosol optical properties and radiative effects</a> (David Ridley, MIT)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1xqovonIfim8s47hqXJ9nOl-G89UO20BL/view?usp=drive_link" target="_blank">Why the aerosol indirect forcing using the mass-only aerosol representation in GEOS-Chem may never look quite right</a> (Jack Kodros, CSU)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1yyWuygZx4SfAHLWzqh4DtsJ7ILPhqP1U/view?usp=drive_link" target="_blank">Implementation of new nucleation schemes in GEOS-Chem and results</a> (Fangqun Yu, SUNY-Albany)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Lld_EhIzrlPEW9w6jyBxQ6qiMGVlrdGi/view?usp=drive_link" target="_blank">The impact of size-resolved aerosol microphysics on heterogeneous chemistry: uncertainties associated with aerosol size and composition</a> (Gan Luo, SUNY-Albany)
-	</li>
-</ul><h3>
-	<a name="TueD" id="TueD"></a>Transport, Sources and Sinks (Hongyu Liu, NIA/NASA Langley, Chair)
-</h3>
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/133ZINPJgYYId_JaNGF_NDBGtKyWoQzHQ/view?usp=drive_link" target="_blank">GEOS-Chem for beginners</a> (Melissa Sulprizio, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1vpO_jPUJV1iQ-JPUJLpiI9mGQUVg54Mz/view?usp=drive_link" target="_blank">GEOS-Chem for advanced users</a> (Bob Yantosca, Harvard)
+  </li>
+  <li>
+    <a href="https://prezi.com/g1hlt6u1pr8u/adjoint-clinic-2017/?utm_campaign=share&amp;utm_medium=copy" target="_blank">GEOS-Chem adjoint</a>; <a href="https://drive.google.com/file/d/18ZrS-pnsIyyFhzb8MnkdmaaIdJ0XBfQX/view?usp=drive_link" target="_blank">handout</a> (Daven Henze and Yanko Davila U. CU-Boulder)
+  </li>
+</ul>
 
-<ul><li>
-		<a href="https://drive.google.com/file/d/1Jvp0PPei42kF0p5rw4nrDiEc1v6ZgkBI/view?usp=drive_link" target="_blank">Impact of higher resolution GMAO Forward Processing fields on short-lived tropospheric tracers</a> (Clara Orbe, NASA GSFC – GMAO)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Z-k2wIEbKxgebOcWwRa-dMfsElbZT2fp/view?usp=drive_link" target="_blank">Limits on GEOS-Chem's ability to represent intercontinental transport</a> (Seb Eastham, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1dS6WOgqAWsSVVQkAleWx3epuuOnf2OgL/view?usp=drive_link" target="_blank">How representative are airborne field campaigns of reactive tropospheric composition?</a> (Lee Murray, U. Rochester)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/11Epsw6EwL6QO_q90pnuveXy-EypjsxyX/view?usp=drive_link" target="_blank">Constraints from airborne 210Pb observations on aerosol scavenging and lifetime in GEOS-Chem</a> (Bo Zhang, NIA/NASA Langley)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1l_yXpENOLiLKzDvENHyEjMWySJcaAmGE/view?usp=drive_link" target="_blank">Top-down estimate of aerosol emissions from MODIS and OMI</a> (Jun Wang, U. Iowa)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1ZuEFODFTKhHUWGjeOHhPuPZsrGFxZKE_/view?usp=drive_link" target="_blank">Two-way ecosystem-atmosphere exchange of VOCs: New observational constraints from PROPHET-AMOS</a> (Dylan Millet, U. Minnesota)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1SSnBGhTWeQYtqxxR7rS-y-srI99o4HPk/view?usp=drive_link" target="_blank">Assessing the contributions of open ocean and sea ice sources of sea salt aerosol over polar regions with GEOS-Chem</a> (Jiayue Huang, U. Washington)
-	</li>
-</ul><h3>
-	<a name="TueE" id="TueE"></a>Sources and Sinks (Hongyu Liu, NIA/NASA Langley, Chair)
-</h3>
+<h3><a name="MonP" id="MonP"></a>Posters</h3>
 
-<ul><li>
-		<a href="https://drive.google.com/file/d/1cDvB8stGEmJ161VFeZ-_fxJIovHrJRcx/view?usp=drive_link" target="_blank">Top-down constraints on global N2O emissions at optimal resolution</a> (Kelley Wells, U. Minnesota)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1378i73wyex3xyGlp5YILK4iIwDj_kqNq/view?usp=drive_link" target="_blank">Adjoint analyses of PM pollution over North China</a> (Lin Zhang, Peking U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1lziAbwL9r6DCfQQERMjH4GZqjOB1bOmG/view?usp=drive_link" target="_blank">Comparing mass balance and adjoint methods for inverse modeling of nitrogen dioxide columns for global nitrogen oxide emissions</a> (Matt Cooper, Dalhousie)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1tW9EWeW37a_JcMU17aKmDhvIy5M9bjM2/view?usp=drive_link" target="_blank">Global deposition of reactive nitrogen oxides from 1996 to 2014 constrained with satellite observations of NO2 columns</a> (Jeffrey Geddes, Boston U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/12ah4RzkQpJo4bIKgD7FrYtdlpVdbVOgP/view?usp=drive_link" target="_blank">Decadal-scale top-down NOx and SO2 emissions from a hybrid 4D-Var / mass balance joint inversion</a> (Zhen Qu, CU – Boulder)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Q01N_10jTszSma2lFlXyLHdtHh_RLN-Z/view?usp=drive_link" target="_blank">Global CO and NOx emission estimates using multiple species data assimilation with GEOS-Chem adjoint model</a> (Xuesong Zhang, U. Toronto)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/100J9sDute_t_OqLCqr7oLSqGAM2Gkqk4/view?usp=drive_link" target="_blank">Responses of surface ozone air quality to anthropogenic nitrogen deposition</a> (Yuanhong Zhao, Peking U.)
-	</li>
-</ul><h3>
-	<a name="TueC" id="TueC"></a>Model Clinics
-</h3>
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1KiMTjkUdj7HaILlIgRqsUE1CJd6-Ll7c/view?usp=drive_link" target="_blank">Cloud radiative effects on key tropospheric oxidants in GEOS-Chem</a> (Hongyu Liu, NIA/NASA Langley)
+  </li>
+  <li>
+    Formaldehyde (HCHO) column measurements from airborne instruments: Comparison with airborne in-situ measurements, model, and satellites (Hyeong-Ahn Kwon, Seoul National U.)
+  </li>
+  <li>
+    Pinpointing inaccuracies in isoprene emission estimates (Jen Kaiser, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1vZPDPhxbVnXU1PwMZqGZ9iRePe3D0W88/view?usp=drive_link" target="_blank">Formaldehyde yields used to derive isoprene emissions in Australia with OMI measurements</a> (Jesse Greenslade, U. Wollongong)
+  </li>
+  <li>
+    Modelled and observed HCHO columns over India (Luke Surl, U. Edinburgh)
+  </li>
+  <li>
+    Constraining hydrocarbon emissions over the Indian subcontinent based on HCHO observations from OMI and GOME-2 (Sreleekha Chaliyakunnel, U. Minnesota)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/15Qs5BXEq99u1XGu4sdhb6THYjcMBFmq6/view?usp=drive_link" target="_blank">Adjoint inversion of Chinese non-methane volatile organic compounds sources using space-based observations of formaldehyde and glyoxal</a> (Hansen Cao, Peking U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1aIXE9LZqfW5IbujaY9B3o7RIzNECAc1Y/view?usp=drive_link" target="_blank">Sources and fate of reactive carbon over North America: constraints from recent aircraft campaigns</a> (Xin Chen, U. Minnesota)
+  </li>
+  <li>
+    Impacts of updated aromatic and monoterpene chemistry (William Porter, MIT)
+  </li>
+  <li>
+    Observing formaldehyde (HCHO) from space: trend analysis and public health implications (Lei Zhu, Harvard)
+  </li>
+  <li>
+    A decadal (2004-2014) analysis of global-to-regional tropospheric ozone column trends using OMI observations and GFDL-AM3 model simulations (Guanyu Huang, Harvard-Smithsonian CFA)
+  </li>
+  <li>
+    How to explain the bias associated with the NOy distribution in the upper troposphere in global chemical transport models? (Alicia Gressent, MIT)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/17LTadIq5frpcIpS95v4VMG7bLE3aA6DV/view?usp=drive_link" target="_blank">Reconciling upper tropospheric NO2 measurements for the interpretation of satellite observations</a> (Rachel Silvern, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1cmi3pqLcA62LlcmqyDRlZXFgMLx-TpIx/view?usp=drive_link" target="_blank">Summary of RS-HDMR sensitivity analyses of modeled ozone and hydrogen oxides for six NASA field campaigns</a> (Ken Christian, Penn State)
+  </li>
+  <li>
+    Infer surface fluxes of bromoform and dibromomethane from aircraft and in-situ observations using tagged VSLS simulations (Liang Feng, U. Edinburgh)
+  </li>
+  <li>
+    Assimilating satellite observed CO2 using GEOS-Chem (Feng Deng, U. Toronto)
+  </li>
+  <li>
+    Arctic CO2 in a changing climate: constraints on fluxes and transport from in situ measurements, modeling, and remote sensing (Kelly Graham, FSU)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1M8X8WPMjxRZ8OssXY0lx9Q76v0VqX_3N/view?usp=drive_link" target="_blank">Evaluation of GEOS-Chem-simulated biospheric carbon dioxide fluxes and atmospheric concentrations using observations</a> (Sajeev Philip, NASA-Ames)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1KQYNytxJEYirgdtQzHy7X92y8L5Dt8IX/view?usp=drive_link" target="_blank">GEOS-Chem simulations of greenhouse gas measurements (CO2, CH4 and CO) from moving platforms in and around Australia</a> (Beata Bukosa, U. Wollongong)
+  </li>
+  <li>
+    Diagnosing GEOS-Chem model biases using GOSAT CH4 retrievals and Weak Constraint 4D-Var Data Assimilation (WC 4D-Var) (Ilya Stanevich, U. Toronto)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1nn988TXGxcYk46blGw7wnVr8z_WMaX6z/view?usp=drive_link" target="_blank">Understanding the sources and sinks of atmospheric methane</a> (Alex Turner, Harvard)
+  </li>
+  <li>
+    Methane trends in North America observed by GOSAT: contributions from different source types (Jianxiong Sheng, Harvard)
+  </li>
+  <li>
+    Improving understanding of U.S. methane emissions using a new gridded inventory (Joannes Maasakkers, Harvard)
+  </li>
+  <li>
+    Spatial attribution of decadal changes in methane and ozone radiative forcing constrained by satellite observations (Thomas Walker, JPL/Caltech)
+  </li>
+  <li>
+    Optimization of CO assimilation using weak constraint (Tailong He, U. Toronto)
+  </li>
+  <li>
+    Development of a tropospheric chemistry data assimilation system: GEOS-Chem-EnKF (Kayuzuki Miyazaki, JAMSTEC/JPL)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1m9AaO5tcuBh3ds6M-mc4q-8xtG8qOsX5/view?usp=drive_link" target="_blank">GEOS-Chem on cloud computing platforms</a> (Jiawei Zhuang, Harvard)
+  </li>
+  <li>
+    On the development of the UCX GEOS-Chem adjoint (Irene Dedoussi, MIT)
+  </li>
+</ul>
 
-<ul><li>
-		High-performance GEOS-Chem (GCHP) (Mike Long, Seb Eastham, Jiawei Zhuang, and Lizzie Lundgren, Harvard)
-	</li>
-</ul><h3>
-	<a name="TueP" id="TueP"></a>Posters
-</h3>
+<h2>Tuesday, May 2</h2>
 
-<ul><li>
-		<a href="https://drive.google.com/file/d/1GbOanMrjJI1lQiNJ8C67F7Dc0nONZBT5/view?usp=drive_link" target="_blank">Characterizing the Asian Tropopause Aerosol Layer (ATAL) using satellite observations, balloon measurements and a chemical transport model</a> (Duncan Fairlie, NASA Langley)
-	</li>
-	<li>
-		Aerosol Types from Chemistry (CATCh): A new algorithm linking remote sensing and chemistry (Nicholas Meskhidze, North Carolina State)
-	</li>
-	<li>
-		Interpreting measurements of aerosol extinction and mass in North America (Robyn Latimer, Dalhousie)
-	</li>
-	<li>
-		Estimating ground PM2.5 speciation concentrations using MISR retrieved aerosol properties and GEOS-Chem aerosol vertical profiles (Xia Meng, Emory)
-	</li>
-	<li>
-		Constraints from reflected solar and infrared spectral measurements on size-dependent dust emissions: An OSSE using FIM-Chem and GEOS-Chem (Xiaoguang Xu and Jun Wang, U. Iowa)
-	</li>
-	<li>
-		4DVAR Assimilation of CALIOP Level 2 aerosol profiles with the adjoint of GEOS-Chem (Colin Lee, Dalhousie)
-	</li>
-	<li>
-		Long-range transport of black carbon to the Arctic: Tagged tracer simulation using GEOS-Chem (Kohei Ikeda, NEIS)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1eeCROU0Bp9gSESWWYCKZQuJHvPWOwuz9/view?usp=drive_link" target="_blank">Using ISORROPIA II to predict heterogeneous chlorine chemistry</a> (Jessica Haskins, U. Washington)
-	</li>
-	<li>
-		Processes controlling aerosol formation and growth in the summertime Arctic (Betty Croft, Dalhousie)
-	</li>
-	<li>
-		The role of MSA in particle growth and the aerosol direct and indirect effects (Anna Hodshire, CSU)
-	</li>
-	<li>
-		Use GEOS-Chem output for WRF-Chem initial and boundary conditions: Impact of long-range transported dust on ice nucleation and precipitation (Yanda Zhang, SUNY-Albany)
-	</li>
-	<li>
-		Factors affecting anthropogenic aerosol radiative forcing (Jingxu Wang, Peking U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1f1HtaeyiV4l9n3KNXarUH0ZVBluGAnOQ/view?usp=drive_link" target="_blank">Modeling the optical properties and radiative effect of brown carbon</a> (Xuan Wang, MIT)
-	</li>
-	<li>
-		Errors in using archived meteorological data for chemical transport modeling (Karen Yu, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1dztfl-8gJm5jLmcsALPaf56ZSqLUjam4/view?usp=drive_link" target="_blank">An Eulerian vs. Lagrangian comparison of modeled carbon monoxide in Texas during biomass burning events</a> (Christopher Brodowski, AER)
-	</li>
-	<li>
-		Complement to GEOS-Chem: Lagrangian Transport model FLEXPART reconfigured for GEOS-FP meteorological fields (Kelley Larson, U Washington)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1f0C6Y7n3awYgxT7UySciNVJE4JoKXamB/view?usp=drive_link" target="_blank">Impacts of precipitation patterns on the wet deposition and lifetime of aerosols</a> (Pei Hou, Michigan Tech)
-	</li>
-	<li>
-		A new approach for monthly updates of anthropogenic sulfur dioxide emissions from space: Application to China and implications for air quality forecasts (Yi Wang, U. Iowa)
-	</li>
-	<li>
-		Evaluating modeled ammonia in California and the South East US with satellite data (Chantelle Lonsdale, AER)
-	</li>
-	<li>
-		Ammonia emissions from agriculture over China (Youfan Chen, Peking U.)
-	</li>
-	<li>
-		Comparison of GEOS-Chem simulated ammonia concentrations with observations (Arshad Nair, SUNY-Albany)
-	</li>
-	<li>
-		Implications of subgrid dry deposition of NO2 in a global chemical transport model (Brian Boys, Dalhousie)
-	</li>
-	<li>
-		Incorporating updated emissions of NEI 2011 v6.3 into GEOS-Chem (Zitely Tzompa, CSU)
-	</li>
-	<li>
-		Incorporating flexible source tracking into GEOS-Chem (Carmen Lamancusa, U. Connecticut)
-	</li>
-	<li>
-		Neural network prediction of agricultural burning in Southern China and its application to air quality forecasts (Tzung-May Fu. Peking U.)
-	</li>
-	<li>
-		NAFED: a ground-based North American Fire Emission Database for 1980-2014 (Xu Yue, IAP)
-	</li>
-	<li>
-		Comparison of wildfire emissions in GEOS-Chem to ground-based FTIR measurements (Erik Lutsch, U. Toronto)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1CJMSVz1VMDAsaYSLZoQjihENW2qkM28I/view?usp=drive_link" target="_blank">Development and evaluation of biomass burning vertical injection height scheme in GEOS-Chem</a> (Juliet Zhu, CSU)
-	</li>
-</ul><h2>
-	Wednesday, May 3
-</h2>
+<h3><a name="TueA" id="TueA"></a>Aerosols (Becky Alexander, U. Washington, Chair)</h3>
 
-<h3>
-	<a name="WedA" id="WedA"></a>Chemistry-ecosystems-climate (Colette Heald, MIT, Chair)
-</h3>
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1H8VJ6aQ_x1U3lp3i_AKzh9SNOrj55PLk/view?usp=drive_link" target="_blank"><b>KEYNOTE:</b> Recent aerosol field and lab results and implications for modeling</a> (Jose Jimenez, CU – Boulder)
+  </li>
+  <li>
+    Insight into the global distribution and chemical composition of PM2.5 from the SPARTAN Global Aerosol Network (Crystal Weagle, Dalhousie)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1APxL5SBarA5MCt6fHEmBEMhBfU-ucXll/view?usp=drive_link" target="_blank">Effect of seasalt nitrate photolysis on global NOx, O3, and OH</a> (Prasad Kasibhatla, Duke)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1GJs3ZDWgsPbQrm_6BOTjSazJfZn_vtry/view?usp=drive_link" target="_blank">Distribution and sources of submicron aerosols during the WINTER 2015 aircraft campaign</a> (Viral Shah, U. Washington)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1-ljAzOMQlTx4a6mErsnbad9HnmzPL4_1/view?usp=drive_link" target="_blank">Trends in chemical composition of global and regional population-weighted fine particulate matter over the recent 25 years</a> (Chi Li, Dalhousie)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1YWdiBnc_ovq0x7K3CJfwBSFVyA9mZ2yS/view?usp=drive_link" target="_blank">Impacts of sulfur oxidation by reactive halogen on both sulfur and reactive halogen budgets</a> (Qianjie Chen, U. Washington)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1w1Okn3D1kqlzS5pq87E0gMVczvYV5EM2/view?usp=drive_link" target="_blank">Inconsistency of ammonium-sulfate aerosol ratios with thermodynamic models in the eastern US: a possible role of organic aerosol</a> (Rachel Silvern, Harvard)
+  </li>
+</ul>
 
-<ul><li>
-		<a href="https://drive.google.com/file/d/1Z09aZU1l2p2jrfLUSR74GRKD6xKsK8dv/view?usp=drive_link" target="_blank"><b>KEYNOTE:</b> Atmospheric composition in the Community Earth System Model (CESM)</a> (Jean- Francois Lamarque, NCAR)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1goLdQbLlLcG5tfffopW8EVHienlntJEa/view?usp=drive_link" target="_blank">Ozone-CO2-Vegetation coupling in GEOS-Chem: Implications for air quality under climate and land use change</a> (Amos Tai, CUHK)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1cjOszdzAjFPzD7Xi_iftHLITDy6JwkIp/view?usp=drive_link" target="_blank">Constraining global dry deposition of ozone: Observations and modeling</a> (Sam Silva, MIT)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/18lsQvHRCmBRP9_K1sbFMIRDJAthsLiKH/view?usp=drive_link" target="_blank">Adverse effects of drought on air quality</a> (Yuxuan Wang, U. Houston)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1P0fgMxWRYSDrFwJbF2D6tGfqYgKpNjJU/view?usp=drive_link" target="_blank">Integrating air quality with afforestation and reforestation efforts</a> (Shiliang Wu, Michigan Tech)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Wwj96piUSOkq8fnQMpUNRRgG6NUpwmQ-/view?usp=drive_link" target="_blank">Effects of climate change on transpacific ozone using IGSM-CAM/GEOS-Chem framework</a> (Mingwei Li, MIT)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1PBmS2AD4NAzcqMFuVHk2Zo2tyf51fK2H/view?usp=drive_link" target="_blank">Influence of 2000-2050 climate change on U.S. particulate matter: Results from statistical models vs. chemistry-climate models</a> (Lu Shen, Harvard)
-	</li>
-</ul><h3>
-	<a name="WedB" id="WedB"></a>Air Quality and Implications (Jenny Fisher, U. Wollongong, Chair)
-</h3>
+<h3><a name="TueB" id="TueB"></a>Aerosol Microphysics and Radiative Forcing (Jeff Pierce, CSU, Chair)</h3>
 
-<ul><li>
-		<a href="https://drive.google.com/file/d/1E2X2bqxegqGEZcuFL8axoGpFAQGWUpxG/view?usp=drive_link" target="_blank">Estimating human health impacts from GEOS-Chem</a> (Irene Dedoussi, MIT)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1VlbaN107x4-qvQuYbbdqGeokP2MxbXAn/view?usp=drive_link" target="_blank">Globalizing air pollution, climate forcing, and health impacts</a> (Jintai Lin, Peking U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/10bq8SPnHv7S5Ni6xb1mDFVy9WtzEaUVF/view?usp=drive_link" target="_blank">ransboundary health impacts of transported global air pollution and international trade</a> (Qiang Zhang, Tsinghua)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1EIWpAWobI6kVOg9vfyRiaOtt6iENVkjf/view?usp=drive_link" target="_blank">Exploring the impacts of particulate matter and surface ozone on global crop production</a> (Luke Schiferl, MIT)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Rgbt-47qUVneL5tJwwvHSb6ADRJmqDN-/view?usp=drive_link" target="_blank">Influence of air pollutant emission controls on the “climate penalty” in the United States</a> (Tao Feng, MIT)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1TLQKUxMDj7-YajWT6DHyvu2xWvzTxt8K/view?usp=drive_link" target="_blank">Mercury co-benefits of climate policy in China</a> (Katie Mulvaney, MIT)
-	</li>
-</ul><h3>
-	<a name="WedD" id="WedD"></a>Air Quality Science (Lin Zhang, PKU, Chair)
-</h3>
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1j1rWX7I6XvnYpW1NUiBeXfHhqc-mIu8K/view?usp=drive_link" target="_blank">Applying observations of the OMI Ultraviolet Aerosol Index to understand trends in aerosol absorption</a> (Melanie Hammer, Dalhousie)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/17QGeRM_8-EgYCdZ3kAwG1kxIiUyf0pKt/view?usp=drive_link" target="_blank">The impact of aerosol size distribution representation on aerosol optical properties and radiative effects</a> (David Ridley, MIT)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1xqovonIfim8s47hqXJ9nOl-G89UO20BL/view?usp=drive_link" target="_blank">Why the aerosol indirect forcing using the mass-only aerosol representation in GEOS-Chem may never look quite right</a> (Jack Kodros, CSU)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1yyWuygZx4SfAHLWzqh4DtsJ7ILPhqP1U/view?usp=drive_link" target="_blank">Implementation of new nucleation schemes in GEOS-Chem and results</a> (Fangqun Yu, SUNY-Albany)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Lld_EhIzrlPEW9w6jyBxQ6qiMGVlrdGi/view?usp=drive_link" target="_blank">The impact of size-resolved aerosol microphysics on heterogeneous chemistry: uncertainties associated with aerosol size and composition</a> (Gan Luo, SUNY-Albany)
+  </li>
+</ul>
 
-<ul><li>
-		<a href="https://drive.google.com/file/d/1IkowdxBmKUCt1qIRGbOj3c_W5Adw8vvM/view?usp=drive_link" target="_blank">Air pollution over West Africa</a> (Eleanor Morris, U. York)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1MWAujduOLJvDJsOVp-f7vmFYM3YZryxU/view?usp=drive_link" target="_blank">Preliminary results of the KORUS-AQ campaign</a> (Rokjin Park, Seoul National U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1tuoIC5bHdoXkDFwCM9yxvwiN-jYkNoy4/view?usp=drive_link" target="_blank">Using in situ data to better understand Chinese air pollution events</a> (Jonathan Moch, Harvard)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1VxUJu8KSNc7eDxc8I_JPDbQyOeX1UwmP/view?usp=drive_link" target="_blank">Chemical composition of ambient PM2.5 over China and relationships to precursor emissions during 2005–2012 (Guannan Geng, Emory)</a>
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1I_FwTNerfhiC24frWSpt0nWVULjW2far/view?usp=drive_link" target="_blank">Foreign and domestic contributions to springtime ozone pollution over China</a> (Ruijing Ni, Peking U.)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1z0B6akc-towWmOFsi68ygPrMrvzsOtHb/view?usp=drive_link" target="_blank">Evaluating a space-based indicator of surface ozone-NOx-VOC sensitivity over mid-latitude source regions and application to decadal trends</a> (Xiaomeng Jin, Columbia)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1Pk0MX724NYJkT9ZPEQpMk-42Y-0vo5YN/view?usp=drive_link" target="_blank">Meteorological drivers of surface ozone biases in the Southeast US</a> (Katie Travis, Harvard)
-	</li>
-</ul><h3>
-	<a name="WedC" id="WedC"></a>Model Clinics
-</h3>
+<h3><a name="TueD" id="TueD"></a>Transport, Sources and Sinks (Hongyu Liu, NIA/NASA Langley, Chair)</h3>
 
-<ul><li>
-		GEOS-Chem as a module for Earth System Models (Mike Long and Seb Eastham, Harvard)
-	</li>
-</ul><h3>
-	<a name="WedP" id="WedP"></a>Posters
-</h3>
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1Jvp0PPei42kF0p5rw4nrDiEc1v6ZgkBI/view?usp=drive_link" target="_blank">Impact of higher resolution GMAO Forward Processing fields on short-lived tropospheric tracers</a> (Clara Orbe, NASA GSFC – GMAO)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Z-k2wIEbKxgebOcWwRa-dMfsElbZT2fp/view?usp=drive_link" target="_blank">Limits on GEOS-Chem's ability to represent intercontinental transport</a> (Seb Eastham, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1dS6WOgqAWsSVVQkAleWx3epuuOnf2OgL/view?usp=drive_link" target="_blank">How representative are airborne field campaigns of reactive tropospheric composition?</a> (Lee Murray, U. Rochester)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/11Epsw6EwL6QO_q90pnuveXy-EypjsxyX/view?usp=drive_link" target="_blank">Constraints from airborne 210Pb observations on aerosol scavenging and lifetime in GEOS-Chem</a> (Bo Zhang, NIA/NASA Langley)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1l_yXpENOLiLKzDvENHyEjMWySJcaAmGE/view?usp=drive_link" target="_blank">Top-down estimate of aerosol emissions from MODIS and OMI</a> (Jun Wang, U. Iowa)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1ZuEFODFTKhHUWGjeOHhPuPZsrGFxZKE_/view?usp=drive_link" target="_blank">Two-way ecosystem-atmosphere exchange of VOCs: New observational constraints from PROPHET-AMOS</a> (Dylan Millet, U. Minnesota)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1SSnBGhTWeQYtqxxR7rS-y-srI99o4HPk/view?usp=drive_link" target="_blank">Assessing the contributions of open ocean and sea ice sources of sea salt aerosol over polar regions with GEOS-Chem</a> (Jiayue Huang, U. Washington)
+  </li>
+</ul>
 
-<ul><li>
-		<a href="https://drive.google.com/file/d/1TgYih-NESbYvlQkZfY8VBjY5B7runIp_/view?usp=drive_link" target="_blank">Weather conditions conducive to Beijing severe haze more frequent under climate change</a> (Ke Li, IAP)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1VCNJwWaHXPYPOjVuJjcn6lXHEycDg9mH/view?usp=drive_link" target="_blank">Effectiveness of maize-soybean intercropping on securing food production and air quality in China</a> (Ka Ming Fung and Amos Tai, CUHK)
-	</li>
-	<li>
-		Influence of the West Pacific subtropical high on surface ozone day to day variability in summertime over Eastern China (Zijian Zhao, Tsinghua)
-	</li>
-	<li>
-		Impacts of changes in climate and vegetation on wildfire emissions (Aditya Kumar, Michigan Tech)
-	</li>
-	<li>
-		The impact of historical land use change from 1850 to 2000 on particulate matter and ozone (Colette Heald, MIT)
-	</li>
-	<li>
-		Chemical and structural uncertainties within CESM CAM-Chem and GEOS-Chem: Ozone, PM2.5, and human health (Benjamin Brown-Steiner, MIT)
-	</li>
-	<li>
-		Multi-decadal trends in aerosol radiative forcing over the Arctic: Contribution of changes in anthropogenic aerosol to Arctic warming since 1980 (Loretta Mickley, Harvard)
-	</li>
-	<li>
-		What controls the  
-	</li>
-	<li>
-		Adjoint analysis of the climate and human health impacts of transient shifts in anthropogenic activity in China (Forrest Lacey, CU - Boulder)
-	</li>
-	<li>
-		Public health impacts of the severe haze in Equatorial Asia in September-October 2015: Demonstration of a new framework for informing fire management strategies to reduce downwind smoke exposure (Loretta Mickley, Harvard)
-	</li>
-	<li>
-		Contributions of natural variability to uncertainty in the efficacy of health and environmental policy (Daniel Rothenberg, MIT)
-	</li>
-	<li>
-		Health impacts of excess NOx emissions in Europe (Guillaume Chossiere, MIT)
-	</li>
-	<li>
-		Air quality and health co-benefit in global coal-fired power sector (Dan Tong, Tsinghua)
-	</li>
-	<li>
-		Implications of climate variability and change for the effectiveness of mercury policy (Amanda Giang, MIT)
-	</li>
-	<li>
-		<a href="https://drive.google.com/file/d/1eLr05t17DOi8odjGdk_fe2zaIZvIsJRj/view?usp=drive_link" target="_blank">A new mechanism for atmospheric mercury redox chemistry: Implications for the global mercury budget</a> (Hannah Horowitz, Harvard)
-	</li>
-	<li>
-		Quantifying sources and pathways of mercury deposition and exposure in Northern Maine, USA using integrated modeling (Helene Angot, MIT)
-	</li>
-	<li>
-		Using GEOS-Chem Hg simulations to help diagnose and predict fisheries health and sustainability (Colin Thackray, Harvard)
-	</li>
-	<li>
-		Updated terrestrial mercury simulation in GEOS-Chem (Rebecca Stern, Harvard)
-	</li>
-	<li>
-		Modeling PAHs over the UK and Europe (Peter Ivatt, U. York)
-	</li>
-	<li>
-		Using GEOS-Chem in the imputation of missing ground PM2.5 estimates due to cloud cover (Jessica Belle, Emory)
-	</li>
-	<li>
-		Evaluation and intercomparison of air quality forecasts over Korea during the KORUS-AQ campaign (Seungun Lee, Seoul National U.)
-	</li>
-	<li>
-		Influence of agricultural fires on urban air pollution in Delhi, India (Dan Cusworth, Harvard)
-	</li>
-	<li>
-		Secondary organic aerosol in the Beijing urban area (Matthew Jolleys, U. Edinburgh)
-	</li>
-	<li>
-		Simulation of severe winter haze in China over 1980-2014 (Ruijun Dang, IAP)
-	</li>
-	<li>
-		Comparison between the simulations of fine particulate matter during APEC period using WRF-CHEM and GEOS-Chem (Mi Zhou, Peking U.)
-	</li>
-	<li>
-		The formation mechanisms of PM2.5 by quantifying the formation pathways of sulfate in China (Jingyuan Shao, U. Washington)
-	</li>
-	<li>
-		Modelling UK and European air quality with GEOS-Chem (Tim Garstin, U York)
-	</li>
-	<li>
-		GEOS-Chem boundary conditions for WRF-chem (Chenghao Tan, U. Iowa)
-	</li>
-	<li>
-		Impacts of Central American fires on ozone air quality in Texas (Sing-Chun Wang, U. Houston)
-	</li>
-</ul><h2>
-	Thursday, May 4
-</h2>
+<h3><a name="TueE" id="TueE"></a>Sources and Sinks (Hongyu Liu, NIA/NASA Langley, Chair)</h3>
 
-<h3>
-	<a name="ThuA" id="ThuA"></a>Future Directions (Randall Martin, Dalhousie, Chair)
-</h3>
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1cDvB8stGEmJ161VFeZ-_fxJIovHrJRcx/view?usp=drive_link" target="_blank">Top-down constraints on global N2O emissions at optimal resolution</a> (Kelley Wells, U. Minnesota)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1378i73wyex3xyGlp5YILK4iIwDj_kqNq/view?usp=drive_link" target="_blank">Adjoint analyses of PM pollution over North China</a> (Lin Zhang, Peking U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1lziAbwL9r6DCfQQERMjH4GZqjOB1bOmG/view?usp=drive_link" target="_blank">Comparing mass balance and adjoint methods for inverse modeling of nitrogen dioxide columns for global nitrogen oxide emissions</a> (Matt Cooper, Dalhousie)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1tW9EWeW37a_JcMU17aKmDhvIy5M9bjM2/view?usp=drive_link" target="_blank">Global deposition of reactive nitrogen oxides from 1996 to 2014 constrained with satellite observations of NO2 columns</a> (Jeffrey Geddes, Boston U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/12ah4RzkQpJo4bIKgD7FrYtdlpVdbVOgP/view?usp=drive_link" target="_blank">Decadal-scale top-down NOx and SO2 emissions from a hybrid 4D-Var / mass balance joint inversion</a> (Zhen Qu, CU – Boulder)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Q01N_10jTszSma2lFlXyLHdtHh_RLN-Z/view?usp=drive_link" target="_blank">Global CO and NOx emission estimates using multiple species data assimilation with GEOS-Chem adjoint model</a> (Xuesong Zhang, U. Toronto)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/100J9sDute_t_OqLCqr7oLSqGAM2Gkqk4/view?usp=drive_link" target="_blank">Responses of surface ozone air quality to anthropogenic nitrogen deposition</a> (Yuanhong Zhao, Peking U.)
+  </li>
+</ul>
 
-<ul><li>
-		Future directions for GEOS-Chem software engineering (Seb Eastham, Mike Long, Bob Yantosca, Harvard, discussion leads)
-	</li>
-	<li>
-		Future directions for the GEOS-Chem adjoint (Daven Henze, CU-Boulder and Jun Wang, U. Iowa, discussion leads)
-	</li>
-	<li>
-		Poster introduction awards (Mat Evans, U. York)
-	</li>
-	<li>
-		Review of GEOS-Chem development priorities defined by Working Groups, functioning of the GEOS-Chem community (Daniel Jacob, Harvard and Randall Martin, Dalhousie, discussion leads)
-	</li>
+<h3><a name="TueC" id="TueC"></a>Model Clinics</h3>
+
+<ul>
+  <li>
+    High-performance GEOS-Chem (GCHP) (Mike Long, Seb Eastham, Jiawei Zhuang, and Lizzie Lundgren, Harvard)
+  </li>
+</ul>
+
+<h3><a name="TueP" id="TueP"></a>Posters</h3>
+
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1GbOanMrjJI1lQiNJ8C67F7Dc0nONZBT5/view?usp=drive_link" target="_blank">Characterizing the Asian Tropopause Aerosol Layer (ATAL) using satellite observations, balloon measurements and a chemical transport model</a> (Duncan Fairlie, NASA Langley)
+  </li>
+  <li>
+    Aerosol Types from Chemistry (CATCh): A new algorithm linking remote sensing and chemistry (Nicholas Meskhidze, North Carolina State)
+  </li>
+  <li>
+    Interpreting measurements of aerosol extinction and mass in North America (Robyn Latimer, Dalhousie)
+  </li>
+  <li>
+    Estimating ground PM2.5 speciation concentrations using MISR retrieved aerosol properties and GEOS-Chem aerosol vertical profiles (Xia Meng, Emory)
+  </li>
+  <li>
+    Constraints from reflected solar and infrared spectral measurements on size-dependent dust emissions: An OSSE using FIM-Chem and GEOS-Chem (Xiaoguang Xu and Jun Wang, U. Iowa)
+  </li>
+  <li>
+    4DVAR Assimilation of CALIOP Level 2 aerosol profiles with the adjoint of GEOS-Chem (Colin Lee, Dalhousie)
+  </li>
+  <li>
+    Long-range transport of black carbon to the Arctic: Tagged tracer simulation using GEOS-Chem (Kohei Ikeda, NEIS)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1eeCROU0Bp9gSESWWYCKZQuJHvPWOwuz9/view?usp=drive_link" target="_blank">Using ISORROPIA II to predict heterogeneous chlorine chemistry</a> (Jessica Haskins, U. Washington)
+  </li>
+  <li>
+    Processes controlling aerosol formation and growth in the summertime Arctic (Betty Croft, Dalhousie)
+  </li>
+  <li>
+    The role of MSA in particle growth and the aerosol direct and indirect effects (Anna Hodshire, CSU)
+  </li>
+  <li>
+    Use GEOS-Chem output for WRF-Chem initial and boundary conditions: Impact of long-range transported dust on ice nucleation and precipitation (Yanda Zhang, SUNY-Albany)
+  </li>
+  <li>
+    Factors affecting anthropogenic aerosol radiative forcing (Jingxu Wang, Peking U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1f1HtaeyiV4l9n3KNXarUH0ZVBluGAnOQ/view?usp=drive_link" target="_blank">Modeling the optical properties and radiative effect of brown carbon</a> (Xuan Wang, MIT)
+  </li>
+  <li>
+    Errors in using archived meteorological data for chemical transport modeling (Karen Yu, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1dztfl-8gJm5jLmcsALPaf56ZSqLUjam4/view?usp=drive_link" target="_blank">An Eulerian vs. Lagrangian comparison of modeled carbon monoxide in Texas during biomass burning events</a> (Christopher Brodowski, AER)
+  </li>
+  <li>
+    Complement to GEOS-Chem: Lagrangian Transport model FLEXPART reconfigured for GEOS-FP meteorological fields (Kelley Larson, U Washington)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1f0C6Y7n3awYgxT7UySciNVJE4JoKXamB/view?usp=drive_link" target="_blank">Impacts of precipitation patterns on the wet deposition and lifetime of aerosols</a> (Pei Hou, Michigan Tech)
+  </li>
+  <li>
+    A new approach for monthly updates of anthropogenic sulfur dioxide emissions from space: Application to China and implications for air quality forecasts (Yi Wang, U. Iowa)
+  </li>
+  <li>
+    Evaluating modeled ammonia in California and the South East US with satellite data (Chantelle Lonsdale, AER)
+  </li>
+  <li>
+    Ammonia emissions from agriculture over China (Youfan Chen, Peking U.)
+  </li>
+  <li>
+    Comparison of GEOS-Chem simulated ammonia concentrations with observations (Arshad Nair, SUNY-Albany)
+  </li>
+  <li>
+    Implications of subgrid dry deposition of NO2 in a global chemical transport model (Brian Boys, Dalhousie)
+  </li>
+  <li>
+    Incorporating updated emissions of NEI 2011 v6.3 into GEOS-Chem (Zitely Tzompa, CSU)
+  </li>
+  <li>
+    Incorporating flexible source tracking into GEOS-Chem (Carmen Lamancusa, U. Connecticut)
+  </li>
+  <li>
+    Neural network prediction of agricultural burning in Southern China and its application to air quality forecasts (Tzung-May Fu. Peking U.)
+  </li>
+  <li>
+    NAFED: a ground-based North American Fire Emission Database for 1980-2014 (Xu Yue, IAP)
+  </li>
+  <li>
+    Comparison of wildfire emissions in GEOS-Chem to ground-based FTIR measurements (Erik Lutsch, U. Toronto)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1CJMSVz1VMDAsaYSLZoQjihENW2qkM28I/view?usp=drive_link" target="_blank">Development and evaluation of biomass burning vertical injection height scheme in GEOS-Chem</a> (Juliet Zhu, CSU)
+  </li>
+</ul>
+
+<h2>Wednesday, May 3</h2>
+
+<h3><a name="WedA" id="WedA"></a>Chemistry-ecosystems-climate (Colette Heald, MIT, Chair)</h3>
+
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1Z09aZU1l2p2jrfLUSR74GRKD6xKsK8dv/view?usp=drive_link" target="_blank"><b>KEYNOTE:</b> Atmospheric composition in the Community Earth System Model (CESM)</a> (Jean- Francois Lamarque, NCAR)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1goLdQbLlLcG5tfffopW8EVHienlntJEa/view?usp=drive_link" target="_blank">Ozone-CO2-Vegetation coupling in GEOS-Chem: Implications for air quality under climate and land use change</a> (Amos Tai, CUHK)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1cjOszdzAjFPzD7Xi_iftHLITDy6JwkIp/view?usp=drive_link" target="_blank">Constraining global dry deposition of ozone: Observations and modeling</a> (Sam Silva, MIT)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/18lsQvHRCmBRP9_K1sbFMIRDJAthsLiKH/view?usp=drive_link" target="_blank">Adverse effects of drought on air quality</a> (Yuxuan Wang, U. Houston)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1P0fgMxWRYSDrFwJbF2D6tGfqYgKpNjJU/view?usp=drive_link" target="_blank">Integrating air quality with afforestation and reforestation efforts</a> (Shiliang Wu, Michigan Tech)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Wwj96piUSOkq8fnQMpUNRRgG6NUpwmQ-/view?usp=drive_link" target="_blank">Effects of climate change on transpacific ozone using IGSM-CAM/GEOS-Chem framework</a> (Mingwei Li, MIT)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1PBmS2AD4NAzcqMFuVHk2Zo2tyf51fK2H/view?usp=drive_link" target="_blank">Influence of 2000-2050 climate change on U.S. particulate matter: Results from statistical models vs. chemistry-climate models</a> (Lu Shen, Harvard)
+  </li>
+</ul>
+
+<h3><a name="WedB" id="WedB"></a>Air Quality and Implications (Jenny Fisher, U. Wollongong, Chair)</h3>
+
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1E2X2bqxegqGEZcuFL8axoGpFAQGWUpxG/view?usp=drive_link" target="_blank">Estimating human health impacts from GEOS-Chem</a> (Irene Dedoussi, MIT)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1VlbaN107x4-qvQuYbbdqGeokP2MxbXAn/view?usp=drive_link" target="_blank">Globalizing air pollution, climate forcing, and health impacts</a> (Jintai Lin, Peking U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/10bq8SPnHv7S5Ni6xb1mDFVy9WtzEaUVF/view?usp=drive_link" target="_blank">ransboundary health impacts of transported global air pollution and international trade</a> (Qiang Zhang, Tsinghua)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1EIWpAWobI6kVOg9vfyRiaOtt6iENVkjf/view?usp=drive_link" target="_blank">Exploring the impacts of particulate matter and surface ozone on global crop production</a> (Luke Schiferl, MIT)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Rgbt-47qUVneL5tJwwvHSb6ADRJmqDN-/view?usp=drive_link" target="_blank">Influence of air pollutant emission controls on the “climate penalty” in the United States</a> (Tao Feng, MIT)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1TLQKUxMDj7-YajWT6DHyvu2xWvzTxt8K/view?usp=drive_link" target="_blank">Mercury co-benefits of climate policy in China</a> (Katie Mulvaney, MIT)
+  </li>
+</ul>
+
+<h3><a name="WedD" id="WedD"></a>Air Quality Science (Lin Zhang, PKU, Chair)</h3>
+
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1IkowdxBmKUCt1qIRGbOj3c_W5Adw8vvM/view?usp=drive_link" target="_blank">Air pollution over West Africa</a> (Eleanor Morris, U. York)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1MWAujduOLJvDJsOVp-f7vmFYM3YZryxU/view?usp=drive_link" target="_blank">Preliminary results of the KORUS-AQ campaign</a> (Rokjin Park, Seoul National U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1tuoIC5bHdoXkDFwCM9yxvwiN-jYkNoy4/view?usp=drive_link" target="_blank">Using in situ data to better understand Chinese air pollution events</a> (Jonathan Moch, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1VxUJu8KSNc7eDxc8I_JPDbQyOeX1UwmP/view?usp=drive_link" target="_blank">Chemical composition of ambient PM2.5 over China and relationships to precursor emissions during 2005–2012 (Guannan Geng, Emory)</a>
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1I_FwTNerfhiC24frWSpt0nWVULjW2far/view?usp=drive_link" target="_blank">Foreign and domestic contributions to springtime ozone pollution over China</a> (Ruijing Ni, Peking U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1z0B6akc-towWmOFsi68ygPrMrvzsOtHb/view?usp=drive_link" target="_blank">Evaluating a space-based indicator of surface ozone-NOx-VOC sensitivity over mid-latitude source regions and application to decadal trends</a> (Xiaomeng Jin, Columbia)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Pk0MX724NYJkT9ZPEQpMk-42Y-0vo5YN/view?usp=drive_link" target="_blank">Meteorological drivers of surface ozone biases in the Southeast US</a> (Katie Travis, Harvard)
+  </li>
+</ul>
+
+<h3><a name="WedC" id="WedC"></a>Model Clinics</h3>
+
+<ul>
+  <li>
+    GEOS-Chem as a module for Earth System Models (Mike Long and Seb Eastham, Harvard)
+  </li>
+</ul>
+
+<h3><a name="WedP" id="WedP"></a>Posters</h3>
+
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1TgYih-NESbYvlQkZfY8VBjY5B7runIp_/view?usp=drive_link" target="_blank">Weather conditions conducive to Beijing severe haze more frequent under climate change</a> (Ke Li, IAP)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1VCNJwWaHXPYPOjVuJjcn6lXHEycDg9mH/view?usp=drive_link" target="_blank">Effectiveness of maize-soybean intercropping on securing food production and air quality in China</a> (Ka Ming Fung and Amos Tai, CUHK)
+  </li>
+  <li>
+    Influence of the West Pacific subtropical high on surface ozone day to day variability in summertime over Eastern China (Zijian Zhao, Tsinghua)
+  </li>
+  <li>
+    Impacts of changes in climate and vegetation on wildfire emissions (Aditya Kumar, Michigan Tech)
+  </li>
+  <li>
+    The impact of historical land use change from 1850 to 2000 on particulate matter and ozone (Colette Heald, MIT)
+  </li>
+  <li>
+    Chemical and structural uncertainties within CESM CAM-Chem and GEOS-Chem: Ozone, PM2.5, and human health (Benjamin Brown-Steiner, MIT)
+  </li>
+  <li>
+    Multi-decadal trends in aerosol radiative forcing over the Arctic: Contribution of changes in anthropogenic aerosol to Arctic warming since 1980 (Loretta Mickley, Harvard)
+  </li>
+  <li>
+    What controls the
+  </li>
+  <li>
+    Adjoint analysis of the climate and human health impacts of transient shifts in anthropogenic activity in China (Forrest Lacey, CU - Boulder)
+  </li>
+  <li>
+    Public health impacts of the severe haze in Equatorial Asia in September-October 2015: Demonstration of a new framework for informing fire management strategies to reduce downwind smoke exposure (Loretta Mickley, Harvard)
+  </li>
+  <li>
+    Contributions of natural variability to uncertainty in the efficacy of health and environmental policy (Daniel Rothenberg, MIT)
+  </li>
+  <li>
+    Health impacts of excess NOx emissions in Europe (Guillaume Chossiere, MIT)
+  </li>
+  <li>
+    Air quality and health co-benefit in global coal-fired power sector (Dan Tong, Tsinghua)
+  </li>
+  <li>
+    Implications of climate variability and change for the effectiveness of mercury policy (Amanda Giang, MIT)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1eLr05t17DOi8odjGdk_fe2zaIZvIsJRj/view?usp=drive_link" target="_blank">A new mechanism for atmospheric mercury redox chemistry: Implications for the global mercury budget</a> (Hannah Horowitz, Harvard)
+  </li>
+  <li>
+    Quantifying sources and pathways of mercury deposition and exposure in Northern Maine, USA using integrated modeling (Helene Angot, MIT)
+  </li>
+  <li>
+    Using GEOS-Chem Hg simulations to help diagnose and predict fisheries health and sustainability (Colin Thackray, Harvard)
+  </li>
+  <li>
+    Updated terrestrial mercury simulation in GEOS-Chem (Rebecca Stern, Harvard)
+  </li>
+  <li>
+    Modeling PAHs over the UK and Europe (Peter Ivatt, U. York)
+  </li>
+  <li>
+    Using GEOS-Chem in the imputation of missing ground PM2.5 estimates due to cloud cover (Jessica Belle, Emory)
+  </li>
+  <li>
+    Evaluation and intercomparison of air quality forecasts over Korea during the KORUS-AQ campaign (Seungun Lee, Seoul National U.)
+  </li>
+  <li>
+    Influence of agricultural fires on urban air pollution in Delhi, India (Dan Cusworth, Harvard)
+  </li>
+  <li>
+    Secondary organic aerosol in the Beijing urban area (Matthew Jolleys, U. Edinburgh)
+  </li>
+  <li>
+    Simulation of severe winter haze in China over 1980-2014 (Ruijun Dang, IAP)
+  </li>
+  <li>
+    Comparison between the simulations of fine particulate matter during APEC period using WRF-CHEM and GEOS-Chem (Mi Zhou, Peking U.)
+  </li>
+  <li>
+    The formation mechanisms of PM2.5 by quantifying the formation pathways of sulfate in China (Jingyuan Shao, U. Washington)
+  </li>
+  <li>
+    Modelling UK and European air quality with GEOS-Chem (Tim Garstin, U York)
+  </li>
+  <li>
+    GEOS-Chem boundary conditions for WRF-chem (Chenghao Tan, U. Iowa)
+  </li>
+  <li>
+    Impacts of Central American fires on ozone air quality in Texas (Sing-Chun Wang, U. Houston)
+  </li>
+</ul>
+
+<h2>Thursday, May 4</h2>
+
+<h3><a name="ThuA" id="ThuA"></a>Future Directions (Randall Martin, Dalhousie, Chair)</h3>
+
+<ul>
+  <li>
+    Future directions for GEOS-Chem software engineering (Seb Eastham, Mike Long, Bob Yantosca, Harvard, discussion leads)
+  </li>
+  <li>
+    Future directions for the GEOS-Chem adjoint (Daven Henze, CU-Boulder and Jun Wang, U. Iowa, discussion leads)
+  </li>
+  <li>
+    Poster introduction awards (Mat Evans, U. York)
+  </li>
+  <li>
+    Review of GEOS-Chem development priorities defined by Working Groups, functioning of the GEOS-Chem community (Daniel Jacob, Harvard and Randall Martin, Dalhousie, discussion leads)
+  </li>
 </ul>
 
 
@@ -734,64 +726,16 @@ The 8th International GEOS-Chem Meeting<br />May 1-4, 2017
 </div>
 </div>
 
-<!--footer region beg-->
+<!--footer-->
 <footer id="footer" class="clearfix" role="contentinfo">
-
-<!-- Three column 3x33 Gpanel -->
-<div class="at-panel gpanel panel-display footer clearfix">
-<div class="region region-footer">
-<div class="region-inner clearfix">
-<div id="block-boxes-1617037690" class="block block-boxes block-boxes-os_boxes_html no-title"  module="boxes" delta="1617037690">
-<div class="block-inner clearfix">  
-<div class="block-content content" ng-non-bindable="">  
-<div id='boxes-box-1617037690' class='boxes-box'>  
 <div class="boxes-box-content">
   <p style="text-align:center">
-    Copyright © 2023 by the International GEOS-Chem Community. All rights reserved.
+    Copyright © 2026 by the International GEOS-Chem Community. All rights reserved.
   </p>
 </div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-<div class="region region-footer-bottom">  
-<div class="region-inner clearfix">  
-<div id="block-boxes-1616879798" class="block block-boxes block-boxes-os_boxes_media no-title"  module="boxes" delta="1616879798">  
-<div class="block-inner clearfix">  
-<div class="block-content content"> 
-<div id='boxes-box-1616879798' class='boxes-box'> 
-<div class="boxes-box-content"> 
-<div id="file-3900146" class="file file-html file-html-embed">
-<h2 class="element-invisible"><a href="">css-brand</a></h2>
-<div class="content">
-<div class="file-info">
-</div>
-<div class="field field-name-field-html-code field-type-text-long field-label-hidden view-mode-full">
-<div class="field-items">
-<div class="field-item even">
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-
-<!--footer region end-->
 </footer>
-</div>
-</div>
 
-<!--page area ends-->
-<div id="extradiv"></div>
+</div>
 </div>
 
 </body>

--- a/igc8.html
+++ b/igc8.html
@@ -1,9 +1,4 @@
 <!DOCTYPE html>
-<!--[if IEMobile 7]><html class="iem7"  lang="en" dir="ltr"><![endif]-->
-<!--[if lte IE 6]><html class="lt-ie9 lt-ie8 lt-ie7"  lang="en" dir="ltr"><![endif]-->
-<!--[if (IE 7)&(!IEMobile)]><html class="lt-ie9 lt-ie8"  lang="en" dir="ltr"><![endif]-->
-<!--[if IE 8]><html class="lt-ie9"  lang="en" dir="ltr"><![endif]-->
-<!--[if (gte IE 9)|(gt IEMobile 7)]><!--><html  lang="en" dir="ltr"><!--<![endif]-->
 <head>
 <meta charset="utf-8" />
 <!--<base href="/igc8" />-->
@@ -18,23 +13,12 @@
 <title>The 8th International GEOS-Chem Meeting</title>
 <meta http-equiv="x-ua-compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<link type="text/css" rel="stylesheet" href="css/css_xE-rWrJf-fncB6ztZfd2huxqgxu4WO-qwma6Xer30m4%EF%B9%96m=1675397288.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_1kR8T1_c-l5pBT6ZwbDT7BFda-4fyqW9Jjum29_2IY8%EF%B9%96m=1675397312.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_YnlUIvHP13qgpYEqubzE8JyDwlSxUnVibfnVkSoSDb0%EF%B9%96m=1675397273.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_Ku-3OcT9qU9h7dnGig5e23q6EVryY8orK4wzVDxsweE%EF%B9%96m=1675397367.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_vprtFTrWyg23GbY50_zJZHWGYMNfS8vsrRS26i4-ISk%EF%B9%96m=1675397406.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_dW-aNNrctRhQNc-KECjtQd0PxuW-h19IEum-TX2MeEk%EF%B9%96m=1675397301.css" media="print" />
-<link type="text/css" rel="stylesheet" href="css/css_SH2Lx3Qprh0GZo_9xRp85U9NsWfkSXn_Bi-rJoMY1sw%EF%B9%96m=1675397273.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_uaIDKcYMUK5osSQXuirpr3ZleXtnnpBN-eiECm7N0M0%EF%B9%96m=1675397395.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/responsive.blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/geos-chem.css" media="all"/>
 <script type="text/javascript" src="dropdown-menu.js"></script>
-<!--[if lte IE 8]>
-<script type="text/javascript">
-  var os_c = document.createElement;os_c('header');os_c('nav');os_c('section');os_c('article');os_c('aside');os_c('footer');os_c('hgroup');os_c('figure');
-</script>
-<![endif]-->
 </head>
 
 <body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-1585687 node-type-page og-context og-context-node og-context-node-1585652 navbar-on">
@@ -45,7 +29,7 @@
 <div id="page_wrap" class="page_wrap">
 <div id="page" class="container page header-main content-top footer-none">
 <div id="page-wrapper">
-		
+
 <!--header regions beg-->
 <header id="header" class="clearfix" role="banner">
 <div id="header-container">
@@ -53,7 +37,7 @@
 <div class="region region-header-second">
 <div class="region-inner clearfix">
 <div id="block-boxes-1617807424" class="block block-boxes block-boxes-os_boxes_html no-title"  module="boxes" delta="1617807424">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <div class="block-content content" ng-non-bindable="">
 <div id='boxes-box-1617807424' class='boxes-box'>
 <div class="boxes-box-content">
@@ -76,16 +60,16 @@ The 8th International GEOS-Chem Meeting<br />May 1-4, 2017
 
 <!--main menu region beg-->
 <div id="menu-bar" class="nav region-menu-bar clearfix">
-<nav id="block-os-igc8-menu" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="igc8_menu">  
-<ul class="nice-menu nice-menu-down nice-menu-igc8_menu" id="nice-menu-igc8_menu">
-  <li class="menu-858656 menu-path-node-1586817  first   odd  "><a href="igc8.html"  class="active">Home</a></li>
-  <li class="menu-858670 menu-path-node-1586819   even  "><a href="igc8-presentations.html" >Presentations and Posters</a></li>
-  <li class="menu-858665 menu-path-node-1586818   odd   last "><a href="igc8-webcast.html" >Webcast Archive</a></li>
+<nav id="block-os-igc8-menu" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="igc8_menu">
+<ul class="nice-menu nice-menu-down">
+  <li><a href="igc8.html" class="active">IGC8 Home</a></li>
+  <li><a href="igc8-presentations.html">Presentations and Posters</a></li>
+  <li><a href="index.html">GEOS-Chem Home</a></li>
 </ul>
 </nav>
 </div>
 <!--main menu region end-->
-		
+
 <div id="columns" class="clearfix">
 <div class="hg-container">
 <div id="content-column" role="main">
@@ -95,48 +79,43 @@ The 8th International GEOS-Chem Meeting<br />May 1-4, 2017
 <a name="main-content"></a>
 <h1 id="page-title" ng-non-bindable="">Overview</h1>
 </header>
-														
+
 <!--front panel regions beg-->
 <div id="content-panels" class="at-panel gpanel panel-display content clearfix">
 <div class="region region-content-top">
 <div class="region-inner clearfix">
 <div id="block-os-pages-main-content" class="block block-os-pages no-title"  module="os_pages" delta="main_content">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <div class="block-content content" ng-non-bindable="">
 <article id="node-1585687" class="node node-page article clearfix" role="article">
 <div class="node-content" ng-non-bindable="">
 <div class="field field-name-body field-type-text-with-summary field-label-hidden view-mode-full">
 <div class="field-items">
 <div class="field-item even">
-  
-<p style="text-align:center">
-	<img style="width: 400px; height: 300px;" alt="IGC8 group photo" class="media-element file-default file-os-files-xxlarge" src="img/igc8_group_photo.jpg" title="" />
-	<img style="width: 400px; height: 300px;" alt="IGC8 group photo from drone" class="media-element file-default  file-os-files-xxlarge" src="img/igc8_group_photo-drone.jpg" title="" /></p>
-
-<p>
-	The 8th International GEOS-Chem Meeting (IGC8) was held at Harvard University on May 1-4, 2017 with <a href="https://drive.google.com/file/d/1mTgJSu9rNoks3X056_-jOSYZir7pu5t3/view?usp=drive_link">200 participants from 55 institutions and 9 countries</a>. Follow the links for:
-</p>
-
-<ul><li>
-		<a href="igc8-presentations.html" target="_blank" title="">Oral and poster presentations from the meeting</a>;
-	</li>
-	<li>
-		<a href="http://wiki.seas.harvard.edu/geos-chem/index.php/GEOS-Chem_model_development_priorities" target="_blank">Model development priorities list coming out of the meeting</a>.
-	</li>
-</ul><p>
-	We are very grateful to our meeting sponsors: the NASA Atmospheric Composition Modeling and Analysis Program, the Atmospheric Chemistry Program of the US National Science Foundation, the Electric Power Research Institute, the US EPA STAR program, the US NOAA Climate Program Office, the Harvard University Committee on the Environment, the UK National Centre for Atomspheric Science, and MIT.
-</p>
-
-<p>
-	We look forward to seeing you at the 9th International GEOS-Chem Meeting in 2019!
-</p>
-
-<p>
-	<a href="steering-committee.html" target="_blank" title="">The GEOS-Chem Steering Committee</a>
-</p>
 
 <p style="text-align:center">
-	<img height="320" width="650" alt="IGC8 sponsors: NASA, NSF, EPRI, EPA, NORA, HUCE, SEAS, NCAS, MIT" class="media-element file-default file-os-files-xlarge" src="img/igc8_sponsors.png" title="" /></p>
+  <img style="width: 400px; height: 300px;" alt="IGC8 group photo" class="media-element file-default file-os-files-xxlarge" src="img/igc8_group_photo.jpg" title="" />
+  <img style="width: 400px; height: 300px;" alt="IGC8 group photo from drone" class="media-element file-default  file-os-files-xxlarge" src="img/igc8_group_photo-drone.jpg" title="" />
+</p>
+
+<p>The 8th International GEOS-Chem Meeting (IGC8) was held at Harvard University on May 1-4, 2017 with <a href="https://drive.google.com/file/d/1mTgJSu9rNoks3X056_-jOSYZir7pu5t3/view?usp=drive_link">200 participants from 55 institutions and 9 countries</a>. Follow the links for:</p>
+
+<ul>
+  <li>
+    <a href="igc8-presentations.html" target="_blank" title="">Oral and poster presentations from the meeting</a>;
+  </li>
+  <li>
+    <a href="http://wiki.seas.harvard.edu/geos-chem/index.php/GEOS-Chem_model_development_priorities" target="_blank">Model development priorities list coming out of the meeting</a>.
+  </li>
+</ul>
+
+<p>We are very grateful to our meeting sponsors: the NASA Atmospheric Composition Modeling and Analysis Program, the Atmospheric Chemistry Program of the US National Science Foundation, the Electric Power Research Institute, the US EPA STAR program, the US NOAA Climate Program Office, the Harvard University Committee on the Environment, the UK National Centre for Atomspheric Science, and MIT.</p>
+
+<p>We look forward to seeing you at the 9th International GEOS-Chem Meeting in 2019!</p>
+
+<p><a href="steering-committee.html" target="_blank" title="">The GEOS-Chem Steering Committee</a></p>
+
+<p style="text-align:center"><img height="320" width="650" alt="IGC8 sponsors: NASA, NSF, EPRI, EPA, NORA, HUCE, SEAS, NCAS, MIT" class="media-element file-default file-os-files-xlarge" src="img/igc8_sponsors.png" title="" /></p>
 
 </div>
 </div>
@@ -156,64 +135,16 @@ The 8th International GEOS-Chem Meeting<br />May 1-4, 2017
 </div>
 </div>
 
-<!--footer region beg-->
+<!--footer-->
 <footer id="footer" class="clearfix" role="contentinfo">
-
-<!-- Three column 3x33 Gpanel -->
-<div class="at-panel gpanel panel-display footer clearfix">
-<div class="region region-footer">
-<div class="region-inner clearfix">
-<div id="block-boxes-1617037690" class="block block-boxes block-boxes-os_boxes_html no-title"  module="boxes" delta="1617037690">
-<div class="block-inner clearfix">  
-<div class="block-content content" ng-non-bindable="">  
-<div id='boxes-box-1617037690' class='boxes-box'>  
 <div class="boxes-box-content">
   <p style="text-align:center">
-    Copyright © 2023 by the International GEOS-Chem Community. All rights reserved.
+    Copyright © 2026 by the International GEOS-Chem Community. All rights reserved.
   </p>
 </div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-<div class="region region-footer-bottom">  
-<div class="region-inner clearfix">  
-<div id="block-boxes-1616879798" class="block block-boxes block-boxes-os_boxes_media no-title"  module="boxes" delta="1616879798">  
-<div class="block-inner clearfix">  
-<div class="block-content content"> 
-<div id='boxes-box-1616879798' class='boxes-box'> 
-<div class="boxes-box-content"> 
-<div id="file-3900146" class="file file-html file-html-embed">
-<h2 class="element-invisible"><a href="">css-brand</a></h2>
-<div class="content">
-<div class="file-info">
-</div>
-<div class="field field-name-field-html-code field-type-text-long field-label-hidden view-mode-full">
-<div class="field-items">
-<div class="field-item even">
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-
-<!--footer region end-->
 </footer>
-</div>
-</div>
 
-<!--page area ends-->
-<div id="extradiv"></div>
+</div>
 </div>
 
 </body>

--- a/igc9-presentations.html
+++ b/igc9-presentations.html
@@ -1,9 +1,4 @@
 <!DOCTYPE html>
-<!--[if IEMobile 7]><html class="iem7"  lang="en" dir="ltr"><![endif]-->
-<!--[if lte IE 6]><html class="lt-ie9 lt-ie8 lt-ie7"  lang="en" dir="ltr"><![endif]-->
-<!--[if (IE 7)&(!IEMobile)]><html class="lt-ie9 lt-ie8"  lang="en" dir="ltr"><![endif]-->
-<!--[if IE 8]><html class="lt-ie9"  lang="en" dir="ltr"><![endif]-->
-<!--[if (gte IE 9)|(gt IEMobile 7)]><!--><html  lang="en" dir="ltr"><!--<![endif]-->
 <head>
 <meta charset="utf-8" />
 <!--<base href="/igc9-presentations" />-->
@@ -18,23 +13,12 @@
 <title>The 9th International GEOS-Chem Meeting</title>
 <meta http-equiv="x-ua-compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<link type="text/css" rel="stylesheet" href="css/css_xE-rWrJf-fncB6ztZfd2huxqgxu4WO-qwma6Xer30m4%EF%B9%96m=1675397288.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_1kR8T1_c-l5pBT6ZwbDT7BFda-4fyqW9Jjum29_2IY8%EF%B9%96m=1675397312.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_YnlUIvHP13qgpYEqubzE8JyDwlSxUnVibfnVkSoSDb0%EF%B9%96m=1675397273.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_Ku-3OcT9qU9h7dnGig5e23q6EVryY8orK4wzVDxsweE%EF%B9%96m=1675397367.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_vprtFTrWyg23GbY50_zJZHWGYMNfS8vsrRS26i4-ISk%EF%B9%96m=1675397406.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_dW-aNNrctRhQNc-KECjtQd0PxuW-h19IEum-TX2MeEk%EF%B9%96m=1675397301.css" media="print" />
-<link type="text/css" rel="stylesheet" href="css/css_SH2Lx3Qprh0GZo_9xRp85U9NsWfkSXn_Bi-rJoMY1sw%EF%B9%96m=1675397273.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_uaIDKcYMUK5osSQXuirpr3ZleXtnnpBN-eiECm7N0M0%EF%B9%96m=1675397395.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/responsive.blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/geos-chem.css" media="all"/>
 <script type="text/javascript" src="dropdown-menu.js"></script>
-<!--[if lte IE 8]>
-<script type="text/javascript">
-  var os_c = document.createElement;os_c('header');os_c('nav');os_c('section');os_c('article');os_c('aside');os_c('footer');os_c('hgroup');os_c('figure');
-</script>
-<![endif]-->
 </head>
 
 <body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-1585687 node-type-page og-context og-context-node og-context-node-1585652 navbar-on">
@@ -45,7 +29,7 @@
 <div id="page_wrap" class="page_wrap">
 <div id="page" class="container page header-main content-top footer-none">
 <div id="page-wrapper">
-		
+
 <!--header regions beg-->
 <header id="header" class="clearfix" role="banner">
 <div id="header-container">
@@ -53,7 +37,7 @@
 <div class="region region-header-second">
 <div class="region-inner clearfix">
 <div id="block-boxes-1617807424" class="block block-boxes block-boxes-os_boxes_html no-title"  module="boxes" delta="1617807424">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <div class="block-content content" ng-non-bindable="">
 <div id='boxes-box-1617807424' class='boxes-box'>
 <div class="boxes-box-content">
@@ -76,15 +60,16 @@ The 9th International GEOS-Chem Meeting (IGC9) May 6-9, 2019
 
 <!--main menu region beg-->
 <div id="menu-bar" class="nav region-menu-bar clearfix">
-<nav id="block-os-igc9-menu" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="igc9_menu">  
-<ul class="nice-menu nice-menu-down nice-menu-igc9_menu" id="nice-menu-igc9_menu">
-  <li class="menu-857212 menu-path-node-1586486  first   odd  "><a href="igc9.html"  class="active">Home</a></li>
-  <li class="menu-857214 menu-path-node-1586487   even  "><a href="igc9-presentations.html" >Presentations and Posters</a></li>
-  <li class="menu-857216 menu-path-node-1586490   odd   last "><a href="igc9-webcast.html" >Webcast Archive</a></li></ul>
+<nav id="block-os-igc9-menu" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="igc9_menu">
+<ul class="nice-menu nice-menu-down">
+  <li><a href="igc9.html" class="active">IGC9 Home</a></li>
+  <li><a href="igc9-presentations.html">Presentations and Posters</a></li>
+  <li><a href="index.html">GEOS-Chem Home</a></li>
+</ul>
 </nav>
 </div>
 <!--main menu region end-->
-		
+
 <div id="columns" class="clearfix">
 <div class="hg-container">
 <div id="content-column" role="main">
@@ -94,609 +79,638 @@ The 9th International GEOS-Chem Meeting (IGC9) May 6-9, 2019
 <a name="main-content"></a>
 <h1 id="page-title" ng-non-bindable="">Presentations and Posters</h1>
 </header>
-														
+
 <!--front panel regions beg-->
 <div id="content-panels" class="at-panel gpanel panel-display content clearfix">
 <div class="region region-content-top">
 <div class="region-inner clearfix">
 <div id="block-os-pages-main-content" class="block block-os-pages no-title"  module="os_pages" delta="main_content">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <div class="block-content content" ng-non-bindable="">
 <article id="node-1585687" class="node node-page article clearfix" role="article">
 <div class="node-content" ng-non-bindable="">
 <div class="field field-name-body field-type-text-with-summary field-label-hidden view-mode-full">
 <div class="field-items">
 <div class="field-item even">
-  
-<p align="justify">
-	<strong>Monday, May 6: <a href="#MonA">Model Overview</a> | <a href="#MonB">Chemistry</a> | <a href="#MonC">Emissions &amp; Surface Fluxes</a> | <a href="#MonD">Model Clinics</a> | <a href="#MonP">Posters</a></strong><br class="clearfix" /><strong>Tuesday, May 7: <a href="#TueA">Aerosols</a> | <a href="#TueB">Chemistry</a> | <a href="#TueC">Chemistry-Ecosystem-Climate</a> | <a href="#TueP">Posters</a></strong><br class="clearfix" /><strong>Wednesday, May 8: <a href="#WedA">Carbon Gases</a> | <a href="#WedB">Global Atmospheric Composition</a> | <a href="#WedC">Air Quality</a> | <a href="#WedP">Posters</a></strong><br class="clearfix" /><strong>Thursday, May 9: <a href="#ThuA">Air Quality</a> | <a href="#ThuB">Model Clinics</a></strong>
+
+<p>
+  <strong>Monday, May 6: <a href="#MonA">Model Overview</a> | <a href="#MonB">Chemistry</a> | <a href="#MonC">Emissions &amp; Surface Fluxes</a> | <a href="#MonD">Model Clinics</a> | <a href="#MonP">Posters</a></strong><br class="clearfix" /><strong>Tuesday, May 7: <a href="#TueA">Aerosols</a> | <a href="#TueB">Chemistry</a> | <a href="#TueC">Chemistry-Ecosystem-Climate</a> | <a href="#TueP">Posters</a></strong><br class="clearfix" /><strong>Wednesday, May 8: <a href="#WedA">Carbon Gases</a> | <a href="#WedB">Global Atmospheric Composition</a> | <a href="#WedC">Air Quality</a> | <a href="#WedP">Posters</a></strong><br class="clearfix" /><strong>Thursday, May 9: <a href="#ThuA">Air Quality</a> | <a href="#ThuB">Model Clinics</a></strong>
 </p>
 
-<div>
-	<h2>
-		Monday, May 6
-	</h2>
-	<a name="MonA" id="MonA"></a><strong>Model overview and new developments (Chair: Christoph Keller, NASA/GMAO)</strong>
 
-	<ul><li>
-			<a href="https://drive.google.com/file/d/1MI-bJFUMliTYrofaV-Jb0GMWUYoMw0X5/view?usp=drive_link" target="_blank">Welcome, GEOS-Chem overview</a> (Daniel Jacob, Harvard)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1TCAF_USVemO4tZlSjSfIb4CLCpqwmPT7/view?usp=drive_link" target="_blank">High-performance GEOS-Chem (GCHP)</a> (Randall Martin, Dalhousie)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/168ccqZc1mZoQT_Q5h1R9_vJFtnlLl-je/view?usp=drive_link" target="_blank">WRF-GC: online coupling of WRF and GEOS-Chem</a> (Tzung-May Fu, SUSTC)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1x2GUy8kFpjcLb9v_wEZo99nA0pfHBtw9/view?usp=drive_link" target="_blank">GEOS-Chem on the AWS cloud</a> (Jiawei Zhuang, Harvard)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1kz2zInwW3aKu2YihAJ13j5-E-HdWpeid/view?usp=drive_link" target="_blank">GEOS-Chem and the GMAO: Reaction, replay, and reanalysis</a> (Steven Pawson, NASA)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1GivBkXU4pvULlSaHQVGt5rn0XuON0s-Z/view?usp=drive_link" target="_blank">Update on GMAO assimilation systems</a> (Andrea Molod, NASA)
-		</li>
-	</ul><a name="MonB" id="MonB"></a><strong>Chemistry (Chair: Eloïse Marais, U. Leicester)</strong>
+<h2>Monday, May 6</h2>
+<a name="MonA" id="MonA"></a><strong>Model overview and new developments (Chair: Christoph Keller, NASA/GMAO)</strong>
 
-	<ul><li>
-			<a href="https://drive.google.com/file/d/13SsFwRDlkRWzMpMcOuOmi_Bu3Hc6lI_z/view?usp=drive_link" target="_blank"><b>KEYNOTE:</b> Biogenic VOC chemistry influencing secondary organic aerosol</a> (Joel Thornton, U. Washington)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1_jOjOrkJPptaQI5JX1r-1rafjUr2VB7K/view?usp=drive_link" target="_blank">Anthropogenic control over wintertime oxidation of atmospheric pollutants: the importance of incorporating atypical radical precursors</a> (Jessica Haskins, U. Washington)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1sA7NENPNMW-qczmxWtY2SdDwBrJlx_EH/view?usp=drive_link" target="_blank">The global budget of methylethylketone</a> (Jared Brewer, CSU)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1Qo9KwJGHruWfYSKevkH1MLqxq8Fkhg1H/view?usp=drive_link" target="_blank">The role of clouds in the tropospheric NOx cycle: a new modeling approach for cloud chemistry and its global implications</a> (Chris Holmes, FSU)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1sk-GzKLtbTZ9LsTnfkmGqRB87upTe43_/view?usp=drive_link" target="_blank">Redefining odd oxygen: A new budget diagnostic for tropospheric ozone</a> (Kelvin Bates, Harvard)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1c3DdxYPr1qgOPjrHg78VymXfGvVvmvYe/view?usp=drive_link" target="_blank">Development of the adjoint of the GEOS-Chem UCX</a> (Irene Dedoussi, MIT / TU Delft)
-		</li>
-	</ul><a name="MonC" id="MonC"></a><strong>Emissions and surface fluxes (Chair: Emily Fischer, CSU)</strong>
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1MI-bJFUMliTYrofaV-Jb0GMWUYoMw0X5/view?usp=drive_link" target="_blank">Welcome, GEOS-Chem overview</a> (Daniel Jacob, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1TCAF_USVemO4tZlSjSfIb4CLCpqwmPT7/view?usp=drive_link" target="_blank">High-performance GEOS-Chem (GCHP)</a> (Randall Martin, Dalhousie)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/168ccqZc1mZoQT_Q5h1R9_vJFtnlLl-je/view?usp=drive_link" target="_blank">WRF-GC: online coupling of WRF and GEOS-Chem</a> (Tzung-May Fu, SUSTC)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1x2GUy8kFpjcLb9v_wEZo99nA0pfHBtw9/view?usp=drive_link" target="_blank">GEOS-Chem on the AWS cloud</a> (Jiawei Zhuang, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1kz2zInwW3aKu2YihAJ13j5-E-HdWpeid/view?usp=drive_link" target="_blank">GEOS-Chem and the GMAO: Reaction, replay, and reanalysis</a> (Steven Pawson, NASA)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1GivBkXU4pvULlSaHQVGt5rn0XuON0s-Z/view?usp=drive_link" target="_blank">Update on GMAO assimilation systems</a> (Andrea Molod, NASA)
+  </li>
+</ul>
 
-	<ul><li>
-			Inverse modeling constraints on sources of NH3 using CrIS remote sensing measurements (Hansen Cao, U. Colorado)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1gIJiTkVL-S9tHwkielIAdF-P4h30_fnT/view?usp=drive_link" target="_blank">Assessing the iterative finite difference mass balance and 4D-Var methods to retrieve ammonia emissions over North America using synthetic Cross-track Infrared Sounder observations</a> (Chi Li, Dalhousie)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1h3hKzk1KgfAD50p7Dx6dPpRMln-gunvI/view?usp=drive_link" target="_blank">Recent trends in China's anthropogenic emissions</a> (Qiang Zhang, Tsinghua)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/14J3Ga68CTTTgM5SmcSx3CtOvE43t-qyc/view?usp=drive_link" target="_blank">Impacts of improved burned area estimates on biomass burning emissions</a> (Holly Nowell, FSU)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1vqaeCeyBFNqm_5sw6WRgQjGRLsZ_yO0_/view?usp=drive_link" target="_blank">Health impacts of future fossil fuel emissions in Africa</a> (Eloise Marais, U. Leicester)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1AjQJjNbaeILo2AbCZz8nC8nM5f7kxWLX/view?usp=drive_link" target="_blank">Using OMI NO2 observations to evaluate seasonal trends in NOx emissions over eastern China: influence of NOx chemistry</a> (Viral Shah, Harvard)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1stiJ5LMPt7BZDQRzR5Vi5sxYlaXKiw7A/view?usp=drive_link" target="_blank">Global high-resolution emissions of soil NOx, biogenic VOC, and sea salt aerosols</a> (Hongjian Weng, PKU)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1ABRF-sI2YTdvManrzijR5wXx61bAyNo0/view?usp=drive_link" target="_blank">Global isoprene measurements from CrIS</a> (Kelley Wells, U. Minnesota)
-		</li>
-	</ul><a name="MonD" id="MonD"></a><strong>GEOS-Chem Model Clinics</strong>
+<a name="MonB" id="MonB"></a><strong>Chemistry (Chair: Eloïse Marais, U. Leicester)</strong>
 
-	<ul><li>
-			<a href="https://drive.google.com/file/d/1HkGbCThK5LHsphehyfy_eJQz2zK4AP87/view?usp=drive_link" target="_blank">Model Clinic 1: Working with GEOS-Chem</a> (Bob Yantosca and Melissa Sulprizio, Harvard)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1UHiyd73PcHGm-izvkau8ayKVulr1eHkp/view?usp=drive_link" target="_blank">Model Clinic 2: WRF-GC: GEOS-Chem in WRF</a> (Haipeng Lin and Xu Feng, PKU)
-		</li>
-		<li>
-			<a href="https://docs.google.com/presentation/d/172qz4PwzBJHcviQHARoNC2Afh7sg3VGl/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Model Clinic 3: High-performance GEOS-Chem (GCHP)</a> (Lizzie Lundgren, Harvard; Sebastian Eastham, MIT)
-		</li>
-	</ul><a name="MonP" id="MonP"></a><strong>Posters</strong>
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/13SsFwRDlkRWzMpMcOuOmi_Bu3Hc6lI_z/view?usp=drive_link" target="_blank"><b>KEYNOTE:</b> Biogenic VOC chemistry influencing secondary organic aerosol</a> (Joel Thornton, U. Washington)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1_jOjOrkJPptaQI5JX1r-1rafjUr2VB7K/view?usp=drive_link" target="_blank">Anthropogenic control over wintertime oxidation of atmospheric pollutants: the importance of incorporating atypical radical precursors</a> (Jessica Haskins, U. Washington)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1sA7NENPNMW-qczmxWtY2SdDwBrJlx_EH/view?usp=drive_link" target="_blank">The global budget of methylethylketone</a> (Jared Brewer, CSU)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Qo9KwJGHruWfYSKevkH1MLqxq8Fkhg1H/view?usp=drive_link" target="_blank">The role of clouds in the tropospheric NOx cycle: a new modeling approach for cloud chemistry and its global implications</a> (Chris Holmes, FSU)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1sk-GzKLtbTZ9LsTnfkmGqRB87upTe43_/view?usp=drive_link" target="_blank">Redefining odd oxygen: A new budget diagnostic for tropospheric ozone</a> (Kelvin Bates, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1c3DdxYPr1qgOPjrHg78VymXfGvVvmvYe/view?usp=drive_link" target="_blank">Development of the adjoint of the GEOS-Chem UCX</a> (Irene Dedoussi, MIT / TU Delft)
+  </li>
+</ul>
 
-	<ul><li>
-			Adaptive chemistry mechanisms for efficient numerical calculations in GEOS-Chem (Lu Shen, Harvard)
-		</li>
-		<li>
-			A CMake build system for GEOS-Chem (Liam Bindle, Dalhousie)
-		</li>
-		<li>
-			Machine learning emulator (Christoph Keller, NASA)
-		</li>
-		<li>
-			Coupling GEOS-Chem to CESM (Sebastian Eastham, MIT)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/13Jll1ocOqqAh6JrQTSXkjLmemrEHifzp/view?usp=drive_link" target="_blank">Validation and optimization of the RAS parameterization in GEOS-Chem</a> (Tailong He, U. Toronto)
-		</li>
-		<li>
-			Effect of PBL mixing on air quality modeling during KORUS-AQ (Rokjin Park, Seoul National U.)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1Fl9i3bc1jbuaZkKYjHAfaEvdpjJHg7Vo/view?usp=drive_link" target="_blank">Furan oxidation mechanisms: How simple is too simple? How complex is too complex?</a> (Benjamin Brown-Steiner, AER)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1q3U2UtZBqu9OBpBp2VxgcZZ7SSCQcBbv/view?usp=drive_link" target="_blank">Evaluating sources and concentrations of reactive bromine in the Arctic using ground observations and GEOS-Chem</a> (William Swanson, University of Alaska Fairbanks)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1C_uHWlv0TWlywPH0gm3wfT8kgR97SHH9/view?usp=drive_link" target="_blank">Comparison of GEOS-Chem and Hemispheric CMAQ predicted ozone and particulate matter</a> (Barron Henderson, US EPA)
-		</li>
-		<li>
-			SatJ: A satellite-derived climatology of photolysis rates in the atmosphere (Jason Ducker, FSU)
-		</li>
-		<li>
-			Impacts of marine cloud brightening on atmospheric chemistry (Hannah Horowitz, U. Washington)
-		</li>
-		<li>
-			Global OH concentrations inferred from HCFC/HFCs (Jianxiong Sheng, MIT)
-		</li>
-		<li>
-			The impact of model resolution on ozone simulation (Kunna Li, U. Toronto)
-		</li>
-		<li>
-			Volatile organic compounds in fire smoke: How many matter? (Lu Hu, U. Montana)
-		</li>
-		<li>
-			The sources, transformations and health impacts of polycyclic aromatic hydrocarbons (Jamie Kelly, MIT)
-		</li>
-		<li>
-			Improving simple parameterization of secondary organic aerosol (SOA): IEPOX-SOA and urban SOA (Duseong Jo, U. Colorado)
-		</li>
-		<li>
-			Isotopic constraints on heterogeneous chemistry of NOx in extreme urban haze (Yuk Chun Chan, U. Washington)
-		</li>
-		<li>
-			SOA formation from volatile chemical products in the US (Momei Qin, US EPA)
-		</li>
-		<li>
-			Supplementing the analysis of ground-based FTIR measurements at Toronto with GEOS-Chem (Shoma Yamanouchi, U. Toronto)
-		</li>
-		<li>
-			Tropospheric ozone over Southeast Asia (Xiaolin Wang, PKU)
-		</li>
-		<li>
-			WRF-Chem simulation of ozone and particulate matter in the Pearl River Delta region, China (Haoran Zhang, NUIST)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1deLslyeaFQhKmR_3GDuarUIzA3ER372d/view?usp=drive_link" target="_blank">Recent decline of NOx emissions in China observed from space by OMPS NM</a> (Nan Lin, Tsinghua)
-		</li>
-		<li>
-			Constraining NMVOCs emissions with satellite and aircraft observations during KORUS-AQ (Jinkyul Choi, U. Colorado)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1CsbgB8QHbODmvua__O2xju3--cAzG241/view?usp=drive_link" target="_blank">Diagnosing spatial biases and uncertainties in global fire emissions inventories: Indonesia as regional case study</a> (Tianjia (Tina) Liu, Harvard)
-		</li>
-		<li>
-			Evaluating ocean sources of carbonyl sulfide (OCS) through remote atmosphere observations (Luke Schiferl, LDEO/Columbia)
-		</li>
-		<li>
-			Modeling of soil NOx in GEOS-chem (Jun Wang, U. Iowa)
-		</li>
-		<li>
-			Updates to the reactive nitrogen dry deposition parameterization in GEOS-Chem (Brian Boys, Dalhousie)
-		</li>
-		<li>
-			Spatio-seasonal variations of atmospheric ammonia: comprehensive modelobservation comparison (Arshad Nair, SUNY-Albany)
-		</li>
-		<li>
-			Sub-grid ship emission of particle number concentrations: Parameterization and implication (Jingbo Mao, SUNY-Albany)
-		</li>
-		<li>
-			Source apportionment in GEOS-Chem (Carmen Lamancusa, U. Connecticut)
-		</li>
-		<li>
-			Representing pyrocumulonimbus events in GEOS-Chem (Kenneth Christian, NASA)
-		</li>
-		<li>
-			Fires in the Amazon Basin and their environmental impacts across South America (Eimy Bonilla, Harvard)
-		</li>
-		<li>
-			Health effects of air pollution embodied in international food trade (Yang Liu, Tsinghua)
-		</li>
-	</ul></div>
+<a name="MonC" id="MonC"></a><strong>Emissions and surface fluxes (Chair: Emily Fischer, CSU)</strong>
 
-<div>
-	<h2>
-		Tuesday, May 7
-	</h2>
-	<a name="TueA" id="TueA"></a><strong>Aerosols (Chair: Colette Heald, MIT)</strong>
+<ul>
+  <li>
+    Inverse modeling constraints on sources of NH3 using CrIS remote sensing measurements (Hansen Cao, U. Colorado)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1gIJiTkVL-S9tHwkielIAdF-P4h30_fnT/view?usp=drive_link" target="_blank">Assessing the iterative finite difference mass balance and 4D-Var methods to retrieve ammonia emissions over North America using synthetic Cross-track Infrared Sounder observations</a> (Chi Li, Dalhousie)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1h3hKzk1KgfAD50p7Dx6dPpRMln-gunvI/view?usp=drive_link" target="_blank">Recent trends in China's anthropogenic emissions</a> (Qiang Zhang, Tsinghua)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/14J3Ga68CTTTgM5SmcSx3CtOvE43t-qyc/view?usp=drive_link" target="_blank">Impacts of improved burned area estimates on biomass burning emissions</a> (Holly Nowell, FSU)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1vqaeCeyBFNqm_5sw6WRgQjGRLsZ_yO0_/view?usp=drive_link" target="_blank">Health impacts of future fossil fuel emissions in Africa</a> (Eloise Marais, U. Leicester)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1AjQJjNbaeILo2AbCZz8nC8nM5f7kxWLX/view?usp=drive_link" target="_blank">Using OMI NO2 observations to evaluate seasonal trends in NOx emissions over eastern China: influence of NOx chemistry</a> (Viral Shah, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1stiJ5LMPt7BZDQRzR5Vi5sxYlaXKiw7A/view?usp=drive_link" target="_blank">Global high-resolution emissions of soil NOx, biogenic VOC, and sea salt aerosols</a> (Hongjian Weng, PKU)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1ABRF-sI2YTdvManrzijR5wXx61bAyNo0/view?usp=drive_link" target="_blank">Global isoprene measurements from CrIS</a> (Kelley Wells, U. Minnesota)
+  </li>
+</ul>
 
-	<ul><li>
-			<a href="https://drive.google.com/file/d/1pFixqjGQl_DuAM8TgL836bnv1zGz8moC/view?usp=drive_link" target="_blank"><b>KEYNOTE:</b> Decadal change in particulate organic carbon fractions</a> (Annmarie Carlton, UC Irvine)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1jOZ_Pb5TkBn0xxZveco-ZKT4O13kXvNn/view?usp=drive_link" target="_blank">Heterogeneous sulfate formation in Chinese Haze events</a> (Becky Alexander, U. Washington)
-		</li>
-		<li>
-			Simulation of trace metals in PM2.5 over North America using the GEOS-Chem model (Junwei Xu, Dalhousie)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1-LW6CGu9Wm_q_9hEmPKV29FnSdb6auet/view?usp=drive_link" target="_blank">Defining domains of relevance for secondary organic aerosol formation</a> (William Porter, UC Riverside)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1G0ORd8y5uQnfgzJXhVdDzNg1vW3djlWO/view?usp=drive_link" target="_blank">Evaluation of simulated SOA in Seoul during KORUS-AQ 2016</a> (Yujin Oak, Seoul National U.)
-		</li>
-		<li>
-			<a href="hhttps://drive.google.com/file/d/1M8i6ERUfcke7B3kCaBkjpGxONllInANZ/view?usp=drive_link" target="_blank">New methodology for deriving PM2.5 chemical composition using the synthesis of GEOSChem and High Spectral Resolution Lidar (HSRL) retrievals</a> (Nicholas Meskhidze, NCSU)
-		</li>
-	</ul><a name="TueB" id="TueB"></a><strong>Chemistry (Chair: Barron Henderson, EPA)</strong>
+<a name="MonD" id="MonD"></a><strong>GEOS-Chem Model Clinics</strong>
 
-	<ul><li>
-			<a href="https://drive.google.com/file/d/1ZdbzL8GPUMeCpZw7y51NMycwae6WBu4w/view?usp=drive_link" target="_blank">Changes in aircraft emissions impacts due to non-linear, subgrid-scale plume processes</a> (Thibaud Fritz, MIT)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/14WbPcdNOpg2x_C38yRK5G0iFZV30VkWK/view?usp=drive_link" target="_blank">Influences of ocean iodide on tropospheric photochemistry</a> (Ryan Pound, U. York)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1XY0gEvB-u_DZZAimJtygWkLpig600aDz/view?usp=drive_link" target="_blank">Tropospheric chlorine chemistry in GEOS-Chem</a> (Xuan Wang, Harvard)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1Se9qYSCbgGfxwhqUbMLR1Ypu_GnIvQU8/view?usp=drive_link" target="_blank">Using machine learning to bias correct ozone within GEOS-Chem</a> (Peter Ivatt, U. York)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1HTcrONQV8VVJRU5CgQziue-ZTDn7vWQC/view?usp=drive_link" target="_blank">Observed covariance of ozone and PM2.5 in the Yangtze River Delta region from 2015 to 2017</a> (Huibin Dai, NUIST)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/16_y6FR9M7I3AMJajGYXMKmO-Q-BFVU-9/view?usp=drive_link" target="_blank">Suppression of summer ozone formation under high aerosol conditions</a> (Ke Li, Harvard)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1n8_KTrvecfMyFFB2hNukEKhF3SBIl94c/view?usp=drive_link" target="_blank">Incorporating chemical interactions and co-emissions in top-down constraints on sources of NOx, SO2, and CO</a> (Zhen Qu, U. Colorado)
-		</li>
-	</ul><a name="TueC" id="TueC"></a><strong>Chemistry-Ecosystem-Climate (Chair: Hong Liao, NUIST)</strong>
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1HkGbCThK5LHsphehyfy_eJQz2zK4AP87/view?usp=drive_link" target="_blank">Model Clinic 1: Working with GEOS-Chem</a> (Bob Yantosca and Melissa Sulprizio, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1UHiyd73PcHGm-izvkau8ayKVulr1eHkp/view?usp=drive_link" target="_blank">Model Clinic 2: WRF-GC: GEOS-Chem in WRF</a> (Haipeng Lin and Xu Feng, PKU)
+  </li>
+  <li>
+    <a href="https://docs.google.com/presentation/d/172qz4PwzBJHcviQHARoNC2Afh7sg3VGl/edit?usp=drive_link&ouid=116746565761151195371&rtpof=true&sd=true" target="_blank">Model Clinic 3: High-performance GEOS-Chem (GCHP)</a> (Lizzie Lundgren, Harvard; Sebastian Eastham, MIT)
+  </li>
+</ul>
 
-	<ul><li>
-			<a href="https://drive.google.com/file/d/1oNO4s6LF80DUc310dMopzpqWLH54YK79/view?usp=drive_link" target="_blank">Coupling a simplified biosphere model with GEOS-Chem</a> (Liang Feng, U. Edinburgh)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1hfc3lhdVURbnXCq4VR_voA-MMBpBaeHV/view?usp=drive_link" target="_blank">Evaluation of air pollution impacts on terrestrial ecosystems using GEOS-Chem</a> (Amos Tai, CUHK)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1hokJKeZhRfX916RUnDS9mQoaFhmFx_Zf/view?usp=drive_link" target="_blank">Reassessment of historic fire trends based on Antarctic-wide array of ice cores and fire modeling</a> (Pengfei Liu, Harvard)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1Cg8OolnUPUitKnm_mEEOIOCq6JefABeU/view?usp=drive_link" target="_blank">Fire air pollution reduces global terrestrial productivity</a> (Xu Yue, IAP CAS)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1ELTjwg_BZBkzgoxzVskWXPTXf9yPqy3T/view?usp=drive_link" target="_blank">Development of the Beijing Climate Center climate-chemistry model (BCC-AGCM-GCHP): model description and evaluation</a> (Xiao Lu, PKU)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1DwfLsvIqR8JmBT2yHydP3YHr_peny6hc/view?usp=drive_link" target="_blank">Linking GEOS-Chem to CESM: An intermodel comparison of the modeling frameworks</a> (Forrest Lacey, NCAR)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1yKJ817oSndB7D8jkFHIh3CjdCegYSFPk/view?usp=drive_link" target="_blank">Constraining gaseous dry deposition velocity with in-situ flux observations</a> (Anthony Wong, Boston U.)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1jRdYZKenQeJBbgcvyA0K7YG9Jupah9Ag/view?usp=drive_link" target="_blank">Significant impact of cloud condensation water variability and empirical washout rate on concentrations of nitrate and ammonium</a> (Gan Luo, SUNY-Albany)
-		</li>
-	</ul><a name="TueP" id="TueP"></a><strong>Posters</strong>
+<a name="MonP" id="MonP"></a><strong>Posters</strong>
 
-	<ul><li>
-			Simulation of organic aerosol in China (Ruqian Miao, PKU)
-		</li>
-		<li>
-			PyroCb tropopause smoke composition modeling (Tyler Van, U. Iowa)
-		</li>
-		<li>
-			Improved representation of surface PM2.5 using High Spectral Resolution Lidar retrievals and GEOS-Chem-derived aerosol types (Xinyi Ling, NCSU)
-		</li>
-		<li>
-			PM2.5 over China during 2014-2017 inferred from MAIAC AOD and Cloud GEOS-Chem (Fei Yao, U. Edinburgh)
-		</li>
-		<li>
-			Investigating aerosol influences over Central Asia (Shannon Capps, Drexel U.)
-		</li>
-		<li>
-			Application of GEOS-Chem to interpret observations for the estimation of global PM2.5 (Melanie Hammer, Dalhousie)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1cJ5sJF97zf5cuYNAFMPaB9j68EyZf5Hc/view?usp=drive_link" target="_blank">Sensitivity of global PM2.5 to emission sectors in GEOS-Chem</a> (Erin McDuffie, Dalhousie)
-		</li>
-		<li>
-			On the change of aerosol size distribution due to ionization (Irina Thaler, Hebrew U.)
-		</li>
-		<li>
-			Impact of mixing states on aerosol direct radiative forcing and heating rate based on GEOSChem- APM (Hailing Jia, SUNY-Albany)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/12rHbDTIuW5To5lXVGqStQwYYUakcsqje/view?usp=drive_link" target="_blank">The contribution of wild land-fire smoke to US PM2.5 and its influence on recent trends</a> (Katelyn O’Dell, CSU)
-		</li>
-		<li>
-			Implications of using the GEOS-Chem air mass factor for interpreting satellite NO2 observations (Matt Cooper, Dalhousie)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1kbmd3x4GJ-1v7m7QF3XaXlQG-wedZO1L/view?usp=drive_link" target="_blank">Using satellite observations of tropospheric NO2 columns to infer long-term trends in US NOx emissions: the importance of accounting for the free tropospheric NO2 background</a> (Rachel Silvern, Harvard)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1np0Py3_N-1seQcqkbzQrWihdbdGQaygB/view?usp=drive_link" target="_blank">Atmospheric impacts of improved sea-surface iodide fields and evidence for changes since 1950</a> (Tomas Sherwen, U. York)
-		</li>
-		<li>
-			Gas-phase photo-reduction of oxidized mercury and its implications (Colin Thackray, Harvard)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1oO8eYkUJ13Oxvw_Op16iVmBJT_tRwzWz/view?usp=drive_link" target="_blank">Hydroxymethane sulfonate in extreme haze</a> (Jonathan Moch, Harvard)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1H69Dk4aIR44yuO_V5zSITJ3DOW-S0Ylo/view?usp=drive_link" target="_blank">Impacts of atmospheric acidity on halogen chemistry from preindustrial to present day</a> (Shuting Zhai, U. Washington)
-		</li>
-		<li>
-			Tropospheric bromine chemistry and its impact on ozone and OH (Lei Zhu, Harvard)
-		</li>
-		<li>
-			Stratospheric halogen loading in GEOS-Chem UCX and satellite-based retrievals of tropospheric BrO (PamWales, NASA)
-		</li>
-		<li>
-			Interpreting TROPOMI data over Southeast Asia using the nested GEOS-Chem model simulation (Margaret Marvin, U. Edinburgh)
-		</li>
-		<li>
-			Trends, drivers, and impacts of ozone exposure in the United States from 2000-2015 (Karl Setzer, Duke)
-		</li>
-		<li>
-			How much does long-range transport of air pollutants from South Asia affect the Arctic region? (Sujai Banerji, U. Alaska Fairbanks)
-		</li>
-		<li>
-			Evaluating and improving Arctic ozone chemistry in GEOS-Chem (Kaitlyn Confer, FSU)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1RzIeORFp3dw32bsIMpalTYYxtmvMGHFU/view?usp=drive_link" target="_blank">Air quality and climate impact of charcoal use in Africa</a> (Alfred Bockarie, U. Birmingham)
-		</li>
-		<li>
-			Investigating drivers of particulate matter pollution over India and implications for climate (Alex Karambelas, LDEO/Columbia)
-		</li>
-		<li>
-			An improved vegetation canopy representation in GEOS-Chem (Sam Silva, MIT)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1c3H--TBHAe04i9pl2YHp2Xuy-hMqkj5a/view?usp=drive_link" target="_blank">Development of a new ecophysiology module in GEOS-Chem to represent biosphereatmosphere exchange</a> (Joey Lam, CUHK)
-		</li>
-		<li>
-			Fine-scale projections of wildfire under the mid- and late-21st century climate and land use in the western US (Yang Li, Harvard)
-		</li>
-		<li>
-			Radiative effects of aerosols and ozone in China over 2012-2017 as the consequence of clean air actions (Ruijun Dang, IAP CAS)
-		</li>
-		<li>
-			Source attribution of climate and health impacts from aerosols (Omar Nawaz, U. Colorado)
-		</li>
-		<li>
-			Ecosystem ozone impacts in past, present, future scenarios (David Yung, CUHK)
-		</li>
-		<li>
-			Impacts of China anthropogenic aerosols on springtime mesoscale convective systems over southern China (Lijuan Zhang, PKU)
-		</li>
-		<li>
-			Response of BVOC emissions to drought stress (Elizabeth Klovenski, U. Houston)
-		</li>
-		<li>
-			Sensitivity of aerosol radiative effects to shipping emissions (Deanna Kerry, Dalhousie
-		</li>
-	</ul></div>
+<ul>
+  <li>
+    Adaptive chemistry mechanisms for efficient numerical calculations in GEOS-Chem (Lu Shen, Harvard)
+  </li>
+  <li>
+    A CMake build system for GEOS-Chem (Liam Bindle, Dalhousie)
+  </li>
+  <li>
+    Machine learning emulator (Christoph Keller, NASA)
+  </li>
+  <li>
+    Coupling GEOS-Chem to CESM (Sebastian Eastham, MIT)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/13Jll1ocOqqAh6JrQTSXkjLmemrEHifzp/view?usp=drive_link" target="_blank">Validation and optimization of the RAS parameterization in GEOS-Chem</a> (Tailong He, U. Toronto)
+  </li>
+  <li>
+    Effect of PBL mixing on air quality modeling during KORUS-AQ (Rokjin Park, Seoul National U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Fl9i3bc1jbuaZkKYjHAfaEvdpjJHg7Vo/view?usp=drive_link" target="_blank">Furan oxidation mechanisms: How simple is too simple? How complex is too complex?</a> (Benjamin Brown-Steiner, AER)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1q3U2UtZBqu9OBpBp2VxgcZZ7SSCQcBbv/view?usp=drive_link" target="_blank">Evaluating sources and concentrations of reactive bromine in the Arctic using ground observations and GEOS-Chem</a> (William Swanson, University of Alaska Fairbanks)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1C_uHWlv0TWlywPH0gm3wfT8kgR97SHH9/view?usp=drive_link" target="_blank">Comparison of GEOS-Chem and Hemispheric CMAQ predicted ozone and particulate matter</a> (Barron Henderson, US EPA)
+  </li>
+  <li>
+    SatJ: A satellite-derived climatology of photolysis rates in the atmosphere (Jason Ducker, FSU)
+  </li>
+  <li>
+    Impacts of marine cloud brightening on atmospheric chemistry (Hannah Horowitz, U. Washington)
+  </li>
+  <li>
+    Global OH concentrations inferred from HCFC/HFCs (Jianxiong Sheng, MIT)
+  </li>
+  <li>
+    The impact of model resolution on ozone simulation (Kunna Li, U. Toronto)
+  </li>
+  <li>
+    Volatile organic compounds in fire smoke: How many matter? (Lu Hu, U. Montana)
+  </li>
+  <li>
+    The sources, transformations and health impacts of polycyclic aromatic hydrocarbons (Jamie Kelly, MIT)
+  </li>
+  <li>
+    Improving simple parameterization of secondary organic aerosol (SOA): IEPOX-SOA and urban SOA (Duseong Jo, U. Colorado)
+  </li>
+  <li>
+    Isotopic constraints on heterogeneous chemistry of NOx in extreme urban haze (Yuk Chun Chan, U. Washington)
+  </li>
+  <li>
+    SOA formation from volatile chemical products in the US (Momei Qin, US EPA)
+  </li>
+  <li>
+    Supplementing the analysis of ground-based FTIR measurements at Toronto with GEOS-Chem (Shoma Yamanouchi, U. Toronto)
+  </li>
+  <li>
+    Tropospheric ozone over Southeast Asia (Xiaolin Wang, PKU)
+  </li>
+  <li>
+    WRF-Chem simulation of ozone and particulate matter in the Pearl River Delta region, China (Haoran Zhang, NUIST)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1deLslyeaFQhKmR_3GDuarUIzA3ER372d/view?usp=drive_link" target="_blank">Recent decline of NOx emissions in China observed from space by OMPS NM</a> (Nan Lin, Tsinghua)
+  </li>
+  <li>
+    Constraining NMVOCs emissions with satellite and aircraft observations during KORUS-AQ (Jinkyul Choi, U. Colorado)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1CsbgB8QHbODmvua__O2xju3--cAzG241/view?usp=drive_link" target="_blank">Diagnosing spatial biases and uncertainties in global fire emissions inventories: Indonesia as regional case study</a> (Tianjia (Tina) Liu, Harvard)
+  </li>
+  <li>
+    Evaluating ocean sources of carbonyl sulfide (OCS) through remote atmosphere observations (Luke Schiferl, LDEO/Columbia)
+  </li>
+  <li>
+    Modeling of soil NOx in GEOS-chem (Jun Wang, U. Iowa)
+  </li>
+  <li>
+    Updates to the reactive nitrogen dry deposition parameterization in GEOS-Chem (Brian Boys, Dalhousie)
+  </li>
+  <li>
+    Spatio-seasonal variations of atmospheric ammonia: comprehensive modelobservation comparison (Arshad Nair, SUNY-Albany)
+  </li>
+  <li>
+    Sub-grid ship emission of particle number concentrations: Parameterization and implication (Jingbo Mao, SUNY-Albany)
+  </li>
+  <li>
+    Source apportionment in GEOS-Chem (Carmen Lamancusa, U. Connecticut)
+  </li>
+  <li>
+    Representing pyrocumulonimbus events in GEOS-Chem (Kenneth Christian, NASA)
+  </li>
+  <li>
+    Fires in the Amazon Basin and their environmental impacts across South America (Eimy Bonilla, Harvard)
+  </li>
+  <li>
+    Health effects of air pollution embodied in international food trade (Yang Liu, Tsinghua)
+  </li>
+</ul>
 
-<div>
-	<h2>
-		Wednesday, May 8
-	</h2>
-	<a name="WedA" id="WedA"></a><strong>Carbon Gases (Chair: Dylan Jones, U. Toronto)</strong>
+<h2>Tuesday, May 7</h2>
 
-	<ul><li>
-			<a href="https://drive.google.com/file/d/1k3oMSBE9ehACPSrx8DS69Jvx0n6X8hko/view?usp=drive_link" target="_blank"><b>KEYNOTE</b>: Regional and global scale measurements and modeling of CO2, CH4, and CO</a> (Steve Wofsy, Harvard)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1NiMBET6AzUfFRZ8b7nXQgaC9yirjqI8L/view?usp=drive_link" target="_blank">Recent trends in methane emissions from China and opportunities for mitigation</a> (Scot Miller, Johns Hopkins U.)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1_TTEyFApGrrH84qfA7Vgz5XEfVnJlVML/view?usp=drive_link" target="_blank">Global budget of atmospheric methane as inferred from GOSAT satellite observations during 2009-2017</a> (Yuzhong Zhang, Harvard)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1wNDdrjTTq55p5RIKa9MULD1kUFZK56O9/view?usp=drive_link" target="_blank">Towards an improved carbon greenhouse gas simulation in GEOS-Chem v12</a> (Beata Bukosa, U. Wollongong)
-		</li>
-		<li>
-			Resolving information in large-scale inversions (Kevin Bowman, JPL)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1SJBn4_4_ZtcCcJrl7kSsy2mbhiShcY-s/view?usp=drive_link" target="_blank">Optimizing OH distributions using 14CO and methyl chloroform in the GEOS-Chem adjoint</a> (Lee Murray, U. Rochester)
-		</li>
-	</ul><a name="WedB" id="WedB"></a><strong>Global atmospheric composition (Chair: Daven Henze, U. Colorado</strong>
+<a name="TueA" id="TueA"></a><strong>Aerosols (Chair: Colette Heald, MIT)</strong>
 
-	<ul><li>
-			<a href="https://drive.google.com/file/d/1fDCMZ66ocdsnyrLo9IprJq2ooOUfBn5s/view?usp=drive_link" target="_blank">Model analysis of interannual variability of Asian Tropopause Aerosol Layer: Transport pathways, sources, and composition</a> (Bo Zhang, NIA)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1vw2Y9ETE3v8U2LcaGtLHwmOzdHlibGkz/view?usp=drive_link" target="_blank">Near real-time forecasts at 25km horizontal resolution</a> (Emma Knowland, NASA)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1wpmN3dJLMYOtW1NjE9BT50-YjMkwiDH_/view?usp=drive_link" target="_blank">Trade, atmospheric transport and globalizing air pollution: recent progress</a> (Jintai Lin, PKU)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1TKl303MyWAEiQvgrYrpPzjtMbd_F_baK/view?usp=drive_link" target="_blank">Applying GEOS-Chem-TOMAS to understand Arctic marine secondary aerosol contributions to particle size distributions</a> (Betty Croft, Dalhousie)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1JxHMF0f6Xv_ATP7gfnIWeEnaEHrM_bn9/view?usp=drive_link" target="_blank">On the temporal resolution of transport</a> (Shiliang Wu, Michigan Tech)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1QGNe3Y-O-lyk_lpWVXw_zIW4A0hpORYG/view?usp=drive_link" target="_blank">Multi-model comparisons of multi-constituent satellite data assimilation based on ensemble Kalman filter for tropospheric chemistry analysis</a> (Kazuyuki Miyazaki, JPL/JAMSTEC)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1wXJPAUHoWoMj8jq4Wj_JMAulU8DuBBuh/view?usp=drive_link" target="_blank">Constraining modeled remote oxidation capacity with ATom observations</a> (Katie Travis, MIT/NASA)
-		</li>
-	</ul><a name="WedC" id="WedC"></a><strong>Air Quality (Chair: Jintai Lin, PKU)</strong>
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1pFixqjGQl_DuAM8TgL836bnv1zGz8moC/view?usp=drive_link" target="_blank"><b>KEYNOTE:</b> Decadal change in particulate organic carbon fractions</a> (Annmarie Carlton, UC Irvine)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1jOZ_Pb5TkBn0xxZveco-ZKT4O13kXvNn/view?usp=drive_link" target="_blank">Heterogeneous sulfate formation in Chinese Haze events</a> (Becky Alexander, U. Washington)
+  </li>
+  <li>
+    Simulation of trace metals in PM2.5 over North America using the GEOS-Chem model (Junwei Xu, Dalhousie)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1-LW6CGu9Wm_q_9hEmPKV29FnSdb6auet/view?usp=drive_link" target="_blank">Defining domains of relevance for secondary organic aerosol formation</a> (William Porter, UC Riverside)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1G0ORd8y5uQnfgzJXhVdDzNg1vW3djlWO/view?usp=drive_link" target="_blank">Evaluation of simulated SOA in Seoul during KORUS-AQ 2016</a> (Yujin Oak, Seoul National U.)
+  </li>
+  <li>
+    <a href="hhttps://drive.google.com/file/d/1M8i6ERUfcke7B3kCaBkjpGxONllInANZ/view?usp=drive_link" target="_blank">New methodology for deriving PM2.5 chemical composition using the synthesis of GEOSChem and High Spectral Resolution Lidar (HSRL) retrievals</a> (Nicholas Meskhidze, NCSU)
+  </li>
+</ul>
 
-	<ul><li>
-			<a href="https://drive.google.com/file/d/1-q3p1g0ZBNhvpJ76uYwcItJh5F29lzS3/view?usp=drive_link" target="_blank">The effect of emission control measures on ozone concentration in Hangzhou during G20 meeting in 2016</a> (Ye Wang, NUIST)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/17BEOWIlfiXM7_PJgyJquTJwiLxjV5hC_/view?usp=drive_link" target="_blank">Air quality and health co-benefits of shale gas development in China</a> (Yanxu Zhang, Nanjing)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1uLmgPXSsqlCzotijH27x4h28slOBz6AA/view?usp=drive_link" target="_blank">Air quality and health effects of the residential energy transition in China</a> (Kelsey Bilsback, CSU)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1fWIDsM7ABFH1kDJP8RMaowLdY-7M3_8k/view?usp=drive_link" target="_blank">Analysis of PM2.5 variations across China</a> (Matthew Jolleys, U. Edinburgh)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1SvOJgs7e7b3jRcgtZgmkbhJIf-goKrkP/view?usp=drive_link" target="_blank">Effect of the transport of ozone and its precursors in Central China on ozone pollution episodes in North China</a> (Cheng Gong, IAP CAS)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1tZ0RNXd0B4kd78Ciiyl2y8NrCb2s_z2l/view?usp=drive_link" target="_blank">Environmental and health impact of Chinese dietary change from 1980 to 2010</a> (Xueying Liu, CUHK)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1NAOcK4FTVC8wUzzSMzAnOaAPebvRILi4/view?usp=drive_link" target="_blank">Future changes in the sensitivity of inorganic fine particulate matter to precursor emissions in China</a> (Mingwei Li, MIT)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/18Blf5aBXdAiPVSJBxOHfTZLUigCXPXo8/view?usp=drive_link" target="_blank">Re-estimating ammonia emission inventory in eastern China using CrIS satellite observations of ammonia and GEOS-Chem adjoint model</a> (Juliet (Liye) Zhu, Sun-Yat-Sen U.)
-		</li>
-	</ul><a name="WedP" id="WedP"></a><strong>Posters</strong>
+<a name="TueB" id="TueB"></a><strong>Chemistry (Chair: Barron Henderson, EPA)</strong>
 
-	<ul><li>
-			Prior biosphere model impact on global terrestrial CO2 fluxes estimated from OCO-2 retrievals (Sajeev Philip, NASA)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/19ohcL0v8KFKPkj7z2Oo5EOSU6pF8cQ82/view?usp=drive_link" target="_blank">Diagnosing global changes in atmospheric methane using ethane and propane</a> (Douglas Finch, U. Edinburgh)
-		</li>
-		<li>
-			Methane clumped isotopes In GEOS-Chem (Alice Drinkwater, U. Edinburgh)
-		</li>
-		<li>
-			Evaluation of a new methane isotopologue forward model of GEOS-Chem (Mingjian Shi, U. Rochester)
-		</li>
-		<li>
-			Interannual variability in CO2 fluxes from OCO-2 using a geostatistical inverse model (Zichong Chen, Johns Hopkins U.)
-		</li>
-		<li>
-			Inverse modeling of CO2 fluxes using O-Buoys, a multi-year dataset of surface observations from the Arctic Ocean (Kelly Graham, FSU)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1T6PSOP9pgdtFlra5G-5Shuo5qk9d6ESJ/view?usp=drive_link" target="_blank">Methane emissions from oil and gas industries in three western provinces of Canada using GOSAT observations in mass balance method and comparison with GEOS-Chem</a> (Nazrul Islam, U. Northern British Columbia)
-		</li>
-		<li>
-			Regional inversion modeling: A framework for understanding CO2 concentration in Seoul megacity (JongWong Lee, Seoul National U.)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1WG6_vIhGiQURp9CghBzdl56ROCvE_5k0/view?usp=drive_link" target="_blank">Strengthened scientific support for the Endangerment Finding for atmospheric greenhouse gases</a> (Loretta Mickley, Harvard)
-		</li>
-		<li>
-			The variation trend of atmospheric methane from observation and modeling (Haiyue Tan, PKU)
-		</li>
-		<li>
-			Top-down constraints on methane point source emissions from animal agriculture and waste based on GEM airborne measurements in the US Upper Midwest (Xueying Yu, U. Minnesota)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1oMxFKE1JDv-8Gq6oiflPIzlah9zm8wXG/view?usp=drive_link" target="_blank">Reduced rank Jacobians: Decreasing the computational cost of high resolution analytic inversions</a> (Hannah Nesser, Harvard)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1a7ZVjeKJCOPQuicpYGR9dMKmaHg9kn1F/view?usp=drive_link" target="_blank">Quantification of Canadian methane emissions using the ECCC surface observation network</a> (Sabour Baray, York U.)
-		</li>
-		<li>
-			Modeling CO2 fluxes using satellite observations (Feng Deng, U. Toronto)
-		</li>
-		<li>
-			Variability and sources of tropospheric aerosols over the North Atlantic during NAAMES (Hongyu Liu, NIA)
-		</li>
-		<li>
-			Long-range transport events of black carbon and carbon monoxide from East Asia to the Arctic (Kohei Ikeda, NEIS)
-		</li>
-		<li>
-			HCOOH from ATom (Xin Chen, U. Minnesota)
-		</li>
-		<li>
-			Detection of wildfire pollution in the Arctic using ground-based FTIR measurements and GEOS-Chem (Erik Lutsch, U. Toronto)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1mVMpoZ2D9ECz6IOng2wl-0rNnQVlebU4/view?usp=drive_link" target="_blank">Temporal variations in CO and isoprene over tropical Africa</a> (Christian DiMaria, U. Toronto)
-		</li>
-		<li>
-			Designing new interventions to mitigate the impact of Indian agricultural residue burning (Ruoyu Lan, MIT)
-		</li>
-		<li>
-			Understanding the sources of aerosol pollution in India (Sidhant Pai, MIT)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1xEWmsLBs-N0PXFKZd-htzE6npCWIMvJ7/view?usp=drive_link" target="_blank">Air quality and health impacts of household energy transitions in the Indo Gangetic Plain</a> (Mrinmoy Chakraborty, U. British Columbia)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/11GthO9KJjomEAggug5SvaE37Rk1FLjG1/view?usp=drive_link" target="_blank">Impact of emissions from coal fired power plants on health using air chemistry modeling</a> (Madhulika Gurazada, Indian School of Business Hyderabad)
-		</li>
-		<li>
-			Air quality study using GEOS-Chem (Xinhua Shen, U. Northern Iowa)
-		</li>
-		<li>
-			The impact of large-scale afforestation project on ozone pollution in Beijing-Tianjin-Hebei region, China (Xin Long, SUSTC)
-		</li>
-		<li>
-			Investigation of extreme particulate pollution in Beijing (Anqi Hu, NUIST)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1zrO9z79q0z6zupUOSXLaHvYiE8u7MGUB/view?usp=drive_link" target="_blank">Evaluating the efficacy of autumn-winter emission controls in the Beijing-Tianjin-Hebei region</a> (Gongda Lu, U. Birmingham)
-		</li>
-		<li>
-			Simulated severe particulate pollution in China over years of 2013-2018 (Ling Kang, NUIST)
-		</li>
-		<li>
-			Changes in ammonia agriculture emissions and their impact on surface PM2.5 pollution in China during 2005-2015 (Youfan Chen, PKU / U. Colorado)
-		</li>
-		<li>
-			Air quality benefits of wind power development in U.S. (Minghao Qiu, MIT)
-		</li>
-		<li>
-			Diagnosing the long-term and short-term changes in ozone production sensitivity to precursor emissions: the view from space (Xiaomeng Jin, LDEO/Columbia)
-		</li>
-		<li>
-			Modelled and measured fine-scale spatiotemporal variability in AOD and PM2.5 across the Colorado Front Range (Michael Cheeseman, CSU)
-		</li>
-		<li>
-			Seasonal variations and long-term trend of dust particle number concentration over the Northeastern United States (Yanda Zhang, SUNY-Albany)
-		</li>
-	</ul></div>
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1ZdbzL8GPUMeCpZw7y51NMycwae6WBu4w/view?usp=drive_link" target="_blank">Changes in aircraft emissions impacts due to non-linear, subgrid-scale plume processes</a> (Thibaud Fritz, MIT)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/14WbPcdNOpg2x_C38yRK5G0iFZV30VkWK/view?usp=drive_link" target="_blank">Influences of ocean iodide on tropospheric photochemistry</a> (Ryan Pound, U. York)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1XY0gEvB-u_DZZAimJtygWkLpig600aDz/view?usp=drive_link" target="_blank">Tropospheric chlorine chemistry in GEOS-Chem</a> (Xuan Wang, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Se9qYSCbgGfxwhqUbMLR1Ypu_GnIvQU8/view?usp=drive_link" target="_blank">Using machine learning to bias correct ozone within GEOS-Chem</a> (Peter Ivatt, U. York)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1HTcrONQV8VVJRU5CgQziue-ZTDn7vWQC/view?usp=drive_link" target="_blank">Observed covariance of ozone and PM2.5 in the Yangtze River Delta region from 2015 to 2017</a> (Huibin Dai, NUIST)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/16_y6FR9M7I3AMJajGYXMKmO-Q-BFVU-9/view?usp=drive_link" target="_blank">Suppression of summer ozone formation under high aerosol conditions</a> (Ke Li, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1n8_KTrvecfMyFFB2hNukEKhF3SBIl94c/view?usp=drive_link" target="_blank">Incorporating chemical interactions and co-emissions in top-down constraints on sources of NOx, SO2, and CO</a> (Zhen Qu, U. Colorado)
+  </li>
+</ul>
 
-<div>
-	<h2>
-		Thursday, May 9
-	</h2>
-	<a name="ThuA" id="ThuA"></a><strong>Air quality (Chair: Yuxuan Wang, U. Houston)</strong>
+<a name="TueC" id="TueC"></a><strong>Chemistry-Ecosystem-Climate (Chair: Hong Liao, NUIST)</strong>
 
-	<ul><li>
-			<a href="https://drive.google.com/file/d/1pWWhRYscDdAHbbefhzU6z4U9bYDnUx5N/view?usp=drive_link" target="_blank">Meteorology of ozone episodes in North American summers from 1980 to 2018</a> (Charlie White, U. Toronto)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1_KtvQ0u2S6k91tQX1bX8Hgw6OGV8GL6M/view?usp=drive_link" target="_blank">Transport of ozone for San Antonio</a> (Wei Li, U. Houston)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1m8RSIkmxqzTmMHOli7KgN-HmD1zqSqzf/view?usp=drive_link" target="_blank">Long-term trend of particle number concentrations in the United States and implications</a> (Fangqun Yu, SUNY-Albany)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1j9r32ISXViacgaBQJN4I53aCzEXWjdvE/view?usp=drive_link" target="_blank">Improving surface PM2.5 forecast using an ensemble of satellite data, chemistry transport model outputs, and surface observations</a> (Jessie Zhang, U. Iowa)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1g6DLRjPbRxByh3R0WmTdDtKdHfwqPXgq/view?usp=drive_link" target="_blank">Investigating biomass burning aerosol in North America</a> (Tess Carter, MIT)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1DqH_Yvx_pVoj7yN3lFH7hri_8ArQZK45/view?usp=drive_link" target="_blank">Response of Hurricane Harvey's rainfall to anthropogenic aerosols</a> (Amir Souri, Harvard-Smithsonian CFA)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/19BPEdD2aTtPqCc0RsDLtdvFgLPmTPTUI/view?usp=drive_link" target="_blank">Investigation of anthropogenic influence on VOCs and SOA in the southeast US</a> (Yiqi Zheng, U. Alaska Fairbanks)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1XxWbhozEHi07GYuwjXksIHLm0miO6aKy/view?usp=drive_link" target="_blank">GEOS-Chem adjoint inversion of SO2 and NOx emissions with multi-sensor</a> (OMPS, OMI, and VIIRS) data over China (Yi Wang, U. Iowa)
-		</li>
-		<li>
-			Source contributions to ambient fine particulate matter for Canada using GEOS-Chem (Jun Meng, Dalhousie)
-		</li>
-	</ul><a name="ThuB" id="ThuB"></a><strong>Model Clinics</strong>
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1oNO4s6LF80DUc310dMopzpqWLH54YK79/view?usp=drive_link" target="_blank">Coupling a simplified biosphere model with GEOS-Chem</a> (Liang Feng, U. Edinburgh)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1hfc3lhdVURbnXCq4VR_voA-MMBpBaeHV/view?usp=drive_link" target="_blank">Evaluation of air pollution impacts on terrestrial ecosystems using GEOS-Chem</a> (Amos Tai, CUHK)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1hokJKeZhRfX916RUnDS9mQoaFhmFx_Zf/view?usp=drive_link" target="_blank">Reassessment of historic fire trends based on Antarctic-wide array of ice cores and fire modeling</a> (Pengfei Liu, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1Cg8OolnUPUitKnm_mEEOIOCq6JefABeU/view?usp=drive_link" target="_blank">Fire air pollution reduces global terrestrial productivity</a> (Xu Yue, IAP CAS)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1ELTjwg_BZBkzgoxzVskWXPTXf9yPqy3T/view?usp=drive_link" target="_blank">Development of the Beijing Climate Center climate-chemistry model (BCC-AGCM-GCHP): model description and evaluation</a> (Xiao Lu, PKU)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1DwfLsvIqR8JmBT2yHydP3YHr_peny6hc/view?usp=drive_link" target="_blank">Linking GEOS-Chem to CESM: An intermodel comparison of the modeling frameworks</a> (Forrest Lacey, NCAR)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1yKJ817oSndB7D8jkFHIh3CjdCegYSFPk/view?usp=drive_link" target="_blank">Constraining gaseous dry deposition velocity with in-situ flux observations</a> (Anthony Wong, Boston U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1jRdYZKenQeJBbgcvyA0K7YG9Jupah9Ag/view?usp=drive_link" target="_blank">Significant impact of cloud condensation water variability and empirical washout rate on concentrations of nitrate and ammonium</a> (Gan Luo, SUNY-Albany)
+  </li>
+</ul>
 
-	<ul><li>
-			<a href="https://drive.google.com/file/d/17-BniqQfxZHmvg33cSqYRSc8KAz6Ovp1/view?usp=drive_link" target="_blank">Model Clinic 4: GEOS-Chem on the AWS Cloud</a> (Jiawei Zhuang and Bob Yantosca, Harvard)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/138mr1iV4Rvz6CHPDgctgwFJIdZe1wryE/view?usp=drive_link" target="_blank">Model Clinic 5: GEOS-Chem in Earth System Models</a> (Christoph Keller, NASA; Sebastian Eastham, MIT)
-		</li>
-		<li>
-			<a href="https://drive.google.com/file/d/1A59Ow4TKP9wbL7L7ZGV0jbVuyE2UjoFt/view?usp=drive_link" target="_blank">Model Clinic 6: GEOS-Chem nested model</a> (Yuxuan Wang, U. Houston; Lin Zhang, PKU)
-		</li>
-		<li>
-			<a href="https://prezi.com/iut9jtq9muas/?utm_campaign=share&amp;utm_medium=copy&amp;rc=ex0share" target="_blank">Model Clinic 7: GEOS-Chem adjoint model</a>; <a href="https://drive.google.com/file/d/19_B5iie1v3j6lFHWPCmEToP94zlYZXNy/view?usp=drive_link" target="_blank">Handout</a> (Daven Henze and Yanko Davila, U. Colorado)
-		</li>
-	</ul>
-  </div>
+<a name="TueP" id="TueP"></a><strong>Posters</strong>
+
+<ul>
+  <li>
+    Simulation of organic aerosol in China (Ruqian Miao, PKU)
+  </li>
+  <li>
+    PyroCb tropopause smoke composition modeling (Tyler Van, U. Iowa)
+  </li>
+  <li>
+    Improved representation of surface PM2.5 using High Spectral Resolution Lidar retrievals and GEOS-Chem-derived aerosol types (Xinyi Ling, NCSU)
+  </li>
+  <li>
+    PM2.5 over China during 2014-2017 inferred from MAIAC AOD and Cloud GEOS-Chem (Fei Yao, U. Edinburgh)
+  </li>
+  <li>
+    Investigating aerosol influences over Central Asia (Shannon Capps, Drexel U.)
+  </li>
+  <li>
+    Application of GEOS-Chem to interpret observations for the estimation of global PM2.5 (Melanie Hammer, Dalhousie)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1cJ5sJF97zf5cuYNAFMPaB9j68EyZf5Hc/view?usp=drive_link" target="_blank">Sensitivity of global PM2.5 to emission sectors in GEOS-Chem</a> (Erin McDuffie, Dalhousie)
+  </li>
+  <li>
+    On the change of aerosol size distribution due to ionization (Irina Thaler, Hebrew U.)
+  </li>
+  <li>
+    Impact of mixing states on aerosol direct radiative forcing and heating rate based on GEOSChem- APM (Hailing Jia, SUNY-Albany)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/12rHbDTIuW5To5lXVGqStQwYYUakcsqje/view?usp=drive_link" target="_blank">The contribution of wild land-fire smoke to US PM2.5 and its influence on recent trends</a> (Katelyn O’Dell, CSU)
+  </li>
+  <li>
+    Implications of using the GEOS-Chem air mass factor for interpreting satellite NO2 observations (Matt Cooper, Dalhousie)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1kbmd3x4GJ-1v7m7QF3XaXlQG-wedZO1L/view?usp=drive_link" target="_blank">Using satellite observations of tropospheric NO2 columns to infer long-term trends in US NOx emissions: the importance of accounting for the free tropospheric NO2 background</a> (Rachel Silvern, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1np0Py3_N-1seQcqkbzQrWihdbdGQaygB/view?usp=drive_link" target="_blank">Atmospheric impacts of improved sea-surface iodide fields and evidence for changes since 1950</a> (Tomas Sherwen, U. York)
+  </li>
+  <li>
+    Gas-phase photo-reduction of oxidized mercury and its implications (Colin Thackray, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1oO8eYkUJ13Oxvw_Op16iVmBJT_tRwzWz/view?usp=drive_link" target="_blank">Hydroxymethane sulfonate in extreme haze</a> (Jonathan Moch, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1H69Dk4aIR44yuO_V5zSITJ3DOW-S0Ylo/view?usp=drive_link" target="_blank">Impacts of atmospheric acidity on halogen chemistry from preindustrial to present day</a> (Shuting Zhai, U. Washington)
+  </li>
+  <li>
+    Tropospheric bromine chemistry and its impact on ozone and OH (Lei Zhu, Harvard)
+  </li>
+  <li>
+    Stratospheric halogen loading in GEOS-Chem UCX and satellite-based retrievals of tropospheric BrO (PamWales, NASA)
+  </li>
+  <li>
+    Interpreting TROPOMI data over Southeast Asia using the nested GEOS-Chem model simulation (Margaret Marvin, U. Edinburgh)
+  </li>
+  <li>
+    Trends, drivers, and impacts of ozone exposure in the United States from 2000-2015 (Karl Setzer, Duke)
+  </li>
+  <li>
+    How much does long-range transport of air pollutants from South Asia affect the Arctic region? (Sujai Banerji, U. Alaska Fairbanks)
+  </li>
+  <li>
+    Evaluating and improving Arctic ozone chemistry in GEOS-Chem (Kaitlyn Confer, FSU)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1RzIeORFp3dw32bsIMpalTYYxtmvMGHFU/view?usp=drive_link" target="_blank">Air quality and climate impact of charcoal use in Africa</a> (Alfred Bockarie, U. Birmingham)
+  </li>
+  <li>
+    Investigating drivers of particulate matter pollution over India and implications for climate (Alex Karambelas, LDEO/Columbia)
+  </li>
+  <li>
+    An improved vegetation canopy representation in GEOS-Chem (Sam Silva, MIT)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1c3H--TBHAe04i9pl2YHp2Xuy-hMqkj5a/view?usp=drive_link" target="_blank">Development of a new ecophysiology module in GEOS-Chem to represent biosphereatmosphere exchange</a> (Joey Lam, CUHK)
+  </li>
+  <li>
+    Fine-scale projections of wildfire under the mid- and late-21st century climate and land use in the western US (Yang Li, Harvard)
+  </li>
+  <li>
+    Radiative effects of aerosols and ozone in China over 2012-2017 as the consequence of clean air actions (Ruijun Dang, IAP CAS)
+  </li>
+  <li>
+    Source attribution of climate and health impacts from aerosols (Omar Nawaz, U. Colorado)
+  </li>
+  <li>
+    Ecosystem ozone impacts in past, present, future scenarios (David Yung, CUHK)
+  </li>
+  <li>
+    Impacts of China anthropogenic aerosols on springtime mesoscale convective systems over southern China (Lijuan Zhang, PKU)
+  </li>
+  <li>
+    Response of BVOC emissions to drought stress (Elizabeth Klovenski, U. Houston)
+  </li>
+  <li>
+    Sensitivity of aerosol radiative effects to shipping emissions (Deanna Kerry, Dalhousie
+  </li>
+</ul>
+
+
+<h2>Wednesday, May 8</h2>
+
+<a name="WedA" id="WedA"></a><strong>Carbon Gases (Chair: Dylan Jones, U. Toronto)</strong>
+
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1k3oMSBE9ehACPSrx8DS69Jvx0n6X8hko/view?usp=drive_link" target="_blank"><b>KEYNOTE</b>: Regional and global scale measurements and modeling of CO2, CH4, and CO</a> (Steve Wofsy, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1NiMBET6AzUfFRZ8b7nXQgaC9yirjqI8L/view?usp=drive_link" target="_blank">Recent trends in methane emissions from China and opportunities for mitigation</a> (Scot Miller, Johns Hopkins U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1_TTEyFApGrrH84qfA7Vgz5XEfVnJlVML/view?usp=drive_link" target="_blank">Global budget of atmospheric methane as inferred from GOSAT satellite observations during 2009-2017</a> (Yuzhong Zhang, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1wNDdrjTTq55p5RIKa9MULD1kUFZK56O9/view?usp=drive_link" target="_blank">Towards an improved carbon greenhouse gas simulation in GEOS-Chem v12</a> (Beata Bukosa, U. Wollongong)
+  </li>
+  <li>
+    Resolving information in large-scale inversions (Kevin Bowman, JPL)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1SJBn4_4_ZtcCcJrl7kSsy2mbhiShcY-s/view?usp=drive_link" target="_blank">Optimizing OH distributions using 14CO and methyl chloroform in the GEOS-Chem adjoint</a> (Lee Murray, U. Rochester)
+  </li>
+</ul>
+
+<a name="WedB" id="WedB"></a><strong>Global atmospheric composition (Chair: Daven Henze, U. Colorado</strong>
+
+<ul
+  ><li>
+    <a href="https://drive.google.com/file/d/1fDCMZ66ocdsnyrLo9IprJq2ooOUfBn5s/view?usp=drive_link" target="_blank">Model analysis of interannual variability of Asian Tropopause Aerosol Layer: Transport pathways, sources, and composition</a> (Bo Zhang, NIA)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1vw2Y9ETE3v8U2LcaGtLHwmOzdHlibGkz/view?usp=drive_link" target="_blank">Near real-time forecasts at 25km horizontal resolution</a> (Emma Knowland, NASA)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1wpmN3dJLMYOtW1NjE9BT50-YjMkwiDH_/view?usp=drive_link" target="_blank">Trade, atmospheric transport and globalizing air pollution: recent progress</a> (Jintai Lin, PKU)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1TKl303MyWAEiQvgrYrpPzjtMbd_F_baK/view?usp=drive_link" target="_blank">Applying GEOS-Chem-TOMAS to understand Arctic marine secondary aerosol contributions to particle size distributions</a> (Betty Croft, Dalhousie)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1JxHMF0f6Xv_ATP7gfnIWeEnaEHrM_bn9/view?usp=drive_link" target="_blank">On the temporal resolution of transport</a> (Shiliang Wu, Michigan Tech)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1QGNe3Y-O-lyk_lpWVXw_zIW4A0hpORYG/view?usp=drive_link" target="_blank">Multi-model comparisons of multi-constituent satellite data assimilation based on ensemble Kalman filter for tropospheric chemistry analysis</a> (Kazuyuki Miyazaki, JPL/JAMSTEC)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1wXJPAUHoWoMj8jq4Wj_JMAulU8DuBBuh/view?usp=drive_link" target="_blank">Constraining modeled remote oxidation capacity with ATom observations</a> (Katie Travis, MIT/NASA)
+  </li>
+</ul>
+
+<a name="WedC" id="WedC"></a><strong>Air Quality (Chair: Jintai Lin, PKU)</strong>
+
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1-q3p1g0ZBNhvpJ76uYwcItJh5F29lzS3/view?usp=drive_link" target="_blank">The effect of emission control measures on ozone concentration in Hangzhou during G20 meeting in 2016</a> (Ye Wang, NUIST)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/17BEOWIlfiXM7_PJgyJquTJwiLxjV5hC_/view?usp=drive_link" target="_blank">Air quality and health co-benefits of shale gas development in China</a> (Yanxu Zhang, Nanjing)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1uLmgPXSsqlCzotijH27x4h28slOBz6AA/view?usp=drive_link" target="_blank">Air quality and health effects of the residential energy transition in China</a> (Kelsey Bilsback, CSU)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1fWIDsM7ABFH1kDJP8RMaowLdY-7M3_8k/view?usp=drive_link" target="_blank">Analysis of PM2.5 variations across China</a> (Matthew Jolleys, U. Edinburgh)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1SvOJgs7e7b3jRcgtZgmkbhJIf-goKrkP/view?usp=drive_link" target="_blank">Effect of the transport of ozone and its precursors in Central China on ozone pollution episodes in North China</a> (Cheng Gong, IAP CAS)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1tZ0RNXd0B4kd78Ciiyl2y8NrCb2s_z2l/view?usp=drive_link" target="_blank">Environmental and health impact of Chinese dietary change from 1980 to 2010</a> (Xueying Liu, CUHK)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1NAOcK4FTVC8wUzzSMzAnOaAPebvRILi4/view?usp=drive_link" target="_blank">Future changes in the sensitivity of inorganic fine particulate matter to precursor emissions in China</a> (Mingwei Li, MIT)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/18Blf5aBXdAiPVSJBxOHfTZLUigCXPXo8/view?usp=drive_link" target="_blank">Re-estimating ammonia emission inventory in eastern China using CrIS satellite observations of ammonia and GEOS-Chem adjoint model</a> (Juliet (Liye) Zhu, Sun-Yat-Sen U.)
+  </li>
+</ul>
+
+<a name="WedP" id="WedP"></a><strong>Posters</strong>
+
+<ul>
+  <li>
+    Prior biosphere model impact on global terrestrial CO2 fluxes estimated from OCO-2 retrievals (Sajeev Philip, NASA)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/19ohcL0v8KFKPkj7z2Oo5EOSU6pF8cQ82/view?usp=drive_link" target="_blank">Diagnosing global changes in atmospheric methane using ethane and propane</a> (Douglas Finch, U. Edinburgh)
+  </li>
+  <li>
+    Methane clumped isotopes In GEOS-Chem (Alice Drinkwater, U. Edinburgh)
+  </li>
+  <li>
+    Evaluation of a new methane isotopologue forward model of GEOS-Chem (Mingjian Shi, U. Rochester)
+  </li>
+  <li>
+    Interannual variability in CO2 fluxes from OCO-2 using a geostatistical inverse model (Zichong Chen, Johns Hopkins U.)
+  </li>
+  <li>
+    Inverse modeling of CO2 fluxes using O-Buoys, a multi-year dataset of surface observations from the Arctic Ocean (Kelly Graham, FSU)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1T6PSOP9pgdtFlra5G-5Shuo5qk9d6ESJ/view?usp=drive_link" target="_blank">Methane emissions from oil and gas industries in three western provinces of Canada using GOSAT observations in mass balance method and comparison with GEOS-Chem</a> (Nazrul Islam, U. Northern British Columbia)
+  </li>
+  <li>
+    Regional inversion modeling: A framework for understanding CO2 concentration in Seoul megacity (JongWong Lee, Seoul National U.)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1WG6_vIhGiQURp9CghBzdl56ROCvE_5k0/view?usp=drive_link" target="_blank">Strengthened scientific support for the Endangerment Finding for atmospheric greenhouse gases</a> (Loretta Mickley, Harvard)
+  </li>
+  <li>
+    The variation trend of atmospheric methane from observation and modeling (Haiyue Tan, PKU)
+  </li>
+  <li>
+    Top-down constraints on methane point source emissions from animal agriculture and waste based on GEM airborne measurements in the US Upper Midwest (Xueying Yu, U. Minnesota)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1oMxFKE1JDv-8Gq6oiflPIzlah9zm8wXG/view?usp=drive_link" target="_blank">Reduced rank Jacobians: Decreasing the computational cost of high resolution analytic inversions</a> (Hannah Nesser, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1a7ZVjeKJCOPQuicpYGR9dMKmaHg9kn1F/view?usp=drive_link" target="_blank">Quantification of Canadian methane emissions using the ECCC surface observation network</a> (Sabour Baray, York U.)
+  </li>
+  <li>
+    Modeling CO2 fluxes using satellite observations (Feng Deng, U. Toronto)
+  </li>
+  <li>
+    Variability and sources of tropospheric aerosols over the North Atlantic during NAAMES (Hongyu Liu, NIA)
+  </li>
+  <li>
+    Long-range transport events of black carbon and carbon monoxide from East Asia to the Arctic (Kohei Ikeda, NEIS)
+  </li>
+  <li>
+    HCOOH from ATom (Xin Chen, U. Minnesota)
+  </li>
+  <li>
+    Detection of wildfire pollution in the Arctic using ground-based FTIR measurements and GEOS-Chem (Erik Lutsch, U. Toronto)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1mVMpoZ2D9ECz6IOng2wl-0rNnQVlebU4/view?usp=drive_link" target="_blank">Temporal variations in CO and isoprene over tropical Africa</a> (Christian DiMaria, U. Toronto)
+  </li>
+  <li>
+    Designing new interventions to mitigate the impact of Indian agricultural residue burning (Ruoyu Lan, MIT)
+  </li>
+  <li>
+    Understanding the sources of aerosol pollution in India (Sidhant Pai, MIT)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1xEWmsLBs-N0PXFKZd-htzE6npCWIMvJ7/view?usp=drive_link" target="_blank">Air quality and health impacts of household energy transitions in the Indo Gangetic Plain</a> (Mrinmoy Chakraborty, U. British Columbia)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/11GthO9KJjomEAggug5SvaE37Rk1FLjG1/view?usp=drive_link" target="_blank">Impact of emissions from coal fired power plants on health using air chemistry modeling</a> (Madhulika Gurazada, Indian School of Business Hyderabad)
+  </li>
+  <li>
+    Air quality study using GEOS-Chem (Xinhua Shen, U. Northern Iowa)
+  </li>
+  <li>
+    The impact of large-scale afforestation project on ozone pollution in Beijing-Tianjin-Hebei region, China (Xin Long, SUSTC)
+  </li>
+  <li>
+    Investigation of extreme particulate pollution in Beijing (Anqi Hu, NUIST)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1zrO9z79q0z6zupUOSXLaHvYiE8u7MGUB/view?usp=drive_link" target="_blank">Evaluating the efficacy of autumn-winter emission controls in the Beijing-Tianjin-Hebei region</a> (Gongda Lu, U. Birmingham)
+  </li>
+  <li>
+    Simulated severe particulate pollution in China over years of 2013-2018 (Ling Kang, NUIST)
+  </li>
+  <li>
+    Changes in ammonia agriculture emissions and their impact on surface PM2.5 pollution in China during 2005-2015 (Youfan Chen, PKU / U. Colorado)
+  </li>
+  <li>
+    Air quality benefits of wind power development in U.S. (Minghao Qiu, MIT)
+  </li>
+  <li>
+    Diagnosing the long-term and short-term changes in ozone production sensitivity to precursor emissions: the view from space (Xiaomeng Jin, LDEO/Columbia)
+  </li>
+  <li>
+    Modelled and measured fine-scale spatiotemporal variability in AOD and PM2.5 across the Colorado Front Range (Michael Cheeseman, CSU)
+  </li>
+  <li>
+    Seasonal variations and long-term trend of dust particle number concentration over the Northeastern United States (Yanda Zhang, SUNY-Albany)
+  </li>
+</ul>
+
+<h2>Thursday, May 9</h2>
+
+<a name="ThuA" id="ThuA"></a><strong>Air quality (Chair: Yuxuan Wang, U. Houston)</strong>
+
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/1pWWhRYscDdAHbbefhzU6z4U9bYDnUx5N/view?usp=drive_link" target="_blank">Meteorology of ozone episodes in North American summers from 1980 to 2018</a> (Charlie White, U. Toronto)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1_KtvQ0u2S6k91tQX1bX8Hgw6OGV8GL6M/view?usp=drive_link" target="_blank">Transport of ozone for San Antonio</a> (Wei Li, U. Houston)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1m8RSIkmxqzTmMHOli7KgN-HmD1zqSqzf/view?usp=drive_link" target="_blank">Long-term trend of particle number concentrations in the United States and implications</a> (Fangqun Yu, SUNY-Albany)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1j9r32ISXViacgaBQJN4I53aCzEXWjdvE/view?usp=drive_link" target="_blank">Improving surface PM2.5 forecast using an ensemble of satellite data, chemistry transport model outputs, and surface observations</a> (Jessie Zhang, U. Iowa)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1g6DLRjPbRxByh3R0WmTdDtKdHfwqPXgq/view?usp=drive_link" target="_blank">Investigating biomass burning aerosol in North America</a> (Tess Carter, MIT)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1DqH_Yvx_pVoj7yN3lFH7hri_8ArQZK45/view?usp=drive_link" target="_blank">Response of Hurricane Harvey's rainfall to anthropogenic aerosols</a> (Amir Souri, Harvard-Smithsonian CFA)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/19BPEdD2aTtPqCc0RsDLtdvFgLPmTPTUI/view?usp=drive_link" target="_blank">Investigation of anthropogenic influence on VOCs and SOA in the southeast US</a> (Yiqi Zheng, U. Alaska Fairbanks)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1XxWbhozEHi07GYuwjXksIHLm0miO6aKy/view?usp=drive_link" target="_blank">GEOS-Chem adjoint inversion of SO2 and NOx emissions with multi-sensor</a> (OMPS, OMI, and VIIRS) data over China (Yi Wang, U. Iowa)
+  </li>
+  <li>
+    Source contributions to ambient fine particulate matter for Canada using GEOS-Chem (Jun Meng, Dalhousie)
+  </li>
+</ul>
+
+<a name="ThuB" id="ThuB"></a><strong>Model Clinics</strong>
+
+<ul>
+  <li>
+    <a href="https://drive.google.com/file/d/17-BniqQfxZHmvg33cSqYRSc8KAz6Ovp1/view?usp=drive_link" target="_blank">Model Clinic 4: GEOS-Chem on the AWS Cloud</a> (Jiawei Zhuang and Bob Yantosca, Harvard)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/138mr1iV4Rvz6CHPDgctgwFJIdZe1wryE/view?usp=drive_link" target="_blank">Model Clinic 5: GEOS-Chem in Earth System Models</a> (Christoph Keller, NASA; Sebastian Eastham, MIT)
+  </li>
+  <li>
+    <a href="https://drive.google.com/file/d/1A59Ow4TKP9wbL7L7ZGV0jbVuyE2UjoFt/view?usp=drive_link" target="_blank">Model Clinic 6: GEOS-Chem nested model</a> (Yuxuan Wang, U. Houston; Lin Zhang, PKU)
+  </li>
+  <li>
+    <a href="https://prezi.com/iut9jtq9muas/?utm_campaign=share&amp;utm_medium=copy&amp;rc=ex0share" target="_blank">Model Clinic 7: GEOS-Chem adjoint model</a>; <a href="https://drive.google.com/file/d/19_B5iie1v3j6lFHWPCmEToP94zlYZXNy/view?usp=drive_link" target="_blank">Handout</a> (Daven Henze and Yanko Davila, U. Colorado)
+  </li>
+</ul>
 
 </div>
 </div>
@@ -716,64 +730,16 @@ The 9th International GEOS-Chem Meeting (IGC9) May 6-9, 2019
 </div>
 </div>
 
-<!--footer region beg-->
+<!--footer-->
 <footer id="footer" class="clearfix" role="contentinfo">
-
-<!-- Three column 3x33 Gpanel -->
-<div class="at-panel gpanel panel-display footer clearfix">
-<div class="region region-footer">
-<div class="region-inner clearfix">
-<div id="block-boxes-1617037690" class="block block-boxes block-boxes-os_boxes_html no-title"  module="boxes" delta="1617037690">
-<div class="block-inner clearfix">  
-<div class="block-content content" ng-non-bindable="">  
-<div id='boxes-box-1617037690' class='boxes-box'>  
 <div class="boxes-box-content">
   <p style="text-align:center">
-    Copyright © 2023 by the International GEOS-Chem Community. All rights reserved.
+    Copyright © 2026 by the International GEOS-Chem Community. All rights reserved.
   </p>
 </div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-<div class="region region-footer-bottom">  
-<div class="region-inner clearfix">  
-<div id="block-boxes-1616879798" class="block block-boxes block-boxes-os_boxes_media no-title"  module="boxes" delta="1616879798">  
-<div class="block-inner clearfix">  
-<div class="block-content content"> 
-<div id='boxes-box-1616879798' class='boxes-box'> 
-<div class="boxes-box-content"> 
-<div id="file-3900146" class="file file-html file-html-embed">
-<h2 class="element-invisible"><a href="">css-brand</a></h2>
-<div class="content">
-<div class="file-info">
-</div>
-<div class="field field-name-field-html-code field-type-text-long field-label-hidden view-mode-full">
-<div class="field-items">
-<div class="field-item even">
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-
-<!--footer region end-->
 </footer>
-</div>
-</div>
 
-<!--page area ends-->
-<div id="extradiv"></div>
+</div>
 </div>
 
 </body>

--- a/igc9.html
+++ b/igc9.html
@@ -1,9 +1,4 @@
 <!DOCTYPE html>
-<!--[if IEMobile 7]><html class="iem7"  lang="en" dir="ltr"><![endif]-->
-<!--[if lte IE 6]><html class="lt-ie9 lt-ie8 lt-ie7"  lang="en" dir="ltr"><![endif]-->
-<!--[if (IE 7)&(!IEMobile)]><html class="lt-ie9 lt-ie8"  lang="en" dir="ltr"><![endif]-->
-<!--[if IE 8]><html class="lt-ie9"  lang="en" dir="ltr"><![endif]-->
-<!--[if (gte IE 9)|(gt IEMobile 7)]><!--><html  lang="en" dir="ltr"><!--<![endif]-->
 <head>
 <meta charset="utf-8" />
 <!--<base href="/igc9" />-->
@@ -18,23 +13,12 @@
 <title>The 9th International GEOS-Chem Meeting</title>
 <meta http-equiv="x-ua-compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<link type="text/css" rel="stylesheet" href="css/css_xE-rWrJf-fncB6ztZfd2huxqgxu4WO-qwma6Xer30m4%EF%B9%96m=1675397288.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_1kR8T1_c-l5pBT6ZwbDT7BFda-4fyqW9Jjum29_2IY8%EF%B9%96m=1675397312.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_YnlUIvHP13qgpYEqubzE8JyDwlSxUnVibfnVkSoSDb0%EF%B9%96m=1675397273.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_Ku-3OcT9qU9h7dnGig5e23q6EVryY8orK4wzVDxsweE%EF%B9%96m=1675397367.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_vprtFTrWyg23GbY50_zJZHWGYMNfS8vsrRS26i4-ISk%EF%B9%96m=1675397406.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_dW-aNNrctRhQNc-KECjtQd0PxuW-h19IEum-TX2MeEk%EF%B9%96m=1675397301.css" media="print" />
-<link type="text/css" rel="stylesheet" href="css/css_SH2Lx3Qprh0GZo_9xRp85U9NsWfkSXn_Bi-rJoMY1sw%EF%B9%96m=1675397273.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_uaIDKcYMUK5osSQXuirpr3ZleXtnnpBN-eiECm7N0M0%EF%B9%96m=1675397395.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/responsive.blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/geos-chem.css" media="all"/>
 <script type="text/javascript" src="dropdown-menu.js"></script>
-<!--[if lte IE 8]>
-<script type="text/javascript">
-  var os_c = document.createElement;os_c('header');os_c('nav');os_c('section');os_c('article');os_c('aside');os_c('footer');os_c('hgroup');os_c('figure');
-</script>
-<![endif]-->
 </head>
 
 <body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-1585687 node-type-page og-context og-context-node og-context-node-1585652 navbar-on">
@@ -45,7 +29,7 @@
 <div id="page_wrap" class="page_wrap">
 <div id="page" class="container page header-main content-top footer-none">
 <div id="page-wrapper">
-		
+    
 <!--header regions beg-->
 <header id="header" class="clearfix" role="banner">
 <div id="header-container">
@@ -76,15 +60,16 @@ The 9th International GEOS-Chem Meeting (IGC9) May 6-9, 2019
 
 <!--main menu region beg-->
 <div id="menu-bar" class="nav region-menu-bar clearfix">
-<nav id="block-os-igc9-menu" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="igc9_menu">  
-<ul class="nice-menu nice-menu-down nice-menu-igc9_menu" id="nice-menu-igc9_menu">
-  <li class="menu-857212 menu-path-node-1586486  first   odd  "><a href="igc9.html"  class="active">Home</a></li>
-  <li class="menu-857214 menu-path-node-1586487   even  "><a href="igc9-presentations.html" >Presentations and Posters</a></li>
-  <li class="menu-857216 menu-path-node-1586490   odd   last "><a href="igc9-webcast.html" >Webcast Archive</a></li></ul>
+<nav id="block-os-igc9-menu" class="block block-os os-custom-menu no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="igc9_menu">
+<ul class="nice-menu nice-menu-down">
+  <li><a href="igc9.html" class="active">IGC9 Home</a></li>
+  <li><a href="igc9-presentations.html">Presentations and Posters</a></li>
+  <li><a href="index.html">GEOS-Chem Home</a></li>
+</ul>
 </nav>
 </div>
 <!--main menu region end-->
-		
+    
 <div id="columns" class="clearfix">
 <div class="hg-container">
 <div id="content-column" role="main">
@@ -94,7 +79,7 @@ The 9th International GEOS-Chem Meeting (IGC9) May 6-9, 2019
 <a name="main-content"></a>
 <h1 id="page-title" ng-non-bindable="">Overview</h1>
 </header>
-														
+                            
 <!--front panel regions beg-->
 <div id="content-panels" class="at-panel gpanel panel-display content clearfix">
 <div class="region region-content-top">
@@ -109,32 +94,27 @@ The 9th International GEOS-Chem Meeting (IGC9) May 6-9, 2019
 <div class="field-item even">
   
 <p style="text-align:center">
-	<img height="795" width="1753" style="width: 600px; height: 272px;" alt="IGC9 group photo" class="media-element file-default file-os-files-xxlarge" src="img/igc9_group_photo.jpg" title="" /></p>
+  <img height="795" width="1753" style="width: 600px; height: 272px;" alt="IGC9 group photo" class="media-element file-default file-os-files-xxlarge" src="img/igc9_group_photo.jpg" title="" /></p>
 
-<p align="justify">
-	The 9th International GEOS-Chem Meeting (IGC9) was held at Harvard University (Cambridge, MA, USA) on May 6–9, 2019 with <a href="https://drive.google.com/file/d/1bIGhBEwVOFlinqkk2HqhACfQpMjzOc2f/view?usp=sharing">237 participants from over 60 institutions and 9 countries</a>. Follow the links for:
+<p>The 9th International GEOS-Chem Meeting (IGC9) was held at Harvard University (Cambridge, MA, USA) on May 6–9, 2019 with <a href="https://drive.google.com/file/d/1bIGhBEwVOFlinqkk2HqhACfQpMjzOc2f/view?usp=sharing">237 participants from over 60 institutions and 9 countries</a>. Follow the links for:
 </p>
 
-<ul><li>
-		<a href="igc9-presentations.html" title="">Oral and poster presentations from the meeting</a>;
-	</li>
-	<li>
-		<a href="http://wiki.seas.harvard.edu/geos-chem/index.php/GEOS-Chem_model_development_priorities" target="_blank">Model development priority list coming out of the meeting.</a>
-	</li>
-</ul><p>
-	We are grateful for the financial support for the meeting offered by NASA, NSF, NOAA, HUCE, EPRI, and the MIT GEOS-Chem community.
-</p>
+<ul>
+  <li>
+    <a href="igc9-presentations.html" title="">Oral and poster presentations from the meeting</a>;
+  </li>
+  <li>
+    <a href="http://wiki.seas.harvard.edu/geos-chem/index.php/GEOS-Chem_model_development_priorities" target="_blank">Model development priority list coming out of the meeting.</a>
+  </li>
+</ul>
 
-<p>
-	We look forward to seeing you at the 10th International GEOS-Chem Meeting in 2021.
-</p>
+<p>We are grateful for the financial support for the meeting offered by NASA, NSF, NOAA, HUCE, EPRI, and the MIT GEOS-Chem community.</p>
 
-<p>
-	<a href="steering-committee.html" target="_blank" title="">The GEOS-Chem Steering Committee</a>
-</p>
+<p>We look forward to seeing you at the 10th International GEOS-Chem Meeting in 2021.</p>
 
-<p style="text-align:center">
-	<img height="304" width="716" alt="IGC9 sponsors - NASA, NSF, NORA, EPRI, HUCE, SEAS, MIT" class="media-element file-default file-os-files-xlarge" src="img/igc9_sponsors.png" title="" /></p>
+<p><a href="steering-committee.html" target="_blank" title="">The GEOS-Chem Steering Committee</a></p>
+
+<p style="text-align:center"><img height="304" width="716" alt="IGC9 sponsors - NASA, NSF, NORA, EPRI, HUCE, SEAS, MIT" class="media-element file-default file-os-files-xlarge" src="img/igc9_sponsors.png" title="" /></p>
 
 </div>
 </div>
@@ -154,64 +134,16 @@ The 9th International GEOS-Chem Meeting (IGC9) May 6-9, 2019
 </div>
 </div>
 
-<!--footer region beg-->
+<!--footer-->
 <footer id="footer" class="clearfix" role="contentinfo">
-
-<!-- Three column 3x33 Gpanel -->
-<div class="at-panel gpanel panel-display footer clearfix">
-<div class="region region-footer">
-<div class="region-inner clearfix">
-<div id="block-boxes-1617037690" class="block block-boxes block-boxes-os_boxes_html no-title"  module="boxes" delta="1617037690">
-<div class="block-inner clearfix">  
-<div class="block-content content" ng-non-bindable="">  
-<div id='boxes-box-1617037690' class='boxes-box'>  
 <div class="boxes-box-content">
   <p style="text-align:center">
-    Copyright © 2023 by the International GEOS-Chem Community. All rights reserved.
+    Copyright © 2026 by the International GEOS-Chem Community. All rights reserved.
   </p>
 </div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-<div class="region region-footer-bottom">  
-<div class="region-inner clearfix">  
-<div id="block-boxes-1616879798" class="block block-boxes block-boxes-os_boxes_media no-title"  module="boxes" delta="1616879798">  
-<div class="block-inner clearfix">  
-<div class="block-content content"> 
-<div id='boxes-box-1616879798' class='boxes-box'> 
-<div class="boxes-box-content"> 
-<div id="file-3900146" class="file file-html file-html-embed">
-<h2 class="element-invisible"><a href="">css-brand</a></h2>
-<div class="content">
-<div class="file-info">
-</div>
-<div class="field field-name-field-html-code field-type-text-long field-label-hidden view-mode-full">
-<div class="field-items">
-<div class="field-item even">
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-
-<!--footer region end-->
 </footer>
-</div>
-</div>
 
-<!--page area ends-->
-<div id="extradiv"></div>
+</div>
 </div>
 
 </body>

--- a/index.html
+++ b/index.html
@@ -1,9 +1,4 @@
 <!DOCTYPE html>
-<!--[if IEMobile 7]><html class="iem7"  lang="en" dir="ltr"><![endif]-->
-<!--[if lte IE 6]><html class="lt-ie9 lt-ie8 lt-ie7"  lang="en" dir="ltr"><![endif]-->
-<!--[if (IE 7)&(!IEMobile)]><html class="lt-ie9 lt-ie8"  lang="en" dir="ltr"><![endif]-->
-<!--[if IE 8]><html class="lt-ie9"  lang="en" dir="ltr"><![endif]-->
-<!--[if (gte IE 9)|(gt IEMobile 7)]><!--><html  lang="en" dir="ltr"><!--<![endif]-->
 <head>
 <meta charset="utf-8" />
 <!--<base href="/" />-->
@@ -31,11 +26,6 @@
 <link type="text/css" rel="stylesheet" href="css/responsive.blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/geos-chem.css" media="all"/>
 <script type="text/javascript" src="dropdown-menu.js"></script>
-<!--[if lte IE 8]>
-<script type="text/javascript">
-  var os_c = document.createElement;os_c('header');os_c('nav');os_c('section');os_c('article');os_c('aside');os_c('footer');os_c('hgroup');os_c('figure');
-</script>
-<![endif]-->
 </head>
 
 <body class="html front not-logged-in no-sidebars page-home og-context og-context-node og-context-node-1585652 navbar-on">
@@ -46,7 +36,7 @@
 <div id="page_wrap" class="page_wrap">
 <div id="page" class="container page header-main content-top footer-none">
 <div id="page-wrapper">
-		
+    
 <!--header regions beg-->
 <header id="header" class="clearfix" role="banner">
 <div id="header-container">
@@ -77,7 +67,7 @@
 <script>inlineDropDownMenu();</script>
 </nav>
 </div>
-<!--main menu region end-->	
+<!--main menu region end-->  
 
 <div id="columns" class="clearfix">
 <div class="hg-container">
@@ -99,11 +89,11 @@
     <td style="text-align:center">
       <h3><strong><a href="http://wiki.seas.harvard.edu/geos-chem/index.php/GEOS-Chem_versions" target="_blank">Past Releases</a></strong></h3>
     </td>
-	<td style="text-align:center; background-color:#87CEFA;">
-	  <h3><strong><a href="http://wiki.geos-chem.org/GEOS-Chem_14.7.1" title="">Current Release: GEOS-Chem 14.7.1</a></strong></h3>
-	</td>
-	<td style="text-align:center">
-	  <h3><strong><a href="http://wiki.seas.harvard.edu/geos-chem/index.php/GEOS-Chem_model_development_priorities" target="_blank">Future Releases</a></strong></h3>
+  <td style="text-align:center; background-color:#87CEFA;">
+    <h3><strong><a href="http://wiki.geos-chem.org/GEOS-Chem_14.7.1" title="">Current Release: GEOS-Chem 14.7.1</a></strong></h3>
+  </td>
+  <td style="text-align:center">
+    <h3><strong><a href="http://wiki.seas.harvard.edu/geos-chem/index.php/GEOS-Chem_model_development_priorities" target="_blank">Future Releases</a></strong></h3>
     </td>
   </tr>
 </table>
@@ -129,43 +119,29 @@
 <b>The 12th International GEOS-Chem Meeting (IGC12) will be held at Washington University in St. Louis (Missouri, USA) on June 8-12, 2026. Check back soon for more information.</b>
 </p>
 
-<p align="justify">
-GEOS-Chem is a global 3-D model of atmospheric chemistry driven by meteorological input from the Goddard Earth Observing System (GEOS) of the <a href="http://gmao.gsfc.nasa.gov/">NASA Global Modeling and Assimilation Office</a>. It is applied by <a href="users.html">hundreds of research groups around the world</a> to a wide range of topics involving atmospheric composition. Regional refinement capabilities and efficient parallelization enable rapid fine resolution simulations. Scientific direction of the model is provided by the international <a href="steering-committee.html" title="">GEOS-Chem Steering Committee</a> and by <a href="working-groups.html" title="">Working Groups</a>. The model is managed by the <a href="support-team.html" title="">GEOS-Chem Support Team</a>, based at Harvard University and Washington University.
-</p>
+<p>GEOS-Chem is a global 3-D model of atmospheric chemistry driven by meteorological input from the Goddard Earth Observing System (GEOS) of the <a href="http://gmao.gsfc.nasa.gov/">NASA Global Modeling and Assimilation Office</a>. It is applied by <a href="users.html">hundreds of research groups around the world</a> to a wide range of topics involving atmospheric composition. Regional refinement capabilities and efficient parallelization enable rapid fine resolution simulations. Scientific direction of the model is provided by the international <a href="steering-committee.html" title="">GEOS-Chem Steering Committee</a> and by <a href="working-groups.html" title="">Working Groups</a>. The model is managed by the <a href="support-team.html" title="">GEOS-Chem Support Team</a>, based at Harvard University and Washington University.</p>
 
 <p align="center">
 <img src="img/GCHP_C720_O3_Frame.png" width="60%" alt="Snapshot of atmospheric ozone concentrations from a c720 GCHP model simulation">
 </p>
 
-<p align="justify">
-GEOS-Chem is a grass-roots open-access model owned by its <a href="users.html">users</a>, and ownership implies some responsibilities as listed in our <a href="welcome.html">welcome page for new users</a>. If you are interested in using GEOS-Chem, please review our <a href="https://geos-chem.readthedocs.io/en/stable/geos-chem-shared-docs/supplemental-guides/related-docs.html">extensive documentation</a> and <a href="https://geos-chem.readthedocs.io/en/stable/help-and-reference/SUPPORT.html">support guidelines</a>.
-</p>
+<p>GEOS-Chem is a grass-roots open-access model owned by its <a href="users.html">users</a>, and ownership implies some responsibilities as listed in our <a href="welcome.html">welcome page for new users</a>. If you are interested in using GEOS-Chem, please review our <a href="https://geos-chem.readthedocs.io/en/stable/geos-chem-shared-docs/supplemental-guides/related-docs.html">extensive documentation</a> and <a href="https://geos-chem.readthedocs.io/en/stable/help-and-reference/SUPPORT.html">support guidelines</a>.</p>
 
 <div id="block-boxes-1616879219" class="block block-boxes block-boxes-os_boxes_html no-title"  module="boxes" delta="1616879219">
 <div class="block-inner clearfix">  
 
-<h3 style="margin-bottom:1em; text-align:center">
-	<strong>GEOS-Chem Community Mission: To advance understanding of human and natural influences on the environment through a comprehensive, state-of-the-science, readily accessible global model of atmospheric composition.</strong>
-</h3>
+<h3 style="margin-bottom:1em; text-align:center"><strong>GEOS-Chem Community Mission: To advance understanding of human and natural influences on the environment through a comprehensive, state-of-the-science, readily accessible global model of atmospheric composition.</strong></h3>
 
 <img src="img/igc11_photo.jpg" alt="Group photo of GEOS-Chem users at the IGC11 meeting">
 
 <div id="block-boxes-1616879219" class="block block-boxes block-boxes-os_boxes_html no-title"  module="boxes" delta="1616879219">
 <div class="block-inner clearfix">  
 
-<p align="justify">
-We are constantly improving GEOS-Chem. Check out the <a href="new-developments.html">New Developments page</a> to see the latest version updates.
-</p>
+<p>We are constantly improving GEOS-Chem. Check out the <a href="new-developments.html">New Developments page</a> to see the latest version updates.</p>
 
-<p align="justify">
-Please proceed to the <a href="overview.html">Model Overview </a>for further information and links.
-</p>
+<p>Please proceed to the <a href="overview.html">Model Overview </a>for further information and links.</p>
 
-
-
-<p style="text-align:center">
-<a href="index.html" title=""><img style="width: 200px; height: 29px;" alt="GEOS-Chem logo" class="media-element file-default file-os-files-xxlarge" src="img/geos-chem-logo.png" title="" /></a>
-</p>
+<p style="text-align:center"><a href="index.html" title=""><img style="width: 200px; height: 29px;" alt="GEOS-Chem logo" class="media-element file-default file-os-files-xxlarge" src="img/geos-chem-logo.png" title="" /></a></p>
 
 </div>
 </div>
@@ -182,47 +158,16 @@ Please proceed to the <a href="overview.html">Model Overview </a>for further i
 </div>
 </div>
 
-<!--footer region beg-->
+<!--footer-->
 <footer id="footer" class="clearfix" role="contentinfo">
-
-<!-- Three column 3x33 Gpanel -->
-<div class="at-panel gpanel panel-display footer clearfix">
-<div class="region region-footer-bottom">
-<div class="region-inner clearfix">
-<div id="block-boxes-1616879798" class="block block-boxes block-boxes-os_boxes_media no-title"  module="boxes" delta="1616879798">
-<div class="block-inner clearfix">
-<div class="block-content content">
-<div id='boxes-box-1616879798' class='boxes-box'>
 <div class="boxes-box-content">
-<div id="file-3900146" class="file file-html file-html-embed">
-<h2 class="element-invisible"><a href="">css-brand</a></h2>
-<div class="content">
-<div class="file-info"></div>
-<div class="field field-name-field-html-code field-type-text-long field-label-hidden view-mode-full">
-<div class="field-items">
-<div class="field-item even">
-
+  <p style="text-align:center">
+    Copyright © 2026 by the International GEOS-Chem Community. All rights reserved.
+  </p>
 </div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-
-<!--footer region end-->
 </footer>
-</div>
-</div>
 
-<!--page area ends-->
-<div id="extradiv"></div>
+</div>
 </div>
 
 </body>

--- a/license.html
+++ b/license.html
@@ -29,14 +29,14 @@
 <div id="page_wrap" class="page_wrap">
 <div id="page" class="container page header-main content-top footer-none">
 <div id="page-wrapper">
-		
+
 <!--header regions beg-->
 <header id="header" class="clearfix" role="banner">
 <div id="header-container">
 <div id="header-panels" class="at-panel gpanel panel-display three-col clearfix">
 <div class="region region-header-second"><div class="region-inner clearfix">
 <section id="block-boxes-1630413211" class="block block-boxes block-boxes-os_boxes_html"  module="boxes" delta="1630413211">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <h2 class="block-title" ng-non-bindable="">Site-Logo</h2>
 <div class="block-content content" ng-non-bindable="">
 <div id='boxes-box-1630413211' class='boxes-box'>
@@ -60,7 +60,7 @@
 <script>inlineDropDownMenu();</script>
 </nav>
 </div>
-<!--main menu region end-->	
+<!--main menu region end-->
 
 <div id="columns" class="clearfix">
 <div class="hg-container">
@@ -77,14 +77,14 @@
 <div class="region region-content-top">
 <div class="region-inner clearfix">
 <div id="block-os-pages-main-content" class="block block-os-pages no-title"  module="os_pages" delta="main_content">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <div class="block-content content" ng-non-bindable="">
 <article id="node-1585689" class="node node-page article clearfix" role="article">
 <div class="node-content" ng-non-bindable="">
 <div class="field field-name-body field-type-text-with-summary field-label-hidden view-mode-full">
 <div class="field-items">
 <div class="field-item even">
-    
+
 <p align="justify">
 GEOS-Chem, including developments, is distributed under <a href="https://opensource.org/licenses/MIT" target="_blank">the MIT "Expat" public license.</a>
 </p>
@@ -116,16 +116,16 @@ You may view a copy of the license agreement and list of GEOS-Chem developers by
 </div>
 </div>
 
-<!--footer region beg-->
+<!--footer-->
 <footer id="footer" class="clearfix" role="contentinfo">
-
-<!--footer region end-->
+<div class="boxes-box-content">
+  <p style="text-align:center">
+    Copyright © 2026 by the International GEOS-Chem Community. All rights reserved.
+  </p>
+</div>
 </footer>
-</div>
-</div>
 
-<!--page area ends-->
-<div id="extradiv"></div>
+</div>
 </div>
 
 </body>

--- a/license.html
+++ b/license.html
@@ -1,9 +1,4 @@
 <!DOCTYPE html>
-<!--[if IEMobile 7]><html class="iem7"  lang="en" dir="ltr"><![endif]-->
-<!--[if lte IE 6]><html class="lt-ie9 lt-ie8 lt-ie7"  lang="en" dir="ltr"><![endif]-->
-<!--[if (IE 7)&(!IEMobile)]><html class="lt-ie9 lt-ie8"  lang="en" dir="ltr"><![endif]-->
-<!--[if IE 8]><html class="lt-ie9"  lang="en" dir="ltr"><![endif]-->
-<!--[if (gte IE 9)|(gt IEMobile 7)]><!--><html  lang="en" dir="ltr"><!--<![endif]-->
 <head>
 <meta charset="utf-8" />
 <!--<base href="/license" />-->
@@ -18,23 +13,12 @@
 <title>GEOS-Chem License</title>
 <meta http-equiv="x-ua-compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<link type="text/css" rel="stylesheet" href="css/css_xE-rWrJf-fncB6ztZfd2huxqgxu4WO-qwma6Xer30m4%EF%B9%96m=1675397288.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_1kR8T1_c-l5pBT6ZwbDT7BFda-4fyqW9Jjum29_2IY8%EF%B9%96m=1675397312.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_YnlUIvHP13qgpYEqubzE8JyDwlSxUnVibfnVkSoSDb0%EF%B9%96m=1675397273.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_Ku-3OcT9qU9h7dnGig5e23q6EVryY8orK4wzVDxsweE%EF%B9%96m=1675397367.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_vprtFTrWyg23GbY50_zJZHWGYMNfS8vsrRS26i4-ISk%EF%B9%96m=1675397406.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_dW-aNNrctRhQNc-KECjtQd0PxuW-h19IEum-TX2MeEk%EF%B9%96m=1675397301.css" media="print" />
-<link type="text/css" rel="stylesheet" href="css/css_SH2Lx3Qprh0GZo_9xRp85U9NsWfkSXn_Bi-rJoMY1sw%EF%B9%96m=1675397273.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_uaIDKcYMUK5osSQXuirpr3ZleXtnnpBN-eiECm7N0M0%EF%B9%96m=1675397395.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/responsive.blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/geos-chem.css" media="all"/>
 <script type="text/javascript" src="dropdown-menu.js"></script>
-<!--[if lte IE 8]>
-<script type="text/javascript">
-  var os_c = document.createElement;os_c('header');os_c('nav');os_c('section');os_c('article');os_c('aside');os_c('footer');os_c('hgroup');os_c('figure');
-</script>
-<![endif]-->
 </head>
 
 <body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-1585687 node-type-page og-context og-context-node og-context-node-1585652 navbar-on">
@@ -134,38 +118,6 @@ You may view a copy of the license agreement and list of GEOS-Chem developers by
 
 <!--footer region beg-->
 <footer id="footer" class="clearfix" role="contentinfo">
-
-<!-- Three column 3x33 Gpanel -->
-<div class="at-panel gpanel panel-display footer clearfix">
-<div class="region region-footer-bottom">
-<div class="region-inner clearfix">
-<div id="block-boxes-1616879798" class="block block-boxes block-boxes-os_boxes_media no-title"  module="boxes" delta="1616879798">
-<div class="block-inner clearfix">
-<div class="block-content content">
-<div id='boxes-box-1616879798' class='boxes-box'>
-<div class="boxes-box-content">
-<div id="file-3900146" class="file file-html file-html-embed">
-<h2 class="element-invisible"><a href="">css-brand</a></h2>
-<div class="content">
-<div class="file-info">
-</div>
-<div class="field field-name-field-html-code field-type-text-long field-label-hidden view-mode-full">
-<div class="field-items">
-<div class="field-item even">
-
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
 
 <!--footer region end-->
 </footer>

--- a/logo.html
+++ b/logo.html
@@ -18,23 +18,12 @@
 <title>GEOS-Chem Logo</title>
 <meta http-equiv="x-ua-compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<link type="text/css" rel="stylesheet" href="css/css_xE-rWrJf-fncB6ztZfd2huxqgxu4WO-qwma6Xer30m4%EF%B9%96m=1675397288.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_1kR8T1_c-l5pBT6ZwbDT7BFda-4fyqW9Jjum29_2IY8%EF%B9%96m=1675397312.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_YnlUIvHP13qgpYEqubzE8JyDwlSxUnVibfnVkSoSDb0%EF%B9%96m=1675397273.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_Ku-3OcT9qU9h7dnGig5e23q6EVryY8orK4wzVDxsweE%EF%B9%96m=1675397367.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_vprtFTrWyg23GbY50_zJZHWGYMNfS8vsrRS26i4-ISk%EF%B9%96m=1675397406.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_dW-aNNrctRhQNc-KECjtQd0PxuW-h19IEum-TX2MeEk%EF%B9%96m=1675397301.css" media="print" />
-<link type="text/css" rel="stylesheet" href="css/css_SH2Lx3Qprh0GZo_9xRp85U9NsWfkSXn_Bi-rJoMY1sw%EF%B9%96m=1675397273.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_uaIDKcYMUK5osSQXuirpr3ZleXtnnpBN-eiECm7N0M0%EF%B9%96m=1675397395.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/responsive.blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/geos-chem.css" media="all"/>
 <script type="text/javascript" src="dropdown-menu.js"></script>
-<!--[if lte IE 8]>
-<script type="text/javascript">
-  var os_c = document.createElement;os_c('header');os_c('nav');os_c('section');os_c('article');os_c('aside');os_c('footer');os_c('hgroup');os_c('figure');
-</script>
-<![endif]-->
 </head>
 
 <body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-1585687 node-type-page og-context og-context-node og-context-node-1585652 navbar-on">
@@ -45,14 +34,14 @@
 <div id="page_wrap" class="page_wrap">
 <div id="page" class="container page header-main content-top footer-none">
 <div id="page-wrapper">
-		
+
 <!--header regions beg-->
 <header id="header" class="clearfix" role="banner">
 <div id="header-container">
 <div id="header-panels" class="at-panel gpanel panel-display three-col clearfix">
 <div class="region region-header-second"><div class="region-inner clearfix">
 <section id="block-boxes-1630413211" class="block block-boxes block-boxes-os_boxes_html"  module="boxes" delta="1630413211">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <h2 class="block-title" ng-non-bindable="">Site-Logo</h2>
 <div class="block-content content" ng-non-bindable="">
 <div id='boxes-box-1630413211' class='boxes-box'>
@@ -76,7 +65,7 @@
 <script>inlineDropDownMenu();</script>
 </nav>
 </div>
-<!--main menu region end-->	
+<!--main menu region end-->
 
 <div id="columns" class="clearfix">
 <div class="hg-container">
@@ -93,7 +82,7 @@
 <div class="region region-content-top">
 <div class="region-inner clearfix">
 <div id="block-os-pages-main-content" class="block block-os-pages no-title"  module="os_pages" delta="main_content">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <div class="block-content content" ng-non-bindable="">
 <article id="node-1585687" class="node node-page article clearfix" role="article">
 <div class="node-content" ng-non-bindable="">
@@ -166,48 +155,16 @@
 </div>
 </div>
 
-<!--footer region beg-->
+<!--footer-->
 <footer id="footer" class="clearfix" role="contentinfo">
-
-<!-- Three column 3x33 Gpanel -->
-<div class="at-panel gpanel panel-display footer clearfix">
-<div class="region region-footer-bottom">
-<div class="region-inner clearfix">
-<div id="block-boxes-1616879798" class="block block-boxes block-boxes-os_boxes_media no-title"  module="boxes" delta="1616879798">
-<div class="block-inner clearfix">
-<div class="block-content content">
-<div id='boxes-box-1616879798' class='boxes-box'>
 <div class="boxes-box-content">
-<div id="file-3900146" class="file file-html file-html-embed">
-<h2 class="element-invisible"><a href="">css-brand</a></h2>
-<div class="content">
-<div class="file-info">
+  <p style="text-align:center">
+    Copyright © 2026 by the International GEOS-Chem Community. All rights reserved.
+  </p>
 </div>
-<div class="field field-name-field-html-code field-type-text-long field-label-hidden view-mode-full">
-<div class="field-items">
-<div class="field-item even">
-
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-
-<!--footer region end-->
 </footer>
-</div>
-</div>
 
-<!--page area ends-->
-<div id="extradiv"></div>
+</div>
 </div>
 
 </body>

--- a/narrative.html
+++ b/narrative.html
@@ -1,9 +1,4 @@
 <!DOCTYPE html>
-<!--[if IEMobile 7]><html class="iem7"  lang="en" dir="ltr"><![endif]-->
-<!--[if lte IE 6]><html class="lt-ie9 lt-ie8 lt-ie7"  lang="en" dir="ltr"><![endif]-->
-<!--[if (IE 7)&(!IEMobile)]><html class="lt-ie9 lt-ie8"  lang="en" dir="ltr"><![endif]-->
-<!--[if IE 8]><html class="lt-ie9"  lang="en" dir="ltr"><![endif]-->
-<!--[if (gte IE 9)|(gt IEMobile 7)]><!--><html  lang="en" dir="ltr"><!--<![endif]-->
 <head>
 <meta charset="utf-8" />
 <!--<base href="/narrative" />-->
@@ -18,23 +13,12 @@
 <title>Narrative description and how to cite GEOS-Chem</title>
 <meta http-equiv="x-ua-compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<link type="text/css" rel="stylesheet" href="css/css_xE-rWrJf-fncB6ztZfd2huxqgxu4WO-qwma6Xer30m4%EF%B9%96m=1675397288.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_1kR8T1_c-l5pBT6ZwbDT7BFda-4fyqW9Jjum29_2IY8%EF%B9%96m=1675397312.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_YnlUIvHP13qgpYEqubzE8JyDwlSxUnVibfnVkSoSDb0%EF%B9%96m=1675397273.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_Ku-3OcT9qU9h7dnGig5e23q6EVryY8orK4wzVDxsweE%EF%B9%96m=1675397367.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_vprtFTrWyg23GbY50_zJZHWGYMNfS8vsrRS26i4-ISk%EF%B9%96m=1675397406.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_dW-aNNrctRhQNc-KECjtQd0PxuW-h19IEum-TX2MeEk%EF%B9%96m=1675397301.css" media="print" />
-<link type="text/css" rel="stylesheet" href="css/css_SH2Lx3Qprh0GZo_9xRp85U9NsWfkSXn_Bi-rJoMY1sw%EF%B9%96m=1675397273.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_uaIDKcYMUK5osSQXuirpr3ZleXtnnpBN-eiECm7N0M0%EF%B9%96m=1675397395.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/responsive.blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/geos-chem.css" media="all"/>
 <script type="text/javascript" src="dropdown-menu.js"></script>
-<!--[if lte IE 8]>
-<script type="text/javascript">
-  var os_c = document.createElement;os_c('header');os_c('nav');os_c('section');os_c('article');os_c('aside');os_c('footer');os_c('hgroup');os_c('figure');
-</script>
-<![endif]-->
 </head>
 
 <body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-1585793 node-type-page og-context og-context-node og-context-node-1585652 navbar-on">
@@ -45,14 +29,14 @@
 <div id="page_wrap" class="page_wrap">
 <div id="page" class="container page header-main content-top footer-none">
 <div id="page-wrapper">
-		
+
 <!--header regions beg-->
 <header id="header" class="clearfix" role="banner">
 <div id="header-container">
 <div id="header-panels" class="at-panel gpanel panel-display three-col clearfix">
 <div class="region region-header-second"><div class="region-inner clearfix">
 <section id="block-boxes-1630413211" class="block block-boxes block-boxes-os_boxes_html"  module="boxes" delta="1630413211">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <h2 class="block-title" ng-non-bindable="">Site-Logo</h2>
 <div class="block-content content" ng-non-bindable="">
 <div id='boxes-box-1630413211' class='boxes-box'>
@@ -70,14 +54,14 @@
 </header>
 <!--header regions end-->
 
-		
+
 <!--main menu region beg-->
 <div id="menu-bar" class="nav region-menu-bar clearfix">
-<nav id="block-os-primary-menu" class="block block-os no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="primary-menu">  
+<nav id="block-os-primary-menu" class="block block-os no-title menu-wrapper menu-bar-wrapper clearfix"  module="os" delta="primary-menu">
 <script>inlineDropDownMenu();</script>
 </nav>
 </div>
-<!--main menu region end-->	
+<!--main menu region end-->
 
 <div id="columns" class="clearfix">
 <div class="hg-container">
@@ -88,13 +72,13 @@
 <a name="main-content"></a>
 <h1 align="center" id="page-title" ng-non-bindable=""> Narrative description and how to cite GEOS-Chem</h1>
 </header>
-			
+
 <!--front panel regions beg-->
 <div id="content-panels" class="at-panel gpanel panel-display content clearfix">
 <div class="region region-content-top">
 <div class="region-inner clearfix">
 <div id="block-os-pages-main-content" class="block block-os-pages no-title"  module="os_pages" delta="main_content">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <div class="block-content content" ng-non-bindable="">
 <article id="node-1585793" class="node node-page article clearfix" role="article">
 <div class="node-content" ng-non-bindable="">
@@ -215,7 +199,7 @@ GEOS-Chem is a grid-independent model. It operates on 1-D columns with default o
 </h2>
 
 <p>
-GEOS-Chem Classic and GCHP can be run on the cloud as originally described by Zhuang et al. [2019, 2020]. The functionality for GCHP required further maintenance, development, and documentation. This update is a <a href="new-developments.html" target="_blank" title="">new development in version 14.2.0</a>.	
+GEOS-Chem Classic and GCHP can be run on the cloud as originally described by Zhuang et al. [2019, 2020]. The functionality for GCHP required further maintenance, development, and documentation. This update is a <a href="new-developments.html" target="_blank" title="">new development in version 14.2.0</a>.
 </p>
 
 <h2>
@@ -241,13 +225,13 @@ The GEOS data are pre-processed for use in GEOS-Chem, in particular to generate 
 </p>
 
 <p>
-The GEOS-FP data for June 2020 onward adn the GEOS-IT data use a new convective scheme [Freitas et al., 2021]; addressing this change for GEOS-Chem is a <a href="new-developments.html" title="">new development in version 14.7.0</a>. 
+The GEOS-FP data for June 2020 onward adn the GEOS-IT data use a new convective scheme [Freitas et al., 2021]; addressing this change for GEOS-Chem is a <a href="new-developments.html" title="">new development in version 14.7.0</a>.
 <p>
 GEOS-Chem simulations can be conducted at the native spatial resolution of the GEOS fields or at coarser resolutions. Simulations focused on the troposphere can reduce the number of vertical levels from 72 to 47 by coarsening the vertical resolution in the stratosphere and mesosphere. This <a href="https://wiki.seas.harvard.edu/geos-chem/index.php?title=GEOS-Chem_14.7.0#1-year_transport_GEOS-Chem_Classic_version_comparison_(14.7.0_on_72_levels_vs_14.7.0_on_47_levels)" target="_blank">does not affect tropospheric transport</a>, but it has a <a href="https://github.com/geoschem/geos-chem/issues/3238" target="_blank">slight effect on tropospheric photolysis rate constants</a>.  GEOS-Chem Classic simulations can also be conducted in nested mode (see Nesting below). The default timesteps are optimized to balance accuracy and speed as described by Philip et al. [2016].
 </p>
 
 <p>
-	GEOS-Chem can also use off-line meteorological fields from the GISS GCM for future climates and paleoclimates. These implementations are referred to as the GCAP and ICECAP models. GCAP 2.0 is described by Murray et al. [2021].
+  GEOS-Chem can also use off-line meteorological fields from the GISS GCM for future climates and paleoclimates. These implementations are referred to as the GCAP and ICECAP models. GCAP 2.0 is described by Murray et al. [2021].
 </p>
 
 <p>
@@ -258,7 +242,7 @@ The GEOS-Chem chemical module can be used in on-line applications on any grid of
   <li>On-line coupling with the GEOS ESM is described by Hu et al. [2018] and is called <em>GEOS-GC</em></li>
   <li>On-line coupling with the Beijing Climate Center (BCC) climate model is described by Lu et al. [2020] and is called <em>BCC-GC</em></li>
   <li>On-line coupling with the Weather Research Forecast (WRF) model is described by Lin et al. [2020] and Feng et al. [2021] and is called <em>WRF-GC</em>.</li>
-  <li>On-line coupling with the Community Earth System Model (CESM) is described in Fritz et al. [2022] and Lin et al. [2024] and is called <em>CESM-GC.</em></li>  
+  <li>On-line coupling with the Community Earth System Model (CESM) is described in Fritz et al. [2022] and Lin et al. [2024] and is called <em>CESM-GC.</em></li>
 </ul>
 
 <h2>
@@ -286,7 +270,7 @@ GEOS-Chem Classic uses the TPCORE advection algorithm of Lin and Rood [1996] on 
 </p>
 
 <p>
-The wet deposition scheme in GEOS-Chem is described by Liu et al. [2001] for water-soluble aerosols and by Amos et al. [2012] for gases. Henry's law constants are from the compilation by Sander [2015] including for water-soluble organics [Safieddine and Heald, 2017]. Scavenging of aerosol by snow and cold/mixed precipitation is described by Q. Wang et al. [2011, 2014]. Faster scavenging as described by Luo et al. [2023] is an option in the model and this is a <a href="new-developments.html" title="">new development in version 14.7.0</a>. 
+The wet deposition scheme in GEOS-Chem is described by Liu et al. [2001] for water-soluble aerosols and by Amos et al. [2012] for gases. Henry's law constants are from the compilation by Sander [2015] including for water-soluble organics [Safieddine and Heald, 2017]. Scavenging of aerosol by snow and cold/mixed precipitation is described by Q. Wang et al. [2011, 2014]. Faster scavenging as described by Luo et al. [2023] is an option in the model and this is a <a href="new-developments.html" title="">new development in version 14.7.0</a>.
 </p>
 
 <p>
@@ -335,7 +319,7 @@ Future projections of anthropogenic emissions following the RCP scenarios have b
 </p>
 
 <p>
-<em>Ships</em>. Global shipping emissions are from CEDS. Shipping emissions of NOx are processed by the PARANOX module of Vinken et al. [2012] to account for ozone and HNO3 production in the plume. The PARANOX module was updated by Holmes et al. [2014]. PARANOX is disabled for simulations at 0.125&deg; and 0.25&deg; resolution in 14.7.0 onward. 
+<em>Ships</em>. Global shipping emissions are from CEDS. Shipping emissions of NOx are processed by the PARANOX module of Vinken et al. [2012] to account for ozone and HNO3 production in the plume. The PARANOX module was updated by Holmes et al. [2014]. PARANOX is disabled for simulations at 0.125&deg; and 0.25&deg; resolution in 14.7.0 onward.
 </p>
 
 <p>
@@ -371,7 +355,7 @@ Future projections of anthropogenic emissions following the RCP scenarios have b
 </h2>
 
 <p>
-	GEOS-Chem simulates detailed oxidant-aerosol chemistry in the troposphere and stratosphere. The chemical solver is KPP 3.0 [Lin et al., 2023] as implemented in GEOS-Chem with the <a href="http://wiki.geos-chem.org/FlexChem">FlexChem interface</a>, and includes the option to use an adaptive chemical solver.  KPP 3.0 is a <a href="new-developments.html" target="_blank" title="">new development in version 14.1.0</a>. The ability for per-species definition of KPP absolute and relative solver tolerances is a <a href="new-developments.html" title="">new development in version 14.5.0</a>.
+  GEOS-Chem simulates detailed oxidant-aerosol chemistry in the troposphere and stratosphere. The chemical solver is KPP 3.0 [Lin et al., 2023] as implemented in GEOS-Chem with the <a href="http://wiki.geos-chem.org/FlexChem">FlexChem interface</a>, and includes the option to use an adaptive chemical solver.  KPP 3.0 is a <a href="new-developments.html" target="_blank" title="">new development in version 14.1.0</a>. The ability for per-species definition of KPP absolute and relative solver tolerances is a <a href="new-developments.html" title="">new development in version 14.5.0</a>.
 </p>
 
 <h3>
@@ -396,7 +380,7 @@ Chemical mechanism kinetics generally follow JPL/IUPAC recommendations as most r
   <li>Lumped furans [Carter et al., 2022]; this is a <a href="new-developments.html" title="">new development in version 14.2.0</a>.</li>
   <li>RCOOH, monoterpenes, new PNs and ANs [Travis et al., 2024];  this is a <a href="new-developments.html" title="">new development in version 14.5.0</a>.</li>
   <li>Update to ALK4 and R4N2 chemistry [Brewer et al., 2023];  this is a <a href="new-developments.html" title="">new development in version 14.5.0</a>.</li>
-  <li>PPN photolysis [Horner et al., 2024];  this is a <a href="new-developments.html" title="">new development in version 14.5.0</a>.</li>	
+  <li>PPN photolysis [Horner et al., 2024];  this is a <a href="new-developments.html" title="">new development in version 14.5.0</a>.</li>
 </ul>
 
 <p>
@@ -412,7 +396,7 @@ Reactive uptake of nitrogen oxides by clouds accounts for entrainment in the sub
 </p>
 
 <p>
-GEOS-Chem simulations prior to version 13.2.0 could be configured to have full chemistry only in the troposphere (“troposphere-only simulation”) with simple linear representation of stratospheric chemistry following the Linoz algorithm of McLinden et al. [2000] for ozone and monthly mean sources and loss rate constants for other gases [Murray et al., 2012]. This capability was disabled in version 13.2.0. 
+GEOS-Chem simulations prior to version 13.2.0 could be configured to have full chemistry only in the troposphere (“troposphere-only simulation”) with simple linear representation of stratospheric chemistry following the Linoz algorithm of McLinden et al. [2000] for ozone and monthly mean sources and loss rate constants for other gases [Murray et al., 2012]. This capability was disabled in version 13.2.0.
 </p>
 
 <h3>
@@ -436,9 +420,9 @@ GEOS-Chem simulations prior to version 13.2.0 could be configured to have full c
 </p>
 
 <p>
-<em>Aerosol size.</em> Aerosol size for SNA and organic aerosol is from a parameterization of Zhu et al. [2023] and this is a <a href="new-developments.html" title="">new development in version 14.4.0.</a> 	
+<em>Aerosol size.</em> Aerosol size for SNA and organic aerosol is from a parameterization of Zhu et al. [2023] and this is a <a href="new-developments.html" title="">new development in version 14.4.0.</a>
 </p>
-	
+
 <p>
 <em>Marine POA</em>. There is an option to emit marine POA following Gantt et al. [2015].
 </p>
@@ -452,7 +436,7 @@ GEOS-Chem simulations prior to version 13.2.0 could be configured to have full c
 </p>
 
 <p>
-<em>Aerosol optical properties. </em>RH-dependent aerosol optical properties affecting photolysis rates are calculated from Zhu et al. [2023] and this is a <a href="new-developments.html" title="">new development in 14.4.0.</a>; older versions used aerosol optical properties from Latimer and Martin [2019]. Extinction of radiation by mineral dust accounts for its nonsphericity [Singh et al., 2024] and this is a <a href="new-developments.html" title="">new development in 14.6.0.</a>; older versions used dust optical properties described by Ridley et al. [2012]. There is an option to add absorption of UV by brown carbon [Hammer et al., 2016] 
+<em>Aerosol optical properties. </em>RH-dependent aerosol optical properties affecting photolysis rates are calculated from Zhu et al. [2023] and this is a <a href="new-developments.html" title="">new development in 14.4.0.</a>; older versions used aerosol optical properties from Latimer and Martin [2019]. Extinction of radiation by mineral dust accounts for its nonsphericity [Singh et al., 2024] and this is a <a href="new-developments.html" title="">new development in 14.6.0.</a>; older versions used dust optical properties described by Ridley et al. [2012]. There is an option to add absorption of UV by brown carbon [Hammer et al., 2016]
 </p>
 
 <p>
@@ -468,7 +452,7 @@ GEOS-Chem simulations prior to version 13.2.0 could be configured to have full c
 </p>
 
 <p>
-<em>Methane</em>. The current form of the simulation is described by Maasakkers et al. [2019]. Updated soil uptake is from the MeMo model v1.0 [Murguia-Flores et al., 2018]. Default global anthropogenic emissions are from EDGAR version 8; this update from EDGAR version 7 is a <a href="new-developments.html" title="">new development in 14.3.1</a>. Updated emissions from fuel exploitation are from Scarpelli et al. [2025] and is a <a href="new-developments.html" title="">new development in version 14.6.0</a>; older versions used Scarpelli et al. [2022a] and this is a <a href="new-developments.html" title="">new development in version 13.4.0</a>. Anthropogenic emissions from Mexico are from Scarpelli et al. [2020b]. Anthropogenic emissions from Canada are from Scarpelli et al. [2022b] and this is a <a href="new-developments.html" title="">new development in version 13.4.0.</a> Methane emissions from hydropower reservoirs is from Delwiche et al. [2022]; this is a <a href="new-developments.html" title="">new development in version 14.2.0.</a> Rice emissions are from Chen et al. [2025] and this is a <a href="new-developments.html" title="">new development in version 14.6.0</a>. An updated surface methane boundary condition using NOAA flask data is a <a href="new-developments.html" title="">new development in 14.4.0.</a> 
+<em>Methane</em>. The current form of the simulation is described by Maasakkers et al. [2019]. Updated soil uptake is from the MeMo model v1.0 [Murguia-Flores et al., 2018]. Default global anthropogenic emissions are from EDGAR version 8; this update from EDGAR version 7 is a <a href="new-developments.html" title="">new development in 14.3.1</a>. Updated emissions from fuel exploitation are from Scarpelli et al. [2025] and is a <a href="new-developments.html" title="">new development in version 14.6.0</a>; older versions used Scarpelli et al. [2022a] and this is a <a href="new-developments.html" title="">new development in version 13.4.0</a>. Anthropogenic emissions from Mexico are from Scarpelli et al. [2020b]. Anthropogenic emissions from Canada are from Scarpelli et al. [2022b] and this is a <a href="new-developments.html" title="">new development in version 13.4.0.</a> Methane emissions from hydropower reservoirs is from Delwiche et al. [2022]; this is a <a href="new-developments.html" title="">new development in version 14.2.0.</a> Rice emissions are from Chen et al. [2025] and this is a <a href="new-developments.html" title="">new development in version 14.6.0</a>. An updated surface methane boundary condition using NOAA flask data is a <a href="new-developments.html" title="">new development in 14.4.0.</a>
 </p>
 
 <p>
@@ -484,7 +468,7 @@ GEOS-Chem simulations prior to version 13.2.0 could be configured to have full c
 </h2>
 
 <p>
-The original GEOS-Chem coupled atmosphere-ocean simulation of mercury was described by Selin et al. [2007] for the atmosphere and by Strode et al. [2007] for the ocean. Extension to a coupled atmosphere-ocean-land model was described by Selin et al. [2008]. The current version of the atmospheric simulation is described by Shah et al. [2021] and this is a <a href="new-developments.html" title="">new development in version 13.4.0</a>. Older versions used Horowitz et al. [2017]. Improvements in modeled Hg0 dry deposition to land is a <a href="new-developments.html" target="_blank" title="">new development in version 14.1.0</a> [Feinberg et al. 2022]. The current version of the ocean simulation is described by Soerensen et al. [2010], with updated ocean rate coefficients from Song et al. [2015]. Treatment of Arctic sea ice and rivers is as described by Fisher et al. [2012, 2013]. Gas-aerosol partitioning of Hg(II) is from Amos et al. [2012].There is an option to couple GEOS-Chem with the terrestrial mercury module developed by Smith-Downey et al. [2010]. The option to use AMAP 2015 emissions [Steenhuisen and Wilson, 2022] is a <a href="new-developments.html" target="_blank" title="">new development in version 14.1.0</a>. 
+The original GEOS-Chem coupled atmosphere-ocean simulation of mercury was described by Selin et al. [2007] for the atmosphere and by Strode et al. [2007] for the ocean. Extension to a coupled atmosphere-ocean-land model was described by Selin et al. [2008]. The current version of the atmospheric simulation is described by Shah et al. [2021] and this is a <a href="new-developments.html" title="">new development in version 13.4.0</a>. Older versions used Horowitz et al. [2017]. Improvements in modeled Hg0 dry deposition to land is a <a href="new-developments.html" target="_blank" title="">new development in version 14.1.0</a> [Feinberg et al. 2022]. The current version of the ocean simulation is described by Soerensen et al. [2010], with updated ocean rate coefficients from Song et al. [2015]. Treatment of Arctic sea ice and rivers is as described by Fisher et al. [2012, 2013]. Gas-aerosol partitioning of Hg(II) is from Amos et al. [2012].There is an option to couple GEOS-Chem with the terrestrial mercury module developed by Smith-Downey et al. [2010]. The option to use AMAP 2015 emissions [Steenhuisen and Wilson, 2022] is a <a href="new-developments.html" target="_blank" title="">new development in version 14.1.0</a>.
 </p>
 
 <p>
@@ -542,14 +526,14 @@ See the <a href="http://wiki.geos-chem.org/GEOS-Chem_Adjoint" target="_blank">GE
   <li>Bates, K.H., and D.J. Jacob, <em>A new model mechanism for atmospheric oxidation of isoprene: global effects on oxidants, nitrogen oxides, organic products, and secondary organic aerosol</em>, <u>Atmos. Chem. Phys.</u>, <strong>19</strong>, 9613-9640, 2019.</li>
   <li>Bates, K.H., Jacob, D.J., Wang, S., Hornbrook, R.S., Apel, E.C., Kim, M.J., Millet, D.B., Wells, K.C., Chen, X., Brewer, J.F., Ray, E.A., Diskin, G.S., Commane, R., Daube, B.C. and Wofsy, S.C., <em><a href="https://agupubs.onlinelibrary.wiley.com/doi/epdf/10.1029/2020JD033439" title="">The global budget of atmospheric methanol: new constraints on secondary, oceanic, and terrestrial source</a></em>, <u>J. Geophys. Res., 126,</u> e2020JD033439, 2021.</li>
   <li>Bates, K. H., Jacob, D. J., Li, K., Ivatt, P. D., Evans, M. J., Yan, Y., and Lin, J.: Development and evaluation of a new compact mechanism for aromatic oxidation in atmospheric models, Atmos. Chem. Phys., 21, 18351–18374,</span> <a href="https://acp.copernicus.org/articles/21/18351/2021/" title="">https://acp.copernicus.org/articles/21/18351/2021/</a>, 2021.</li>
-  <li>Bates, K., Evans, M., Henderson, B., and Jacob, D.: Impacts of updated reaction kinetics on the global GEOS-Chem simulation of atmospheric chemistry, EGUsphere [preprint], https://doi.org/10.5194/egusphere-2023-1374, 2024.</li>	
+  <li>Bates, K., Evans, M., Henderson, B., and Jacob, D.: Impacts of updated reaction kinetics on the global GEOS-Chem simulation of atmospheric chemistry, EGUsphere [preprint], https://doi.org/10.5194/egusphere-2023-1374, 2024.</li>
   <li>Bey, I., D. J. Jacob, R. M. Yantosca, J. A. Logan, B. Field, A. M. Fiore, Q. Li, H. Liu, L. J. Mickley, and M. Schultz, <em>Global modeling of tropospheric chemistry with assimilated meteorology: Model description and evaluation</em>, <u>J. Geophys. Res.</u>, <strong>106</strong>, 23,073-23,096, 2001.</li>
   <li>Bian, H. S., and M. J. Prather, <em>Fast-J2: Accurate simulation of stratospheric photolysis in global chemical models</em>, <u>J. Atmos. Chem.</u>, <strong>41</strong>, 281-296, 2002.</li>
   <li>Bindle, L., Martin, R. V., Cooper, M. J., Lundgren, E. W., Eastham, S. D., Auer, B. M., Clune, T. L., Weng, H., Lin, J., Murray, L. T., Meng, J., Keller, C. A., Putman, W. M., Pawson, S., and Jacob, D. J.: Grid-stretching capability for the GEOS-Chem 13.0.0 atmospheric chemistry model, Geosci. Model Dev., 14, 5977–5997, https://doi.org/10.5194/gmd-14-5977-2021, 2021.</li>
   <li>Bouwman, A. F., D. S. Lee, W. A. H. Asman, F. J. Dentener, K. W. Van Der Hoek, and J. G. J. Olivier (1997), <em>A global high-resolution emission inventory for ammonia</em>, <u>Global Biogeochem. Cycles</u>, <strong>11(4)</strong>, 561-587.</li>
   <li>Breider, T.J., L.J. Mickley, D.J. Jacob, C. Ge, J. Wang, M.P. Sulprizio, B. Croft, D.A. Ridley, J.R. McConnell, S. Sharma, L. Husain, V.A. Dutkiewicz, K. Eleftheriadis, H. Skov, and P.K. Hopke, <em>Multi-decadal trends in aerosol radiative forcing over the Arctic: contribution of changes in anthropogenic aerosol to Arctic warming since 1980</em>, <u>J. Geophys. Res.</u>, <strong>122(6)</strong>, 3573-3594, doi:10.1002/2016JD025321, 2017.</li>
   <li>Brewer, J. F., Jacob, D. J., Jathar, S. H., He, Y., Akherati, A., Zhai, S., et al. A scheme for representing aromatic secondary organic aerosols in chemical transport models: Application to source attribution of organic aerosols over South Korea during the KORUS-AQ campaign. Journal of Geophysical Research: Atmospheres, 128, e2022JD037257, <a href="https://doi.org/10.1029/2022JD037257">https://doi.org/10.1029/2022JD037257</a>, 2023.</li>
-  <li>Carter, T. S., Heald, C. L., Kroll, J. H., Apel, E. C., Blake, D., Coggon, M., Edtbauer, A., Gkatzelis, G., Hornbrook, R. S., Peischl, J., Pfannerstill, E. Y., Piel, F., Reijrink, N. G., Ringsdorf, A., Warneke, C., Williams, J., Wisthaler, A., and Xu, L.: An improved representation of fire non-methane organic gases (NMOGs) in models: emissions to reactivity, Atmos. Chem. Phys., 22, 12093–12111, https://doi.org/10.5194/acp-22-12093-2022, 2022.</li>	
+  <li>Carter, T. S., Heald, C. L., Kroll, J. H., Apel, E. C., Blake, D., Coggon, M., Edtbauer, A., Gkatzelis, G., Hornbrook, R. S., Peischl, J., Pfannerstill, E. Y., Piel, F., Reijrink, N. G., Ringsdorf, A., Warneke, C., Williams, J., Wisthaler, A., and Xu, L.: An improved representation of fire non-methane organic gases (NMOGs) in models: emissions to reactivity, Atmos. Chem. Phys., 22, 12093–12111, https://doi.org/10.5194/acp-22-12093-2022, 2022.</li>
   <li>Chen, Q., J.A. Schmidt, V. Shah, L. Jaegle, T. Sherwen, and B. Alexander, <em>Sulfate production by reactive bromine: Implications for the global sulfur and reactive bromine budgets</em>, <u>Geophys. Res. Lett.</u>, <strong>44</strong>, 7069-7078, 2017.</li>
   <li>Chen, X., Millet, D. B., Singh, H. B., Wisthaler, A., Apel, E. C., Atlas, E. L., Blake, D. R., Bourgeois, I., Brown, S. S., Crounse, J. D., de Gouw, J. A., Flocke, F. M., Fried, A., Heikes, B. G., Hornbrook, R. S., Mikoviny, T., Min, K.-E., MÃ¼ller, M., Neuman, J. A., O'Sullivan, D. W., Peischl, J., Pfister, G. G., Richter, D., Roberts, J. M., Ryerson, T. B., Shertz, S. R., Thompson, C. R., Treadaway, V., Veres, P. R., Walega, J., Warneke, C., Washenfelder, R. A., Weibring, P., and Yuan, B., <em>On the sources and sinks of atmospheric VOCs: an integrated analysis of recent aircraft campaigns over North America</em>, <u>Atmos. Chem. Phys.</u>, <strong>19</strong>, 9097-9123, <a href="https://doi.org/10.5194/acp-19-9097-2019">https://doi.org/10.5194/acp-19-9097-2019</a>, 2019.</li>
   <li>Chen, Z., et al., <em>Global Rice Paddy Inventory (GRPI): a high-resolution inventory of methane emissions from rice agriculture based on Landsat satellite inundation data</em>, <a href="https://eartharxiv.org/repository/view/7890/">https://eartharxiv.org/repository/view/7890/</a>, submitted 2025.</li>
@@ -558,7 +542,7 @@ See the <a href="http://wiki.geos-chem.org/GEOS-Chem_Adjoint" target="_blank">GE
   <li>Crippa, M., Guizzardi, D., Butler, T., Keating, T., Wu, R., Kaminski, J., Kuenen, J., Kurokawa, J., Chatani, S., Morikawa, T., Pouliot, G., Racine, J., Moran, M. D., Klimont, Z., Manseau, P. M., Mashayekhi, R., Henderson, B. H., Smith, S. J., Suchyta, H., Muntean, M., Solazzo, E., Banja, M., Schaaf, E., Pagani, F., Woo, J. H., Kim, J., Monforti-Ferrario, F., Pisoni, E., Zhang, J., Niemi, D., Sassi, M., Ansari, T., and Foley, K.: HTAP_v3 emission mosaic: a global effort to tackle air quality issues by quantifying global anthropogenic air pollutant sources, Earth Syst. Sci. Data Discuss., 2023, 1-34, 10.5194/essd-2022-442, 2023.</li>
   <li>Croft, B., G. R. Wentworth, R. V. Martin, W. R. Leaitch, J. G. Murphy, B. N. Murphy, J. K. Kodros, J. P. D. Abbatt and J. R. Pierce, <em>Contribution of Arctic seabird-colony ammonia to atmospheric particles and cloud-albedo radiative effect, </em><u>Nat. Commun.</u>, <strong>7</strong>:13444, doi:10.1038/ncomms13444, 2016.</li>
   <li>Croft, B., R.V. Martin, R. Y.-W. Chang, L. Bindle, S.D. Eastham, L.A. Estrada, B. Ford, C.  Li, M.S. Long, E.W. Lundgren, S. Sinha, M.P. Sulprizio, Y. Tang, A. van Donkelaar, R.M. Yantosca, D. Zhang, H. Zhu, and J.R. Pierce Towards fine horizontal resolution global simulations of aerosol sectional microphysics: Advances enabled by GCHP-TOMAS. J. Advances in Modeling Earth Systems, 2023: submitted.</li>
-  <li>Delwiche, K. B., Harrison, J. A., Maasakkers, J. D., Sulprizio, M. P., Worden, J., Jacob, D. J., & Sunderland, E. M. (2022). Estimating drivers and pathways for hydroelectric reservoir methane emissions using a new mechanistic model. Journal of Geophysical Research: Biogeosciences, 127, e2022JG006908. https://doi.org/10.1029/2022JG006908.</li>	
+  <li>Delwiche, K. B., Harrison, J. A., Maasakkers, J. D., Sulprizio, M. P., Worden, J., Jacob, D. J., & Sunderland, E. M. (2022). Estimating drivers and pathways for hydroelectric reservoir methane emissions using a new mechanistic model. Journal of Geophysical Research: Biogeosciences, 127, e2022JG006908. https://doi.org/10.1029/2022JG006908.</li>
   <li>Eastham, S.D., Weisenstein, D.K., Barrett, S.R.H., <em>Development and evaluation of the unified tropospheric-stratospheric chemistry extension (UCX) for the global chemistry-transport model GEOS-Chem</em>, <u>Atmos. Env.</u>, <strong>89</strong>, 2014.</li>
   <li>Eastham, S.D., M.S. Long, C.A. Keller, E. Lundgren, R.M. Yantosca, J. Zhuang, C. Li, C.J. Lee, M. Yannetti, B.M. Auer, T.L. Clune, J. Kouatchou, W.M. Putman, M.A. Thompson, A.L. Trayanov, A.M. Molod, R.V. Martin, and D.J. Jacob, <em>GEOS-Chem High Performance (GCHP): A next-generation implementation of the GEOS-Chem chemical transport model for massively parallel applications </em>, <u>Geosci. Mod. Dev.</u>, <strong>11</strong>, 2941-2953, 2018.</li>
   <li>Emerson, E.W., A.L. Hodshire, H.M. DeBolt, K.R. Bilsback, J.R. Pierce, G.R. McMeeking, and D.K. Farmer, Revisiting particle dry deposition and its role in radiative effect estimates, PNAS, 117, 26076-26082, 2020.</li>
@@ -576,7 +560,7 @@ See the <a href="http://wiki.geos-chem.org/GEOS-Chem_Adjoint" target="_blank">GE
   <li>Fisher, J.A., E.L. Atlas, B. Barletta, S. Meinardi, D.R. Blake, C.R. Thompson, T.B. Ryerson, J. Peischl, Z.A. Tzompa-Sosa, and L.T. Murray, <em>Methyl, Ethyl, and Propyl Nitrates: Global Distribution and Impacts on Reactive Nitrogen in Remote Marine Environments</em>, <u>J. Geophys. Res.</u>, <strong>123</strong>, 12,429-12,451, 2018.</li>
   <li>Fountoukis, C., and A. Nenes, <em>ISORROPIA II: A computationally efficient thermodynamic equilibrium model for K+-Ca2+-Mg2+-NH4+-Na+-SO42-NO3--Cl-H2O aerosols</em>, <u>Atmos. Chem. Phys.</u>, <strong>7</strong>(17), 4639-4659, 2007.</li>
   <li>Franks, P.J., et al., <em>Sensitivity of plants to changing atmospheric CO2 concentration: from the geological past to the next century</em>, <u>New Phytologist</u>, <strong>197.4</strong>, 1077-1094, 2013.</li>
-  <li>Freitas, S. R., Grell, G. A., and Li, H.: The Grell–Freitas (GF) convection parameterization: recent developments, extensions, and applications, Geosci. Model Dev., 14, 5393–541,<a href="https://doi.org/10.5194/gmd-14-5393-2021">https://doi.org/10.5194/gmd-14-5393-2021</a>, 2021. 
+  <li>Freitas, S. R., Grell, G. A., and Li, H.: The Grell–Freitas (GF) convection parameterization: recent developments, extensions, and applications, Geosci. Model Dev., 14, 5393–541,<a href="https://doi.org/10.5194/gmd-14-5393-2021">https://doi.org/10.5194/gmd-14-5393-2021</a>, 2021.
   <li>Friedman, C.L., Y. Zhang, and N.E. Selin, <em>Climate change and emissions impacts on atmospheric PAH transport to the Arctic</em>, <u>Environ. Sci. Technol.</u>, <strong>48</strong> (1), 429-437, 2014</li>
   <li>Fritz, T. M., Eastham, S. D., Emmons, L. K., Lin, H., Lundgren, E. W., Goldhaber, S., Barrett, S. R. H., and Jacob, D. J.: Implementation and evaluation of the GEOS-Chem chemistry module version 13.1.2 within the Community Earth System Model v2.1, Geosci. Model Dev., 15, 8669–8704, https://doi.org/10.5194/gmd-15-8669-2022, 2022.</li>
   <li>Guenther, A.B., Jiang, X., Heald, C.L., Sakulyanontvittaya, T., Duhl, T., Emmons, L.K., and Wang, X., <em>The Model of Emissions of Gases and Aerosols from Nature version 2.1 (MEGAN2.1): an extended and updated framework for modeling biogenic emissions</em>, <u>Geosci. Model Dev.</u>, <strong>5</strong>, 1471-1492, doi:10.5194/gmd-5-1471-2012, 2012.</li>
@@ -674,7 +658,7 @@ See the <a href="http://wiki.geos-chem.org/GEOS-Chem_Adjoint" target="_blank">GE
   <li>Stettler, M.E.J., S. Eastham, S.R.H. Barrett, <em>Air quality and public health impacts of UK airports. Part I: Emissions</em>, <u>Atmos. Environ.</u>, <strong>45</strong>, 5415-5424, 2011.</li>
   <li>Streets, D.G., et al., Global and regional trends of mercury emissions and concentrations, 2010-2015, Atmos. Environ., 417-427, 2019.</li>
   <li>Strode, S., L. Jaeglé, N.E. Selin, D.J. Jacob, R.J. Park, R.M. Yantosca, R.P. Mason, and F. Slemr, <em>Air-sea exchange in the global mercury cycle</em>, <u>Glob. Biogeochem. Cycles</u>, <strong>21</strong>, GB1017, doi:10.1029/2006GB002766, 2007.</li>
-  <li>Travis, K. R., Nault, B. A., Crawford, J. H., Bates, K. H., Blake, D. R., Cohen, R. C., Fried, A., Hall, S. R., Huey, L. G., Lee, Y. R., Meinardi, S., Min, K.-E., Simpson, I. J., and Ullman, K.: Impact of improved representation of volatile organic compound emissions and production of NOx reservoirs on modeled urban ozone production, Atmos. Chem. Phys., 24, 9555–9572, <a href="https://doi.org/10.5194/acp-24-9555-2024">https://doi.org/10.5194/acp-24-9555-2024</a>, 2024.</li> 	
+  <li>Travis, K. R., Nault, B. A., Crawford, J. H., Bates, K. H., Blake, D. R., Cohen, R. C., Fried, A., Hall, S. R., Huey, L. G., Lee, Y. R., Meinardi, S., Min, K.-E., Simpson, I. J., and Ullman, K.: Impact of improved representation of volatile organic compound emissions and production of NOx reservoirs on modeled urban ozone production, Atmos. Chem. Phys., 24, 9555–9572, <a href="https://doi.org/10.5194/acp-24-9555-2024">https://doi.org/10.5194/acp-24-9555-2024</a>, 2024.</li>
   <li>Travis, K.R., and D.J. Jacob, <em>Systematic bias in evaluating chemical transport models with maximum daily 8-hour average (MDA8) surface ozone for air quality applications: a case study with GEOS-Chem v9.02</em>, <u>Geophys. Model Dev.</u>, <strong>12</strong>, 3641-3648, 2019.</li>
   <li>Trivitayanurak, W., P. Adams, D. Spracklen, and K. Carslaw, <em>Tropospheric aerosol microphysics simulation with assimilated meteorology: model description and intermodel comparison</em>, <u>Atmos. Chem. Phys.</u>, <strong>8</strong>, 3149-3168, 2008.</li>
   <li>Tzompa-Sosa, Z.A., E. Mahieu, B. Franco, C.A. Keller, A.J. Turner, D. Helmig, A. Fried, D. Richter, P. Weibring, J. Walega, T.I. Yacovitch, S.C. Herndon, D.R. Blake, F. Hase, J.W. Hannigan, S. Conway, K. Strong, M. Schneider, and E.V. Fischer, <em>Revisiting global fossil fuel and biofuel emissions of ethane</em>, <u>J. Geophys. Res.</u>, <strong>12</strong>, 2493-2512, 2016.</li>
@@ -726,48 +710,16 @@ See the <a href="http://wiki.geos-chem.org/GEOS-Chem_Adjoint" target="_blank">GE
 </div>
 </div>
 
-<!--footer region beg-->
+<!--footer-->
 <footer id="footer" class="clearfix" role="contentinfo">
-
-<!-- Three column 3x33 Gpanel -->
-<div class="at-panel gpanel panel-display footer clearfix">
-<div class="region region-footer-bottom">
-<div class="region-inner clearfix">
-<div id="block-boxes-1616879798" class="block block-boxes block-boxes-os_boxes_media no-title"  module="boxes" delta="1616879798">
-<div class="block-inner clearfix">
-<div class="block-content content">
-<div id='boxes-box-1616879798' class='boxes-box'>
 <div class="boxes-box-content">
-<div id="file-3900146" class="file file-html file-html-embed">
-<h2 class="element-invisible"><a href="">css-brand</a></h2>
-<div class="content">
-<div class="file-info">
+  <p style="text-align:center">
+    Copyright © 2026 by the International GEOS-Chem Community. All rights reserved.
+  </p>
 </div>
-<div class="field field-name-field-html-code field-type-text-long field-label-hidden view-mode-full">
-<div class="field-items">
-<div class="field-item even">
-
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-
-<!--footer region end-->
 </footer>
-</div>
-</div>
 
-<!--page area ends-->
-<div id="extradiv"></div>
+</div>
 </div>
 
 </body>

--- a/new-developments.html
+++ b/new-developments.html
@@ -580,48 +580,16 @@
 </div>
 </div>
 
-<!--footer region beg-->
+<!--footer-->
 <footer id="footer" class="clearfix" role="contentinfo">
-
-<!-- Three column 3x33 Gpanel -->
-<div class="at-panel gpanel panel-display footer clearfix">
-<div class="region region-footer-bottom">
-<div class="region-inner clearfix">
-<div id="block-boxes-1616879798" class="block block-boxes block-boxes-os_boxes_media no-title"  module="boxes" delta="1616879798">
-<div class="block-inner clearfix">
-<div class="block-content content">
-<div id='boxes-box-1616879798' class='boxes-box'>
 <div class="boxes-box-content">
-<div id="file-3900146" class="file file-html file-html-embed">
-<h2 class="element-invisible"><a href="">css-brand</a></h2>
-<div class="content">
-<div class="file-info">
+  <p style="text-align:center">
+    Copyright © 2026 by the International GEOS-Chem Community. All rights reserved.
+  </p>
 </div>
-<div class="field field-name-field-html-code field-type-text-long field-label-hidden view-mode-full">
-<div class="field-items">
-<div class="field-item even">
-
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-
-<!--footer region end-->
 </footer>
-</div>
-</div>
 
-<!--page area ends-->
-<div id="extradiv"></div>
+</div>
 </div>
 
 </body>

--- a/new-developments.html
+++ b/new-developments.html
@@ -93,13 +93,9 @@
   <a href="#new">New developments (versions 13.4.0 - 14.7.0)</a> | <a href="#older">Older developments</a>
 </p>
 
-<p>
-  We list below the major new GEOS-Chem developments and their developers from version 13.4.0 (released May 2022) to version 14.7.0 (released February 2026). If these developments have benefited your work we encourage you to offer co-authorship on publications to the relevant developers. This page is reviewed by the <a href="steering-committee.html">GEOS-Chem Steering Committee</a> at every new X.Y version release. <a href="#older">Older developments</a> are adequately credited by citation following the guidelines in the <a href="narrative.html">Narrative GEOS-Chem Description page</a>. A full version history of GEOS-Chem development can be found on the <a href="http://wiki.geos-chem.org/GEOS-Chem_versions">GEOS-Chem versions wiki page</a>. For questions or guidance please contact the relevant <a href="working-groups.html">Working Group Chair</a> or Model Scientist. For new developments in the adjoint model see the<em> </em><a href="http://wiki.geos-chem.org/GEOS-Chem_Adjoint" target="_blank"><em>adjoint wiki page</em></a>.
-</p>
+<p>We list below the major new GEOS-Chem developments and their developers from version 13.4.0 (released May 2022) to version 14.7.0 (released February 2026). If these developments have benefited your work we encourage you to offer co-authorship on publications to the relevant developers. This page is reviewed by the <a href="steering-committee.html">GEOS-Chem Steering Committee</a> at every new X.Y version release. <a href="#older">Older developments</a> are adequately credited by citation following the guidelines in the <a href="narrative.html">Narrative GEOS-Chem Description page</a>. A full version history of GEOS-Chem development can be found on the <a href="http://wiki.geos-chem.org/GEOS-Chem_versions">GEOS-Chem versions wiki page</a>. For questions or guidance please contact the relevant <a href="working-groups.html">Working Group Chair</a> or Model Scientist. For new developments in the adjoint model see the<em> </em><a href="http://wiki.geos-chem.org/GEOS-Chem_Adjoint" target="_blank"><em>adjoint wiki page</em></a>.</p>
 
-<h2>
-  <a name="new" id="new"></a>New developments in GEOS-Chem versions 13.4.0 - 14.7.0
-</h2>
+<h2><a name="new" id="new"></a>New developments in GEOS-Chem versions 13.4.0 - 14.7.0</h2>
 
 <ul>
   <li>
@@ -155,7 +151,7 @@
   <br/><br/></li>
   <li>
     (14.5.0) <strong>Cloud-J v8.0 including UV H2O absorption.</strong> Developers: Lizzie Lundgren (Harvard) and Michael Prather (UCI). Reference:
-	  Prather, M. J., and Zhu, L. Resetting tropospheric OH and CH4 lifetime with ultraviolet H2O absorption. Science 385, 201–204, 2024.
+    Prather, M. J., and Zhu, L. Resetting tropospheric OH and CH4 lifetime with ultraviolet H2O absorption. Science 385, 201–204, 2024.
   <br/><br/></li>
   <li>
     (14.4.0) <strong>Replace ISORROPIA II with HETP aerosol thermodynamics.</strong> Developers: Lizzie Lundgren (Harvard) and Seb Eastham (ICL). Reference: Miller, S. J., Makar, P. A., and Lee, C. J.: HETerogeneous vectorized or Parallel (HETPv1.0): an updated inorganic heterogeneous chemistry solver for the metastable-state NH4+–Na+–Ca2+–K+–Mg2+–SO42−–NO3−–Cl−–H2O system based on ISORROPIA II, Geosci. Model Dev., 17, 2197–2219, <a href="https://doi.org/10.5194/gmd-17-2197-2024">https://doi.org/10.5194/gmd-17-2197-2024</a>, 2024.
@@ -280,9 +276,7 @@
   <br/><br/></li>
 </ul>
 
-<h2>
-  <a name="older" id="older"></a>Older developments
-</h2>
+<h2><a name="older" id="older"></a>Older developments</h2>
 
 <ul>
   <li>

--- a/newsletters.html
+++ b/newsletters.html
@@ -261,43 +261,15 @@
 </div>
 </div>
 
-<!--footer region beg-->
+<!--footer-->
 <footer id="footer" class="clearfix" role="contentinfo">
-
-<!-- Three column 3x33 Gpanel -->
-<div class="at-panel gpanel panel-display footer clearfix">
-<div class="region region-footer-bottom">
-<div class="region-inner clearfix">
-<div id="block-boxes-1616879798" class="block block-boxes block-boxes-os_boxes_media no-title"  module="boxes" delta="1616879798">
-<div class="block-inner clearfix">
-<div class="block-content content">
-<div id='boxes-box-1616879798' class='boxes-box'>
 <div class="boxes-box-content">
-<div id="file-3900146" class="file file-html file-html-embed">
-<h2 class="element-invisible"><a href="">css-brand</a></h2>
-<div class="content">
-<div class="file-info">
+  <p style="text-align:center">
+    Copyright © 2026 by the International GEOS-Chem Community. All rights reserved.
+  </p>
 </div>
-<div class="field field-name-field-html-code field-type-text-long field-label-hidden view-mode-full">
-<div class="field-items">
-<div class="field-item even">
-
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-
-<!--footer region end-->
 </footer>
+
 </div>
 </div>
 

--- a/overview.html
+++ b/overview.html
@@ -80,123 +80,107 @@
 <div class="field-items">
 <div class="field-item even">
 
-<p align="justify">
-GEOS-Chem enables simulations of atmospheric composition on
-local to global scales. It can be used off-line as a 3-D
-chemical transport model driven by assimilated meteorological
-observations from the Goddard Earth Observing System (GEOS) of
-the NASA <a href="http://gmao.gsfc.nasa.gov/"
-target="_blank">Global Modeling Assimilation Office
-(GMAO)</a>. It can also be used on-line as a chemical module
-coupled to weather and climate models. GEOS-Chem is developed
-and used by <a href="users.html">hundreds of research groups worldwide </a>as a
-versatile tool for application to a wide range of atmospheric
-composition problems. It is open-access and can be downloaded
-through github. It is also fully supported for use on the
-Amazon Web Services cloud.
-</p>
+<p>GEOS-Chem enables simulations of atmospheric composition on local
+  to global scales. It can be used off-line as a 3-D chemical
+  transport model driven by assimilated meteorological observations
+  from the Goddard Earth Observing System (GEOS) of the
+  NASA <a href="http://gmao.gsfc.nasa.gov/" target="_blank">Global
+  Modeling Assimilation Office (GMAO)</a>. It can also be used on-line
+  as a chemical module coupled to weather and climate
+  models. GEOS-Chem is developed and used
+  by <a href="users.html">hundreds of research groups worldwide </a>as
+  a versatile tool for application to a wide range of atmospheric
+  composition problems. It is open-access and can be downloaded
+  through github. It is also fully supported for use on the Amazon Web
+  Services cloud.</p>
 
-<p align="justify">
-The off-line version of GEOS-Chem allows immediate simulations
-of atmospheric composition for any period from 1979 to present
-using the continuous global archive of NASA GEOS data packaged
-with GEOS-Chem. The operational GEOS-Forward Processing
-product (<a href="https://wiki.seas.harvard.edu/geos-chem/index.php/GEOS-FP"
-target="_blank">GEOS-FP</a>) for 2012-present has a horizontal
-resolution of 0.25° latitude x 0.3125° longitude with 72
-vertical levels. The
-<a href="https://wiki.seas.harvard.edu/geos-chem/index.php/MERRA-2"
-target="_blank">MERRA-2</a> reanalysis product for
-1979-present has a horizontal resolution of 0.5° latitude x
-0.625° longitude, again with 72 vertical levels. Off-line
-simulations can be conducted with OpenMP shared-memory
-parallelization (GEOS-Chem Classic, called GC-Classic) or with
-MPI distributed-memory parallelization
-(<a href="https://gchp.readthedocs.io" target="_blank">GEOS-Chem
+<p>The off-line version of GEOS-Chem allows immediate simulations of
+  atmospheric composition for any period from 1979 to present using
+  the continuous global archive of NASA GEOS data packaged with
+  GEOS-Chem. The operational GEOS-Forward Processing product
+  (<a href="https://wiki.seas.harvard.edu/geos-chem/index.php/GEOS-FP"
+  target="_blank">GEOS-FP</a>) for 2012-present has a horizontal
+  resolution of 0.25° latitude x 0.3125° longitude with 72 vertical
+  levels. The
+  <a href="https://wiki.seas.harvard.edu/geos-chem/index.php/MERRA-2"
+target="_blank">MERRA-2</a> reanalysis product for 1979-present has a
+  horizontal resolution of 0.5° latitude x 0.625° longitude, again
+  with 72 vertical levels. Off-line simulations can be conducted with
+  OpenMP shared-memory parallelization (GEOS-Chem Classic, called
+  GC-Classic) or with MPI distributed-memory parallelization
+  (<a href="https://gchp.readthedocs.io" target="_blank">GEOS-Chem
 high-performance, called GCHP</a>). GC-Classic operates on a
-rectilinear grid and GCHP operates on a cubed-sphere grid. GEOS-Chem
-simulations can be conducted globally at the native grid resolution or
-at user-selected lower resolution. They can also be conducted
-over user-selected regions with dynamic boundary conditions
-(nested mode) or in stretched-grid mode with zoom over a
-region of interest.
+  rectilinear grid and GCHP operates on a cubed-sphere grid. GEOS-Chem
+  simulations can be conducted globally at the native grid resolution
+  or at user-selected lower resolution. They can also be conducted
+  over user-selected regions with dynamic boundary conditions (nested
+  mode) or in stretched-grid mode with zoom over a region of interest.
 </p>
 
-<p>
-On-line applications of GEOS-Chem use the stand-alone
-GEOS-Chem chemical module that performs chemistry, aerosol
-microphysics, radiation, emissions, and deposition on 1-D
-atmospheric columns for any grid specified at run time. In
-on-line applications, chemical transport is performed by a
-weather or climate model coupled to GEOS-Chem. The emission
-component of GEOS-Chem
-(<a href="https://hemco.readthedocs.io" target="_blank">HEMCO</a>)
-can also be used independently of the rest of GEOS-Chem or as a
-generalized data broker in the weather/climate model. GEOS-Chem has in
-this manner been coupled with the NASA GEOS Earth System Model (ESM),
-the WRF weather model, the Beijing Climate Center ESM, and the NCAR
-CESM.
+<p>On-line applications of GEOS-Chem use the stand-alone GEOS-Chem
+  chemical module that performs chemistry, aerosol microphysics,
+  radiation, emissions, and deposition on 1-D atmospheric columns for
+  any grid specified at run time. In on-line applications, chemical
+  transport is performed by a weather or climate model coupled to
+  GEOS-Chem. The emission component of GEOS-Chem
+  (<a href="https://hemco.readthedocs.io" target="_blank">HEMCO</a>)
+  can also be used independently of the rest of GEOS-Chem or as a
+  generalized data broker in the weather/climate model. GEOS-Chem has
+  in this manner been coupled with the NASA GEOS Earth System Model
+  (ESM), the WRF weather model, the Beijing Climate Center ESM, and
+  the NCAR CESM.
 </p>
 
-<p align="justify">
-All
-<a href="https://wiki.seas.harvard.edu/geos-chem/index.php/GEOS-Chem_versions"
-target="_blank">versions of the GEOS-Chem
-model </a>use the same standard code maintained by
-the <a href="support-team.html" target="_blank">GEOS-Chem
-Support Team</a>. Updated versions of this standard code are
-released regularly. Detailed GEOS-Chem on-line documentation
-is available including
-a <a href="https://geos-chem.readthedocs.io/en/stable/geos-chem-shared-docs/supplemental-guides/related-docs.html"
-target="_blank">User's Guide</a>. The code is fully modular
-and highly parallelized. It is presently being used on several types
-of
+<p>All
+  <a href="https://wiki.seas.harvard.edu/geos-chem/index.php/GEOS-Chem_versions"
+     target="_blank">versions of the GEOS-Chem model</a>
+  use the same  standard code maintained by the
+  <a href="support-team.html" target="_blank">GEOS-Chem Support Team</a>.
+  Updated versions of this standard code are released
+  regularly. Detailed GEOS-Chem on-line documentation is available
+  including
+  a <a href="https://geos-chem.readthedocs.io/en/stable/geos-chem-shared-docs/supplemental-guides/related-docs.html"
+  target="_blank">User's Guide</a>. The code is fully modular and
+  highly parallelized. It is presently being used on several types of
 <a href="https://geos-chem.readthedocs.io/en/latest/getting-started/system-req-hard.html"
-target="_blank">Linux-like computing platforms</a> running Ubuntu,
-Fedora, Red Hat, Rocky Linux, Alma Linux, Amazon Linux, MacOS, and
-similar operating systems. It supports Intel Fortran and the
-open-source GNU Fortran compilers.
+   target="_blank">Linux-like computing platforms</a> running Ubuntu,
+   Fedora, Red Hat, Rocky Linux, Alma Linux, Amazon Linux, MacOS, and
+   similar operating systems. It supports Intel Fortran and the
+   open-source GNU Fortran compilers.
 </p>
 
-<p align="justify">
-An adjoint of the GEOS-Chem model is maintained by the
-GEOS-Chem community under the direction
-of <a href="http://spot.colorado.edu/~henzed"
-target="_blank">Adjoint Model Scientist Daven Henze</a> for
-inverse modeling, data assimilation, and sensitivity studies. See the
-<a href="https://wiki.seas.harvard.edu/geos-chem/index.php/GEOS-Chem_Adjoint"
-target="_blank">GEOS-Chem Adjoint web site</a> for more details.
+<p>An adjoint of the GEOS-Chem model is maintained by the GEOS-Chem
+  community under the direction of <a href="http://spot.colorado.edu/~henzed"
+target="_blank">Adjoint Model Scientist Daven Henze</a> for inverse
+  modeling, data assimilation, and sensitivity studies. See
+  the <a href="https://wiki.seas.harvard.edu/geos-chem/index.php/GEOS-Chem_Adjoint"
+  target="_blank">GEOS-Chem Adjoint web site</a> for more details.
 </p>
 
-<p align="justify">
-Several
-<a href="https://wiki.seas.harvard.edu/geos-chem/index.php/Software_maintained_by_GEOS-Chem_community_members"
-target="blank">software tools</a>
-facilitate the processing of GEOS-Chem model outputs. This
-includes <a href="https://gcpy.readthedocs.io"
+<p>Several
+   <a href="https://wiki.seas.harvard.edu/geos-chem/index.php/Software_maintained_by_GEOS-Chem_community_members"
+   target="blank">software tools</a> facilitate the processing of
+   GEOS-Chem model outputs. This includes <a href="https://gcpy.readthedocs.io"
 target="_blank">GCPy</a>, a package of free and open-source Python
-tools specifically designed for GEOS-Chem output analysis and
-visualization.
+   tools specifically designed for GEOS-Chem output analysis and
+   visualization.
 </p>
 
-<p align="justify">
-
-GEOS-Chem is a freely accessible community model. It is owned
-and supported by its <a href="users.html">user
-community</a> under the purview
-of <a href="working-groups.html">Working Groups</a>
-and an international <a href="steering-committee.html">Steering Committee</a>. User participation,
-responsibility, and feedback are essential. See
-our <a href="welcome.html">welcome page for new
-users</a>. The model is maintained as a robust
-state-of-the-science facility by combining a nimble
-grass-roots approach to code development with strong version
-control. All development is done by users in support of their
-own research needs and then shared with the community. General
-management of GEOS-Chem is supported by the US NASA Earth
-Science Division, the Canadian National Science and
-Engineering Research Council, and the Nanjing University of
-Information Sciences and Technology.
+<p>GEOS-Chem is a freely accessible community model. It is owned and
+  supported by its <a href="users.html">user community</a> under the
+  purview of <a href="working-groups.html">Working Groups</a>
+  and an international
+  <a href="steering-committee.html">Steering Committee</a>. User
+  participation, responsibility, and feedback are essential. See
+  our <a href="welcome.html">welcome page for new users</a>. The model
+  is maintained as a robust state-of-the-science facility by combining
+  a nimble grass-roots approach to code development with strong
+  version control. All development is done by users in support of
+  their own research needs and then shared with the community. General
+  management of GEOS-Chem is supported by the US NASA Earth Science
+  Division, the Canadian National Science and Engineering Research
+  Council, and the Nanjing University of Information Sciences and
+  Technology.
 </p>
 
 </div>
@@ -217,9 +201,6 @@ Information Sciences and Technology.
 </div>
 </div>
 
-<!--footer region beg-->
-<footer id="footer" class="clearfix" role="contentinfo">
-
 <!--footer-->
 <footer id="footer" class="clearfix" role="contentinfo">
 <div class="boxes-box-content">
@@ -229,8 +210,7 @@ Information Sciences and Technology.
 </div>
 </footer>
 
-<!--page area ends-->
-<div id="extradiv"></div>
+</div>
 </div>
 
 </body>

--- a/overview.html
+++ b/overview.html
@@ -1,9 +1,4 @@
 <!DOCTYPE html>
-<!--[if IEMobile 7]><html class="iem7"  lang="en" dir="ltr"><![endif]-->
-<!--[if lte IE 6]><html class="lt-ie9 lt-ie8 lt-ie7"  lang="en" dir="ltr"><![endif]-->
-<!--[if (IE 7)&(!IEMobile)]><html class="lt-ie9 lt-ie8"  lang="en" dir="ltr"><![endif]-->
-<!--[if IE 8]><html class="lt-ie9"  lang="en" dir="ltr"><![endif]-->
-<!--[if (gte IE 9)|(gt IEMobile 7)]><!--><html  lang="en" dir="ltr"><!--<![endif]-->
 <head>
 <meta charset="utf-8" />
 <!--<base href="/overview" />-->
@@ -19,23 +14,12 @@
 <title>GEOS-Chem Overview</title>
 <meta http-equiv="x-ua-compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<link type="text/css" rel="stylesheet" href="css/css_xE-rWrJf-fncB6ztZfd2huxqgxu4WO-qwma6Xer30m4%EF%B9%96m=1675397288.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_1kR8T1_c-l5pBT6ZwbDT7BFda-4fyqW9Jjum29_2IY8%EF%B9%96m=1675397312.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_YnlUIvHP13qgpYEqubzE8JyDwlSxUnVibfnVkSoSDb0%EF%B9%96m=1675397273.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_Ku-3OcT9qU9h7dnGig5e23q6EVryY8orK4wzVDxsweE%EF%B9%96m=1675397367.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_vprtFTrWyg23GbY50_zJZHWGYMNfS8vsrRS26i4-ISk%EF%B9%96m=1675397406.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_dW-aNNrctRhQNc-KECjtQd0PxuW-h19IEum-TX2MeEk%EF%B9%96m=1675397301.css" media="print" />
-<link type="text/css" rel="stylesheet" href="css/css_SH2Lx3Qprh0GZo_9xRp85U9NsWfkSXn_Bi-rJoMY1sw%EF%B9%96m=1675397273.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_uaIDKcYMUK5osSQXuirpr3ZleXtnnpBN-eiECm7N0M0%EF%B9%96m=1675397395.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/responsive.blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/geos-chem.css" media="all"/>
 <script type="text/javascript" src="dropdown-menu.js"></script>
-<!--[if lte IE 8]>
-<script type="text/javascript">
-  var os_c = document.createElement;os_c('header');os_c('nav');os_c('section');os_c('article');os_c('aside');os_c('footer');os_c('hgroup');os_c('figure');
-</script>
-<![endif]-->
 </head>
 
 <div id="page" class="container page header-main content-top footer-none">
@@ -236,42 +220,14 @@ Information Sciences and Technology.
 <!--footer region beg-->
 <footer id="footer" class="clearfix" role="contentinfo">
 
-<!-- Three column 3x33 Gpanel -->
-<div class="at-panel gpanel panel-display footer clearfix">
-<div class="region region-footer-bottom">
-<div class="region-inner clearfix">
-<div id="block-boxes-1616879798" class="block block-boxes block-boxes-os_boxes_media no-title"  module="boxes" delta="1616879798">
-<div class="block-inner clearfix">
-<div class="block-content content">
-<div id='boxes-box-1616879798' class='boxes-box'>
+<!--footer-->
+<footer id="footer" class="clearfix" role="contentinfo">
 <div class="boxes-box-content">
-<div id="file-3900146" class="file file-html file-html-embed">
-<h2 class="element-invisible"><a href="">css-brand</a></h2>
-<div class="content">
-<div class="file-info">
+  <p style="text-align:center">
+    Copyright © 2026 by the International GEOS-Chem Community. All rights reserved.
+  </p>
 </div>
-<div class="field field-name-field-html-code field-type-text-long field-label-hidden view-mode-full">
-<div class="field-items">
-<div class="field-item even">
-
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-
-<!--footer region end-->
 </footer>
-</div>
-</div>
 
 <!--page area ends-->
 <div id="extradiv"></div>

--- a/presentations.html
+++ b/presentations.html
@@ -1,9 +1,4 @@
 <!DOCTYPE html>
-<!--[if IEMobile 7]><html class="iem7"  lang="en" dir="ltr"><![endif]-->
-<!--[if lte IE 6]><html class="lt-ie9 lt-ie8 lt-ie7"  lang="en" dir="ltr"><![endif]-->
-<!--[if (IE 7)&(!IEMobile)]><html class="lt-ie9 lt-ie8"  lang="en" dir="ltr"><![endif]-->
-<!--[if IE 8]><html class="lt-ie9"  lang="en" dir="ltr"><![endif]-->
-<!--[if (gte IE 9)|(gt IEMobile 7)]><!--><html  lang="en" dir="ltr"><!--<![endif]-->
 <head>
 <meta charset="utf-8" />
 <!--<base href="/presentations" />-->
@@ -18,23 +13,12 @@
 <title>Presentations on recent GEOS-Chem developments</title>
 <meta http-equiv="x-ua-compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<link type="text/css" rel="stylesheet" href="css/css_xE-rWrJf-fncB6ztZfd2huxqgxu4WO-qwma6Xer30m4%EF%B9%96m=1675397288.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_1kR8T1_c-l5pBT6ZwbDT7BFda-4fyqW9Jjum29_2IY8%EF%B9%96m=1675397312.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_YnlUIvHP13qgpYEqubzE8JyDwlSxUnVibfnVkSoSDb0%EF%B9%96m=1675397273.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_Ku-3OcT9qU9h7dnGig5e23q6EVryY8orK4wzVDxsweE%EF%B9%96m=1675397367.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_vprtFTrWyg23GbY50_zJZHWGYMNfS8vsrRS26i4-ISk%EF%B9%96m=1675397406.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_dW-aNNrctRhQNc-KECjtQd0PxuW-h19IEum-TX2MeEk%EF%B9%96m=1675397301.css" media="print" />
-<link type="text/css" rel="stylesheet" href="css/css_SH2Lx3Qprh0GZo_9xRp85U9NsWfkSXn_Bi-rJoMY1sw%EF%B9%96m=1675397273.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_uaIDKcYMUK5osSQXuirpr3ZleXtnnpBN-eiECm7N0M0%EF%B9%96m=1675397395.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/responsive.blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/geos-chem.css" media="all"/>
 <script type="text/javascript" src="dropdown-menu.js"></script>
-<!--[if lte IE 8]>
-<script type="text/javascript">
-  var os_c = document.createElement;os_c('header');os_c('nav');os_c('section');os_c('article');os_c('aside');os_c('footer');os_c('hgroup');os_c('figure');
-</script>
-<![endif]-->
 </head>
 
 <body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-1585687 node-type-page og-context og-context-node og-context-node-1585652 navbar-on">
@@ -45,7 +29,7 @@
 <div id="page_wrap" class="page_wrap">
 <div id="page" class="container page header-main content-top footer-none">
 <div id="page-wrapper">
-		
+    
 <!--header regions beg-->
 <header id="header" class="clearfix" role="banner">
 <div id="header-container">
@@ -76,7 +60,7 @@
 <script>inlineDropDownMenu();</script>
 </nav>
 </div>
-<!--main menu region end-->	
+<!--main menu region end-->  
 
 <div id="columns" class="clearfix">
 <div class="hg-container">
@@ -146,48 +130,16 @@
 </div>
 </div>
 
-<!--footer region beg-->
+<!--footer-->
 <footer id="footer" class="clearfix" role="contentinfo">
-
-<!-- Three column 3x33 Gpanel -->
-<div class="at-panel gpanel panel-display footer clearfix">
-<div class="region region-footer-bottom">
-<div class="region-inner clearfix">
-<div id="block-boxes-1616879798" class="block block-boxes block-boxes-os_boxes_media no-title"  module="boxes" delta="1616879798">
-<div class="block-inner clearfix">
-<div class="block-content content">
-<div id='boxes-box-1616879798' class='boxes-box'>
 <div class="boxes-box-content">
-<div id="file-3900146" class="file file-html file-html-embed">
-<h2 class="element-invisible"><a href="">css-brand</a></h2>
-<div class="content">
-<div class="file-info">
+  <p style="text-align:center">
+    Copyright © 2026 by the International GEOS-Chem Community. All rights reserved.
+  </p>
 </div>
-<div class="field field-name-field-html-code field-type-text-long field-label-hidden view-mode-full">
-<div class="field-items">
-<div class="field-item even">
-
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-
-<!--footer region end-->
 </footer>
-</div>
-</div>
 
-<!--page area ends-->
-<div id="extradiv"></div>
+</div>
 </div>
 
 </body>

--- a/stats.html
+++ b/stats.html
@@ -1,9 +1,4 @@
 <!DOCTYPE html>
-<!--[if IEMobile 7]><html class="iem7"  lang="en" dir="ltr"><![endif]-->
-<!--[if lte IE 6]><html class="lt-ie9 lt-ie8 lt-ie7"  lang="en" dir="ltr"><![endif]-->
-<!--[if (IE 7)&(!IEMobile)]><html class="lt-ie9 lt-ie8"  lang="en" dir="ltr"><![endif]-->
-<!--[if IE 8]><html class="lt-ie9"  lang="en" dir="ltr"><![endif]-->
-<!--[if (gte IE 9)|(gt IEMobile 7)]><!--><html  lang="en" dir="ltr"><!--<![endif]-->
 <head>
 <meta charset="utf-8" />
 <!--<base href="/welcome" />-->
@@ -18,23 +13,12 @@
 <title>GEOS-Chem by the Numbers</title>
 <meta http-equiv="x-ua-compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<link type="text/css" rel="stylesheet" href="css/css_xE-rWrJf-fncB6ztZfd2huxqgxu4WO-qwma6Xer30m4%EF%B9%96m=1675397288.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_1kR8T1_c-l5pBT6ZwbDT7BFda-4fyqW9Jjum29_2IY8%EF%B9%96m=1675397312.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_YnlUIvHP13qgpYEqubzE8JyDwlSxUnVibfnVkSoSDb0%EF%B9%96m=1675397273.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_Ku-3OcT9qU9h7dnGig5e23q6EVryY8orK4wzVDxsweE%EF%B9%96m=1675397367.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_vprtFTrWyg23GbY50_zJZHWGYMNfS8vsrRS26i4-ISk%EF%B9%96m=1675397406.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_dW-aNNrctRhQNc-KECjtQd0PxuW-h19IEum-TX2MeEk%EF%B9%96m=1675397301.css" media="print" />
-<link type="text/css" rel="stylesheet" href="css/css_SH2Lx3Qprh0GZo_9xRp85U9NsWfkSXn_Bi-rJoMY1sw%EF%B9%96m=1675397273.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_uaIDKcYMUK5osSQXuirpr3ZleXtnnpBN-eiECm7N0M0%EF%B9%96m=1675397395.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/responsive.blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/geos-chem.css" media="all"/>
 <script type="text/javascript" src="dropdown-menu.js"></script>
-<!--[if lte IE 8]>
-<script type="text/javascript">
-  var os_c = document.createElement;os_c('header');os_c('nav');os_c('section');os_c('article');os_c('aside');os_c('footer');os_c('hgroup');os_c('figure');
-</script>
-<![endif]-->
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
@@ -94,14 +78,14 @@ body {
 <div id="page_wrap" class="page_wrap">
 <div id="page" class="container page header-main content-top footer-none">
 <div id="page-wrapper">
-		
+
 <!--header regions beg-->
 <header id="header" class="clearfix" role="banner">
 <div id="header-container">
 <div id="header-panels" class="at-panel gpanel panel-display three-col clearfix">
 <div class="region region-header-second"><div class="region-inner clearfix">
 <section id="block-boxes-1630413211" class="block block-boxes block-boxes-os_boxes_html"  module="boxes" delta="1630413211">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <h2 class="block-title" ng-non-bindable="">Site-Logo</h2>
 <div class="block-content content" ng-non-bindable="">
 <div id='boxes-box-1630413211' class='boxes-box'>
@@ -125,7 +109,7 @@ body {
 <script>inlineDropDownMenu();</script>
 </nav>
 </div>
-<!--main menu region end-->	
+<!--main menu region end-->
 
 <div id="columns" class="clearfix">
 <div class="hg-container">
@@ -142,7 +126,7 @@ body {
 <div class="region region-content-top">
 <div class="region-inner clearfix">
 <div id="block-os-pages-main-content" class="block block-os-pages no-title"  module="os_pages" delta="main_content">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <div class="block-content content" ng-non-bindable="">
 <article id="node-1585687" class="node node-page article clearfix" role="article">
 <div class="node-content" ng-non-bindable="">
@@ -180,11 +164,11 @@ body {
   </div>
 </div>
 </a>
-  
+
 <br>
 <p align="center">
   <img style="width: 100%;" alt="Line graph of GEOS-Chem users over time" src="img/gc_users_vs_time.png"/>
-</p>  
+</p>
 
 <h3><span style="font-size:40px;color:#377dbd;"><b>25+ years</b></span> of model development and support of observations</h3>
 
@@ -192,12 +176,12 @@ body {
 
 <p align="center">
   <img style="width: 70%;" alt="GEOS-Chem species over time" src="img/gc_species_vs_time.png"/>
-</p>  
+</p>
 
 <table>
 <tr>
   <td style="vertical-align:middle;"><h3><b>Fine resolution capabilities<b></h3></td>
-  <td><h3> 
+  <td><h3>
       > GEOS-Chem Classic simulations down to <span style="font-size:40px;color:#377dbd;"><b>12 km</b></span><br><br>
       > GCHP simulations on <span style="font-size:40px;color:#377dbd;"><b>220M</b></span> grid cells<br><br>
       > WRF-GC simulations down to <span style="font-size:40px;color:#377dbd;"><b>1 km</b></span></h3>
@@ -214,7 +198,7 @@ body {
 
 <p align="center">
   <a href="https://scholar.google.com/citations?user=ho-sNj4AAAAJ" target="#"><img style="width: 100%;" alt="GEOS-Chem citations per year" src="img/gc_citations.png"/></a>
-</p>  
+</p>
 
 <h3>Includes dedicated tools for data assimilation such as <a href="https://wiki.seas.harvard.edu/geos-chem/index.php/GEOS-Chem_Adjoint_Model" target="#">model adjoint</a>, <a href="https://carboninversion.com/" target="#">analytical inversion</a>, and <a href="https://cheereio.readthedocs.io/en/latest/" target="#">Kalman filters</a></h3>
 
@@ -238,48 +222,16 @@ body {
 </div>
 </div>
 
-<!--footer region beg-->
+<!--footer-->
 <footer id="footer" class="clearfix" role="contentinfo">
-
-<!-- Three column 3x33 Gpanel -->
-<div class="at-panel gpanel panel-display footer clearfix">
-<div class="region region-footer-bottom">
-<div class="region-inner clearfix">
-<div id="block-boxes-1616879798" class="block block-boxes block-boxes-os_boxes_media no-title"  module="boxes" delta="1616879798">
-<div class="block-inner clearfix">
-<div class="block-content content">
-<div id='boxes-box-1616879798' class='boxes-box'>
 <div class="boxes-box-content">
-<div id="file-3900146" class="file file-html file-html-embed">
-<h2 class="element-invisible"><a href="">css-brand</a></h2>
-<div class="content">
-<div class="file-info">
+  <p style="text-align:center">
+    Copyright © 2026 by the International GEOS-Chem Community. All rights reserved.
+  </p>
 </div>
-<div class="field field-name-field-html-code field-type-text-long field-label-hidden view-mode-full">
-<div class="field-items">
-<div class="field-item even">
-
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-
-<!--footer region end-->
 </footer>
-</div>
-</div>
 
-<!--page area ends-->
-<div id="extradiv"></div>
+</div>
 </div>
 
 </body>

--- a/steering-committee.html
+++ b/steering-committee.html
@@ -1,9 +1,4 @@
 <!DOCTYPE html>
-<!--[if IEMobile 7]><html class="iem7"  lang="en" dir="ltr"><![endif]-->
-<!--[if lte IE 6]><html class="lt-ie9 lt-ie8 lt-ie7"  lang="en" dir="ltr"><![endif]-->
-<!--[if (IE 7)&(!IEMobile)]><html class="lt-ie9 lt-ie8"  lang="en" dir="ltr"><![endif]-->
-<!--[if IE 8]><html class="lt-ie9"  lang="en" dir="ltr"><![endif]-->
-<!--[if (gte IE 9)|(gt IEMobile 7)]><!--><html  lang="en" dir="ltr"><!--<![endif]-->
 <head>
 <meta charset="utf-8" />
 <!--<base href="/steering-commitee" />-->
@@ -19,23 +14,12 @@
 <title>GEOS-Chem Steering Committee</title>
 <meta http-equiv="x-ua-compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<link type="text/css" rel="stylesheet" href="css/css_xE-rWrJf-fncB6ztZfd2huxqgxu4WO-qwma6Xer30m4%EF%B9%96m=1675397288.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_1kR8T1_c-l5pBT6ZwbDT7BFda-4fyqW9Jjum29_2IY8%EF%B9%96m=1675397312.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_YnlUIvHP13qgpYEqubzE8JyDwlSxUnVibfnVkSoSDb0%EF%B9%96m=1675397273.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_Ku-3OcT9qU9h7dnGig5e23q6EVryY8orK4wzVDxsweE%EF%B9%96m=1675397367.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_vprtFTrWyg23GbY50_zJZHWGYMNfS8vsrRS26i4-ISk%EF%B9%96m=1675397406.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_dW-aNNrctRhQNc-KECjtQd0PxuW-h19IEum-TX2MeEk%EF%B9%96m=1675397301.css" media="print" />
-<link type="text/css" rel="stylesheet" href="css/css_SH2Lx3Qprh0GZo_9xRp85U9NsWfkSXn_Bi-rJoMY1sw%EF%B9%96m=1675397273.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_uaIDKcYMUK5osSQXuirpr3ZleXtnnpBN-eiECm7N0M0%EF%B9%96m=1675397395.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/responsive.blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/geos-chem.css" media="all"/>
 <script type="text/javascript" src="dropdown-menu.js"></script>
-<!--[if lte IE 8]>
-<script type="text/javascript">
-  var os_c = document.createElement;os_c('header');os_c('nav');os_c('section');os_c('article');os_c('aside');os_c('footer');os_c('hgroup');os_c('figure');
-</script>
-<![endif]-->
 </head>
 
 <body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-1585687 node-type-page og-context og-context-node og-context-node-1585652 navbar-on">
@@ -655,10 +639,10 @@ The <em><a href="https://drive.google.com/file/d/1SJSCa64wxvolTDMLDnhc6WlpJy_Ejs
     </td>
     <td align="center">
       <p>
-	<a href="https://drive.google.com/file/d/1xQIMHsj66aR2LuYJoRCh5h6jxqirtGSk/view?usp=share_link">Aerosols Working Group update</a><br />
-	<a href="https://drive.google.com/file/d/12shGl5iNOw2Vlr8Tg6OLjR8db2gqPsMr/view?usp=share_link">Stratospheric Working Group update</a><br />
-	<a href="https://drive.google.com/file/d/1W-NmloyJY0Qk38fVd2yv5OoncDHVvMPA/view?usp=share_link">Hg and POPs Working Group update</a><br />
-	<a href="https://drive.google.com/file/d/1AHy0UUo6HLzTRqYdc6nxJjgJzEoY_qGK/view?usp=share_link">GEOS-Chem Newsletter 2023, Issue 1</a>
+  <a href="https://drive.google.com/file/d/1xQIMHsj66aR2LuYJoRCh5h6jxqirtGSk/view?usp=share_link">Aerosols Working Group update</a><br />
+  <a href="https://drive.google.com/file/d/12shGl5iNOw2Vlr8Tg6OLjR8db2gqPsMr/view?usp=share_link">Stratospheric Working Group update</a><br />
+  <a href="https://drive.google.com/file/d/1W-NmloyJY0Qk38fVd2yv5OoncDHVvMPA/view?usp=share_link">Hg and POPs Working Group update</a><br />
+  <a href="https://drive.google.com/file/d/1AHy0UUo6HLzTRqYdc6nxJjgJzEoY_qGK/view?usp=share_link">GEOS-Chem Newsletter 2023, Issue 1</a>
       </p>
     </td>
   </tr>
@@ -671,8 +655,8 @@ The <em><a href="https://drive.google.com/file/d/1SJSCa64wxvolTDMLDnhc6WlpJy_Ejs
     </td>
     <td align="center">
       <p>
-	<a href="https://drive.google.com/file/d/1VJU9M96PqASlMboCPSxJdlKkD3LfhCXS/view?usp=share_link">Surface-Atmosphere Exchange Working Group update</a><br />
-	<a href="https://drive.google.com/file/d/1KimPfvT7hp0sW06VyHHSANrxVbor8ybf/view?usp=share_link">GEOS-Chem Newsletter 2022, Issue 2</a>
+  <a href="https://drive.google.com/file/d/1VJU9M96PqASlMboCPSxJdlKkD3LfhCXS/view?usp=share_link">Surface-Atmosphere Exchange Working Group update</a><br />
+  <a href="https://drive.google.com/file/d/1KimPfvT7hp0sW06VyHHSANrxVbor8ybf/view?usp=share_link">GEOS-Chem Newsletter 2022, Issue 2</a>
       </p>
     </td>
   </tr>
@@ -696,12 +680,12 @@ The <em><a href="https://drive.google.com/file/d/1SJSCa64wxvolTDMLDnhc6WlpJy_Ejs
     </td>
     <td align="center">
       <p>
-	<a href="https://drive.google.com/file/d/1DxIC4X370rj1cz5FpKStvPN2BGkketDs/view?usp=share_link">Chemistry WG updates</a><br />
-	<a href="https://drive.google.com/file/d/1X-oH77yxx_MhYnn7iTS5b2JLp_KiiNgl/view?usp=share_link">Transport WG updates</a><br />
-	<a href="https://drive.google.com/file/d/1Jc2geRFEiZXcQRzsc3m8HyOICnQG4X8U/view?usp=share_link">GCHP WG updates</a><br />
-	<a href="https://drive.google.com/file/d/1BALC8yx6z61DgY2bZS4NWHzoQRlbDTya/view?usp=share_link">GCHP mass fluxes update</a><br />
-	<a href="https://drive.google.com/file/d/16TwpHIQ6i7pW9M-yYh8j-xT8OCtzGsDz/view?usp=share_link">Bashdatacatalog and cloud updates</a><br />
-	<a href="https://drive.google.com/file/d/1Ty3Vwi4nBveCR8uGddXMFAbd7_xHWCBH/view?usp=share_link">GEOS-Chem Newsletter 2022  Issue 1</a>
+  <a href="https://drive.google.com/file/d/1DxIC4X370rj1cz5FpKStvPN2BGkketDs/view?usp=share_link">Chemistry WG updates</a><br />
+  <a href="https://drive.google.com/file/d/1X-oH77yxx_MhYnn7iTS5b2JLp_KiiNgl/view?usp=share_link">Transport WG updates</a><br />
+  <a href="https://drive.google.com/file/d/1Jc2geRFEiZXcQRzsc3m8HyOICnQG4X8U/view?usp=share_link">GCHP WG updates</a><br />
+  <a href="https://drive.google.com/file/d/1BALC8yx6z61DgY2bZS4NWHzoQRlbDTya/view?usp=share_link">GCHP mass fluxes update</a><br />
+  <a href="https://drive.google.com/file/d/16TwpHIQ6i7pW9M-yYh8j-xT8OCtzGsDz/view?usp=share_link">Bashdatacatalog and cloud updates</a><br />
+  <a href="https://drive.google.com/file/d/1Ty3Vwi4nBveCR8uGddXMFAbd7_xHWCBH/view?usp=share_link">GEOS-Chem Newsletter 2022  Issue 1</a>
       </p>
     </td>
   </tr>
@@ -714,11 +698,11 @@ The <em><a href="https://drive.google.com/file/d/1SJSCa64wxvolTDMLDnhc6WlpJy_Ejs
     </td>
     <td align="center">
       <p>
-	<a href="https://drive.google.com/file/d/1QxwqufTQ2jcZLT3FkHwhhygIq5Na-cwS/view?usp=share_link">Data Assimilation and Adjoint WG updates</a><br />
-	<a href="https://drive.google.com/file/d/1sCW9OKkNYfp0zyzDhTuWFOjpHJFmmLBD/view?usp=share_link">Emission and Deposition Update</a><br />
-	<a href="https://drive.google.com/file/d/1sYyU0HD5ZG60pkice57PdjPjaKD7t7Nm/view?usp=share_link">Direct Reading of GMAO Meteorological Data</a><br />
-	<a href="https://drive.google.com/file/d/1d8kpSTj3D7t8VLPC4FPaziorQuIZwWQo/view?usp=share_link">Tools for the cloud updates</a><br />
-	<a href="https://drive.google.com/file/d/1Xg7n1o6hhyqL4yBNoko7X6viUITq_16H/view?usp=share_link" title="GEOS-Chem Winter 2021 Newsletter">GEOS-Chem Newsletter, Winter 2021 Edition</a>
+  <a href="https://drive.google.com/file/d/1QxwqufTQ2jcZLT3FkHwhhygIq5Na-cwS/view?usp=share_link">Data Assimilation and Adjoint WG updates</a><br />
+  <a href="https://drive.google.com/file/d/1sCW9OKkNYfp0zyzDhTuWFOjpHJFmmLBD/view?usp=share_link">Emission and Deposition Update</a><br />
+  <a href="https://drive.google.com/file/d/1sYyU0HD5ZG60pkice57PdjPjaKD7t7Nm/view?usp=share_link">Direct Reading of GMAO Meteorological Data</a><br />
+  <a href="https://drive.google.com/file/d/1d8kpSTj3D7t8VLPC4FPaziorQuIZwWQo/view?usp=share_link">Tools for the cloud updates</a><br />
+  <a href="https://drive.google.com/file/d/1Xg7n1o6hhyqL4yBNoko7X6viUITq_16H/view?usp=share_link" title="GEOS-Chem Winter 2021 Newsletter">GEOS-Chem Newsletter, Winter 2021 Edition</a>
       </p>
     </td>
   </tr>
@@ -731,9 +715,9 @@ The <em><a href="https://drive.google.com/file/d/1SJSCa64wxvolTDMLDnhc6WlpJy_Ejs
     </td>
     <td align="center">
       <p>
-	<a href="https://drive.google.com/file/d/19h3U_7M6y6LTWyK_i2xTMhrmH2qZBsWH/view?usp=share_link">Hg and POPs WG updates</a><br />
-	<a href="https://drive.google.com/file/d/1oUthZIWirzQVfN6-4lsGEcnkS3U_7u2F/view?usp=share_link">Chemistry-Ecosystems-Climate WG updates</a><br />
-	<a href="https://drive.google.com/file/d/1nxus5RmQxIwBQ3lBbocMDyvWJsMA9mv5/view?usp=share_link" target="_blank" title="GEOS-Chem Newsletter, Fall 2021 Edition">GEOS-Chem Newsletter, Fall 2021 Edition</a>
+  <a href="https://drive.google.com/file/d/19h3U_7M6y6LTWyK_i2xTMhrmH2qZBsWH/view?usp=share_link">Hg and POPs WG updates</a><br />
+  <a href="https://drive.google.com/file/d/1oUthZIWirzQVfN6-4lsGEcnkS3U_7u2F/view?usp=share_link">Chemistry-Ecosystems-Climate WG updates</a><br />
+  <a href="https://drive.google.com/file/d/1nxus5RmQxIwBQ3lBbocMDyvWJsMA9mv5/view?usp=share_link" target="_blank" title="GEOS-Chem Newsletter, Fall 2021 Edition">GEOS-Chem Newsletter, Fall 2021 Edition</a>
       </p>
     </td>
   </tr>
@@ -746,10 +730,10 @@ The <em><a href="https://drive.google.com/file/d/1SJSCa64wxvolTDMLDnhc6WlpJy_Ejs
     </td>
     <td align="center">
       <p>
-	<a href="https://drive.google.com/file/d/15nvI-j5c_PuBoO9cB9aOL3IKiZKni-bD/view?usp=share_link">Aerosols WG updates</a><br />
-	<a href="https://drive.google.com/file/d/1Z0cbbP9z_D32GdWm48jRsSfJHxz23WqE/view?usp=share_link">Software Engineering WG Updates</a><br />
-	<a href="https://drive.google.com/file/d/1jG8VWIZHYKJe-9-NwgPut1e6Gq76iahs/view?usp=share_link">Carbon WG updates</a><br />
-	<a href="https://drive.google.com/file/d/1b5HmvtX_t_LMtWQ47MQLbJYDrtFBHURv/view?usp=share_link" target="_blank" title="GEOS-Chem Newsletter, Spring 2021 Edition">GEOS-Chem Newsletter, Spring 2021 Edition</a>
+  <a href="https://drive.google.com/file/d/15nvI-j5c_PuBoO9cB9aOL3IKiZKni-bD/view?usp=share_link">Aerosols WG updates</a><br />
+  <a href="https://drive.google.com/file/d/1Z0cbbP9z_D32GdWm48jRsSfJHxz23WqE/view?usp=share_link">Software Engineering WG Updates</a><br />
+  <a href="https://drive.google.com/file/d/1jG8VWIZHYKJe-9-NwgPut1e6Gq76iahs/view?usp=share_link">Carbon WG updates</a><br />
+  <a href="https://drive.google.com/file/d/1b5HmvtX_t_LMtWQ47MQLbJYDrtFBHURv/view?usp=share_link" target="_blank" title="GEOS-Chem Newsletter, Spring 2021 Edition">GEOS-Chem Newsletter, Spring 2021 Edition</a>
       </p>
     </td>
   </tr>
@@ -762,8 +746,8 @@ The <em><a href="https://drive.google.com/file/d/1SJSCa64wxvolTDMLDnhc6WlpJy_Ejs
     </td>
     <td align="center">
     <a href="https://drive.google.com/file/d/1STho2XqsdNsrKiGEMqWMRsDrpH-XQm1Y/view?usp=share_link">Transport WG updates</a><br />
-	<a href="https://drive.google.com/file/d/14nZSEbc0_zWwF9HJIzTrslTom9DZq796/view?usp=share_link">Stratospheric WG updates</a><br />
-	<a href="https://drive.google.com/file/d/1Nwe8gNy4oiXXODNdoTko0HluSOYttjhL/view?usp=share_link">GCHP WG updates</a>
+  <a href="https://drive.google.com/file/d/14nZSEbc0_zWwF9HJIzTrslTom9DZq796/view?usp=share_link">Stratospheric WG updates</a><br />
+  <a href="https://drive.google.com/file/d/1Nwe8gNy4oiXXODNdoTko0HluSOYttjhL/view?usp=share_link">GCHP WG updates</a>
     </td>
   </tr>
   <tr>
@@ -943,7 +927,7 @@ The <em><a href="https://drive.google.com/file/d/1SJSCa64wxvolTDMLDnhc6WlpJy_Ejs
     </td>
     <td align="center">
       <a href="https://drive.google.com/file/d/1z6DjO0q4AxDYRX-FDvLxjTa-SI5n_35J/view?usp=share_link" target="_blank">GEOS-Chem Newsletter: Winter 2017 Edition + v11-01 Public Release</a><br />
-      <a href="https://drive.google.com/file/d/1f9iKy07A-TqAxzJaqLuEO7F-C6mdDhSH/view?usp=share_link" target="_blank">Model Engineer's Report to the GCSC</a>
+      <a href="https://drive.google.com/file/d/1f9iKy07A-TqAxzJaqLuEO7F-C6mdDhSH/view?usp=share_link" target="_blank">Model Engineer&apos;s Report to the GCSC</a>
     </td>
   </tr>
   <tr>
@@ -954,7 +938,7 @@ The <em><a href="https://drive.google.com/file/d/1SJSCa64wxvolTDMLDnhc6WlpJy_Ejs
       <a href="https://drive.google.com/file/d/1GfZY_LJZFJVIXrObNzUyHCvVrjHXzpxc/view?usp=share_link" target="_blank">Minutes</a>
     </td>
     <td align="center">
-      <a href="https://drive.google.com/file/d/1g1As41T0vGbv2BvyA59FHZTANtdBYJeJ/view?usp=share_link target="_blank">GEOS-Chem Newsletter: Fall 2016 Edition</a>
+      <a href="https://drive.google.com/file/d/1g1As41T0vGbv2BvyA59FHZTANtdBYJeJ/view?usp=share_link" target="_blank">GEOS-Chem Newsletter: Fall 2016 Edition</a>
     </td>
   </tr>
   <tr>
@@ -1296,48 +1280,16 @@ The <em><a href="https://drive.google.com/file/d/1SJSCa64wxvolTDMLDnhc6WlpJy_Ejs
 </div>
 </div>
 
-<!--footer region beg-->
+<!--footer-->
 <footer id="footer" class="clearfix" role="contentinfo">
-
-<!-- Three column 3x33 Gpanel -->
-<div class="at-panel gpanel panel-display footer clearfix">
-<div class="region region-footer-bottom">
-<div class="region-inner clearfix">
-<div id="block-boxes-1616879798" class="block block-boxes block-boxes-os_boxes_media no-title"  module="boxes" delta="1616879798">
-<div class="block-inner clearfix">
-<div class="block-content content">
-<div id='boxes-box-1616879798' class='boxes-box'>
 <div class="boxes-box-content">
-<div id="file-3900146" class="file file-html file-html-embed">
-<h2 class="element-invisible"><a href="">css-brand</a></h2>
-<div class="content">
-<div class="file-info">
+  <p style="text-align:center">
+    Copyright © 2026 by the International GEOS-Chem Community. All rights reserved.
+  </p>
 </div>
-<div class="field field-name-field-html-code field-type-text-long field-label-hidden view-mode-full">
-<div class="field-items">
-<div class="field-item even">
-
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-
-<!--footer region end-->
 </footer>
-</div>
-</div>
 
-<!--page area ends-->
-<div id="extradiv"></div>
+</div>
 </div>
 
 </body>

--- a/support-team.html
+++ b/support-team.html
@@ -94,7 +94,7 @@
 <h2>GCST Members
 </h2>
 
-<table border="1" cellpadding="1" cellspacing="1" style="width:750px">
+<table border="1" cellpadding="1" cellspacing="1" style="width:800px">
   <thead>
     <tr>
       <th scope="col">
@@ -179,6 +179,20 @@
     </td>
     <td>
       WashU
+    </td>
+  </tr>
+  <tr>
+    <td>
+      Peter Ivatt
+    </td>
+    <td>
+      @peterivatt
+    </td>
+    <td>
+      Lead Computational Scientist
+    </td>
+    <td>
+      U. Rochester
     </td>
   </tr>
 </table>
@@ -288,12 +302,12 @@
 <h2>Software tools maintained by the GEOS-Chem User Community</h2>
 
 <p>
-  <a href="https://wiki.seas.harvard.edu/geos-chem/index.php/Software_maintained_by_GEOS-Chem_community_members" target="_new">Several
-  useful software packages</a> (e.g. Integrated Methane Inversion,
-  CHEEREIO, etc) are maintained by members of the GEOS-Chem User
-  Community.  The GEOS-Chem Support Team claims no responsibility for
-  the upkeep and support of these packages.  Please contact the listed
-  maintainer(s) directly.
+  <a href="community_tools.html">Several useful software packages</a>
+  (e.g. Integrated Methane Inversion, CHEEREIO, etc) are maintained by
+  members of the GEOS-Chem User Community. The GEOS-Chem Support Team
+  claims no responsibility for the upkeep and support of these
+  packages.  Please contact the listed maintainer(s) directly.
+</p>
 
 
 </div>
@@ -314,43 +328,15 @@
 </div>
 </div>
 
-<!--footer region beg-->
+<!--footer-->
 <footer id="footer" class="clearfix" role="contentinfo">
-
-<!-- Three column 3x33 Gpanel -->
-<div class="at-panel gpanel panel-display footer clearfix">
-<div class="region region-footer-bottom">
-<div class="region-inner clearfix">
-<div id="block-boxes-1616879798" class="block block-boxes block-boxes-os_boxes_media no-title"  module="boxes" delta="1616879798">
-<div class="block-inner clearfix">
-<div class="block-content content">
-<div id='boxes-box-1616879798' class='boxes-box'>
 <div class="boxes-box-content">
-<div id="file-3900146" class="file file-html file-html-embed">
-<h2 class="element-invisible"><a href="">css-brand</a></h2>
-<div class="content">
-<div class="file-info">
+  <p style="text-align:center">
+    Copyright © 2026 by the International GEOS-Chem Community. All rights reserved.
+  </p>
 </div>
-<div class="field field-name-field-html-code field-type-text-long field-label-hidden view-mode-full">
-<div class="field-items">
-<div class="field-item even">
-
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-
-<!--footer region end-->
 </footer>
+
 </div>
 </div>
 

--- a/users.html
+++ b/users.html
@@ -1,9 +1,4 @@
 <!DOCTYPE html>
-<!--[if IEMobile 7]><html class="iem7"  lang="en" dir="ltr"><![endif]-->
-<!--[if lte IE 6]><html class="lt-ie9 lt-ie8 lt-ie7"  lang="en" dir="ltr"><![endif]-->
-<!--[if (IE 7)&(!IEMobile)]><html class="lt-ie9 lt-ie8"  lang="en" dir="ltr"><![endif]-->
-<!--[if IE 8]><html class="lt-ie9"  lang="en" dir="ltr"><![endif]-->
-<!--[if (gte IE 9)|(gt IEMobile 7)]><!--><html  lang="en" dir="ltr"><!--<![endif]-->
 <head>
 <meta charset="utf-8" />
 <!--<base href="/users" />-->
@@ -20,14 +15,8 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<link type="text/css" rel="stylesheet" href="css/css_xE-rWrJf-fncB6ztZfd2huxqgxu4WO-qwma6Xer30m4%EF%B9%96m=1675397288.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_1kR8T1_c-l5pBT6ZwbDT7BFda-4fyqW9Jjum29_2IY8%EF%B9%96m=1675397312.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_YnlUIvHP13qgpYEqubzE8JyDwlSxUnVibfnVkSoSDb0%EF%B9%96m=1675397273.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_Ku-3OcT9qU9h7dnGig5e23q6EVryY8orK4wzVDxsweE%EF%B9%96m=1675397367.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_vprtFTrWyg23GbY50_zJZHWGYMNfS8vsrRS26i4-ISk%EF%B9%96m=1675397406.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_dW-aNNrctRhQNc-KECjtQd0PxuW-h19IEum-TX2MeEk%EF%B9%96m=1675397301.css" media="print" />
-<link type="text/css" rel="stylesheet" href="css/css_SH2Lx3Qprh0GZo_9xRp85U9NsWfkSXn_Bi-rJoMY1sw%EF%B9%96m=1675397273.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_uaIDKcYMUK5osSQXuirpr3ZleXtnnpBN-eiECm7N0M0%EF%B9%96m=1675397395.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/responsive.blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/geos-chem.css" media="all"/>
@@ -35,11 +24,6 @@
 <script type="text/javascript" src="dropdown-menu.js"></script>
 <script type="text/javascript" src="leaflet/leaflet.js"></script>
 <script type="text/javascript" src="leaflet/leaflet-color-markers.js"></script>
-<!--[if lte IE 8]>
-<script type="text/javascript">
-  var os_c = document.createElement;os_c('header');os_c('nav');os_c('section');os_c('article');os_c('aside');os_c('footer');os_c('hgroup');os_c('figure');
-</script>
-<![endif]-->
 </head>
 
 <body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-1585687 node-type-page og-context og-context-node og-context-node-1585652 navbar-on">

--- a/welcome.html
+++ b/welcome.html
@@ -1,9 +1,4 @@
 <!DOCTYPE html>
-<!--[if IEMobile 7]><html class="iem7"  lang="en" dir="ltr"><![endif]-->
-<!--[if lte IE 6]><html class="lt-ie9 lt-ie8 lt-ie7"  lang="en" dir="ltr"><![endif]-->
-<!--[if (IE 7)&(!IEMobile)]><html class="lt-ie9 lt-ie8"  lang="en" dir="ltr"><![endif]-->
-<!--[if IE 8]><html class="lt-ie9"  lang="en" dir="ltr"><![endif]-->
-<!--[if (gte IE 9)|(gt IEMobile 7)]><!--><html  lang="en" dir="ltr"><!--<![endif]-->
 <head>
 <meta charset="utf-8" />
 <!--<base href="/welcome" />-->
@@ -18,23 +13,12 @@
 <title>Welcome to GEOS-Chem</title>
 <meta http-equiv="x-ua-compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<link type="text/css" rel="stylesheet" href="css/css_xE-rWrJf-fncB6ztZfd2huxqgxu4WO-qwma6Xer30m4%EF%B9%96m=1675397288.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_1kR8T1_c-l5pBT6ZwbDT7BFda-4fyqW9Jjum29_2IY8%EF%B9%96m=1675397312.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_YnlUIvHP13qgpYEqubzE8JyDwlSxUnVibfnVkSoSDb0%EF%B9%96m=1675397273.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_Ku-3OcT9qU9h7dnGig5e23q6EVryY8orK4wzVDxsweE%EF%B9%96m=1675397367.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_vprtFTrWyg23GbY50_zJZHWGYMNfS8vsrRS26i4-ISk%EF%B9%96m=1675397406.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_dW-aNNrctRhQNc-KECjtQd0PxuW-h19IEum-TX2MeEk%EF%B9%96m=1675397301.css" media="print" />
-<link type="text/css" rel="stylesheet" href="css/css_SH2Lx3Qprh0GZo_9xRp85U9NsWfkSXn_Bi-rJoMY1sw%EF%B9%96m=1675397273.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_uaIDKcYMUK5osSQXuirpr3ZleXtnnpBN-eiECm7N0M0%EF%B9%96m=1675397395.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/responsive.blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/geos-chem.css" media="all"/>
 <script type="text/javascript" src="dropdown-menu.js"></script>
-<!--[if lte IE 8]>
-<script type="text/javascript">
-  var os_c = document.createElement;os_c('header');os_c('nav');os_c('section');os_c('article');os_c('aside');os_c('footer');os_c('hgroup');os_c('figure');
-</script>
-<![endif]-->
 </head>
 
 <body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-1585687 node-type-page og-context og-context-node og-context-node-1585652 navbar-on">
@@ -45,14 +29,14 @@
 <div id="page_wrap" class="page_wrap">
 <div id="page" class="container page header-main content-top footer-none">
 <div id="page-wrapper">
-		
+
 <!--header regions beg-->
 <header id="header" class="clearfix" role="banner">
 <div id="header-container">
 <div id="header-panels" class="at-panel gpanel panel-display three-col clearfix">
 <div class="region region-header-second"><div class="region-inner clearfix">
 <section id="block-boxes-1630413211" class="block block-boxes block-boxes-os_boxes_html"  module="boxes" delta="1630413211">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <h2 class="block-title" ng-non-bindable="">Site-Logo</h2>
 <div class="block-content content" ng-non-bindable="">
 <div id='boxes-box-1630413211' class='boxes-box'>
@@ -76,7 +60,7 @@
 <script>inlineDropDownMenu();</script>
 </nav>
 </div>
-<!--main menu region end-->	
+<!--main menu region end-->
 
 <div id="columns" class="clearfix">
 <div class="hg-container">
@@ -93,7 +77,7 @@
 <div class="region region-content-top">
 <div class="region-inner clearfix">
 <div id="block-os-pages-main-content" class="block block-os-pages no-title"  module="os_pages" delta="main_content">
-<div class="block-inner clearfix">  
+<div class="block-inner clearfix">
 <div class="block-content content" ng-non-bindable="">
 <article id="node-1585687" class="node node-page article clearfix" role="article">
 <div class="node-content" ng-non-bindable="">
@@ -103,7 +87,7 @@
 
 <p>Dear New User of GEOS-Chem:</p>
 
-<p align="justify">Welcome to the <a href="users.html" title="">GEOS-Chem community</a>! We hope that you find GEOS-Chem a useful tool for your work and we look forward to working with you. GEOS-Chem is a grass-roots model that relies on contributions and good practice from its users. We ask that you browse through the GEOS-Chem web pages to familiarize yourself with the model and its user community. We also ask that you consider the following "good practice" protocol:</p>
+<p>Welcome to the <a href="users.html" title="">GEOS-Chem community</a>! We hope that you find GEOS-Chem a useful tool for your work and we look forward to working with you. GEOS-Chem is a grass-roots model that relies on contributions and good practice from its users. We ask that you browse through the GEOS-Chem web pages to familiarize yourself with the model and its user community. We also ask that you consider the following "good practice" protocol:</p>
 
 <ul>
   <li>Subscribe to <a href="working-groups.html">GEOS-Chem working groups</a> and stay informed through the <a href="http://wiki.geos-chem.org/GEOS-Chem_newsletters" target="_blank">model newsletters</a></li>
@@ -113,8 +97,8 @@
   <li>Help out as you can in response to user requests</li>
   <li>Contribute mature new developments to the standard model</li>
 </ul>
-    
-<p align="justify">You will be asked to provide registration information the first time that you download GEOS-Chem or GCHP (please see the relevant <a href="https://geos-chem.readthedocs.io/en/stable/geos-chem-shared-docs/supplemental-guides/related-docs.html" target="_blank"">user manual</a> for download instructions). During the registration process you will be asked to provide a short description about your research and a link to your research group for inclusion the <a href="users.html">GEOS-Chem Users page</a>. We also ask that you take a moment and <a href="email-lists.html">subscribe to the GEOS-Chem email lists</a> that are most relevant to your research.</p>
+
+<p>You will be asked to provide registration information the first time that you download GEOS-Chem or GCHP (please see the relevant <a href="https://geos-chem.readthedocs.io/en/stable/geos-chem-shared-docs/supplemental-guides/related-docs.html" target="_blank">user manual</a> for download instructions). During the registration process you will be asked to provide a short description about your research and a link to your research group for inclusion the <a href="users.html">GEOS-Chem Users page</a>. We also ask that you take a moment and <a href="email-lists.html">subscribe to the GEOS-Chem email lists</a> that are most relevant to your research.</p>
 
 <p>Sincerely,</p>
 
@@ -138,48 +122,16 @@
 </div>
 </div>
 
-<!--footer region beg-->
+<!--footer-->
 <footer id="footer" class="clearfix" role="contentinfo">
-
-<!-- Three column 3x33 Gpanel -->
-<div class="at-panel gpanel panel-display footer clearfix">
-<div class="region region-footer-bottom">
-<div class="region-inner clearfix">
-<div id="block-boxes-1616879798" class="block block-boxes block-boxes-os_boxes_media no-title"  module="boxes" delta="1616879798">
-<div class="block-inner clearfix">
-<div class="block-content content">
-<div id='boxes-box-1616879798' class='boxes-box'>
 <div class="boxes-box-content">
-<div id="file-3900146" class="file file-html file-html-embed">
-<h2 class="element-invisible"><a href="">css-brand</a></h2>
-<div class="content">
-<div class="file-info">
+  <p style="text-align:center">
+    Copyright © 2026 by the International GEOS-Chem Community. All rights reserved.
+  </p>
 </div>
-<div class="field field-name-field-html-code field-type-text-long field-label-hidden view-mode-full">
-<div class="field-items">
-<div class="field-item even">
-
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-
-<!--footer region end-->
 </footer>
-</div>
-</div>
 
-<!--page area ends-->
-<div id="extradiv"></div>
+</div>
 </div>
 
 </body>

--- a/working-groups.html
+++ b/working-groups.html
@@ -1,9 +1,4 @@
 <!DOCTYPE html>
-<!--[if IEMobile 7]><html class="iem7"  lang="en" dir="ltr"><![endif]-->
-<!--[if lte IE 6]><html class="lt-ie9 lt-ie8 lt-ie7"  lang="en" dir="ltr"><![endif]-->
-<!--[if (IE 7)&(!IEMobile)]><html class="lt-ie9 lt-ie8"  lang="en" dir="ltr"><![endif]-->
-<!--[if IE 8]><html class="lt-ie9"  lang="en" dir="ltr"><![endif]-->
-<!--[if (gte IE 9)|(gt IEMobile 7)]><!--><html  lang="en" dir="ltr"><!--<![endif]-->
 <head>
 <meta charset="utf-8" />
 <!--<base href="/working-groups" />-->
@@ -18,23 +13,12 @@
 <title>GEOS-Chem Working Groups</title>
 <meta http-equiv="x-ua-compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<link type="text/css" rel="stylesheet" href="css/css_xE-rWrJf-fncB6ztZfd2huxqgxu4WO-qwma6Xer30m4%EF%B9%96m=1675397288.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_1kR8T1_c-l5pBT6ZwbDT7BFda-4fyqW9Jjum29_2IY8%EF%B9%96m=1675397312.css" media="all" />
-<link type="text/css" rel="stylesheet" href="css/css_YnlUIvHP13qgpYEqubzE8JyDwlSxUnVibfnVkSoSDb0%EF%B9%96m=1675397273.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_Ku-3OcT9qU9h7dnGig5e23q6EVryY8orK4wzVDxsweE%EF%B9%96m=1675397367.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/css_vprtFTrWyg23GbY50_zJZHWGYMNfS8vsrRS26i4-ISk%EF%B9%96m=1675397406.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_dW-aNNrctRhQNc-KECjtQd0PxuW-h19IEum-TX2MeEk%EF%B9%96m=1675397301.css" media="print" />
-<link type="text/css" rel="stylesheet" href="css/css_SH2Lx3Qprh0GZo_9xRp85U9NsWfkSXn_Bi-rJoMY1sw%EF%B9%96m=1675397273.css" media="screen" />
-<link type="text/css" rel="stylesheet" href="css/css_uaIDKcYMUK5osSQXuirpr3ZleXtnnpBN-eiECm7N0M0%EF%B9%96m=1675397395.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/responsive.blue_sky.css" media="all" />
 <link type="text/css" rel="stylesheet" href="css/geos-chem.css" media="all"/>
 <script type="text/javascript" src="dropdown-menu.js"></script>
-<!--[if lte IE 8]>
-<script type="text/javascript">
-  var os_c = document.createElement;os_c('header');os_c('nav');os_c('section');os_c('article');os_c('aside');os_c('footer');os_c('hgroup');os_c('figure');
-</script>
-<![endif]-->
 </head>
 
 <body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-1585687 node-type-page og-context og-context-node og-context-node-1585652 navbar-on">
@@ -45,7 +29,7 @@
 <div id="page_wrap" class="page_wrap">
 <div id="page" class="container page header-main content-top footer-none">
 <div id="page-wrapper">
-		
+    
 <!--header regions beg-->
 <header id="header" class="clearfix" role="banner">
 <div id="header-container">
@@ -76,7 +60,7 @@
 <script>inlineDropDownMenu();</script>
 </nav>
 </div>
-<!--main menu region end-->	
+<!--main menu region end-->  
 
 <div id="columns" class="clearfix">
 <div class="hg-container">
@@ -101,9 +85,7 @@
 <div class="field-items">
 <div class="field-item even">
 
-<p align="justify">
-  The objective of the GEOS-Chem Working Groups (WGs) is to:
-</p>
+<p>The objective of the GEOS-Chem Working Groups (WGs) is to:</p>
 
 <ol>
   <li>
@@ -116,17 +98,11 @@
   </li>
 </ol>
 
-<p align="justify">
-  Working Group chairs engage with the GEOS-Chem community to identify and promote model developments. This process is guided by a document on <a href="https://drive.google.com/file/d/15Ef4_grEck6WYpaGtHF4SHm4wvPC2GZp/view?usp=share_link" target="_blank" title="">Guiding Principles for Updates to the GEOS-Chem Model</a>.
-</p>
+<p>Working Group chairs engage with the GEOS-Chem community to identify and promote model developments. This process is guided by a document on <a href="https://drive.google.com/file/d/15Ef4_grEck6WYpaGtHF4SHm4wvPC2GZp/view?usp=share_link" target="_blank" title="">Guiding Principles for Updates to the GEOS-Chem Model</a>.</p>
 
-<p align="justify">
-  All <a href="users.html">GEOS-Chem users</a> are invited to join the Working Group(s) that corresponds to their own particular area(s) of research. For more information, please contact the relevant Working Group Chair. You effectively join a Working Group by <a href="email-lists.html" target="_blank">signing up for the relevant Working Group email List</a>.
-</p>
+<p>All <a href="users.html">GEOS-Chem users</a> are invited to join the Working Group(s) that corresponds to their own particular area(s) of research. For more information, please contact the relevant Working Group Chair. You effectively join a Working Group by <a href="email-lists.html" target="_blank">signing up for the relevant Working Group email List</a>.</p>
 
-<p align="justify">
-  The currrent GEOS-Chem Working Groups are:
-</p>
+<p>The currrent GEOS-Chem Working Groups are:</p>
 
 <table align="center" border="1" cellpadding="10" cellspacing="0">
   <tr>
@@ -145,7 +121,7 @@
       <a href="http://wiki.geos-chem.org/Aerosols_Working_Group" target="_blank">Aerosols</a>
     </td>
     <td align="center" valign="top">
-	  <a href="http://scholar.pku.edu.cn/qichen/people/qi-chen-%E9%99%88%E7%90%A6" target="_blank">Qi Chen</a><br /><a href="http://pierce.atmos.colostate.edu/people.htm#jeff" target="_blank">Jeff Pierce</a><br /><a href="https://profiles.ucr.edu/app/home/profile/wporter" target="_blank">Will Porter</a>
+    <a href="http://scholar.pku.edu.cn/qichen/people/qi-chen-%E9%99%88%E7%90%A6" target="_blank">Qi Chen</a><br /><a href="http://pierce.atmos.colostate.edu/people.htm#jeff" target="_blank">Jeff Pierce</a><br /><a href="https://profiles.ucr.edu/app/home/profile/wporter" target="_blank">Will Porter</a>
     </td>
     <td align="center" valign="top">
       geos-chem-aerosols [at] g.harvard.edu
@@ -265,9 +241,7 @@
   </tr>
 </table>
 
-<p align="justify">
-  Please also see the <a href="steering-committee.html" target="_blank">GEOS-Chem Steering Committee web page</a>.
-</p>
+<p>Please also see the <a href="steering-committee.html" target="_blank">GEOS-Chem Steering Committee web page</a>.</p>
 
 </div>
 </div>
@@ -287,48 +261,16 @@
 </div>
 </div>
 
-<!--footer region beg-->
+<!--footer-->
 <footer id="footer" class="clearfix" role="contentinfo">
-
-<!-- Three column 3x33 Gpanel -->
-<div class="at-panel gpanel panel-display footer clearfix">
-<div class="region region-footer-bottom">
-<div class="region-inner clearfix">
-<div id="block-boxes-1616879798" class="block block-boxes block-boxes-os_boxes_media no-title"  module="boxes" delta="1616879798">
-<div class="block-inner clearfix">
-<div class="block-content content">
-<div id='boxes-box-1616879798' class='boxes-box'>
 <div class="boxes-box-content">
-<div id="file-3900146" class="file file-html file-html-embed">
-<h2 class="element-invisible"><a href="">css-brand</a></h2>
-<div class="content">
-<div class="file-info">
+  <p style="text-align:center">
+    Copyright © 2026 by the International GEOS-Chem Community. All rights reserved.
+  </p>
 </div>
-<div class="field field-name-field-html-code field-type-text-long field-label-hidden view-mode-full">
-<div class="field-items">
-<div class="field-item even">
-
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-
-<!--footer region end-->
 </footer>
-</div>
-</div>
 
-<!--page area ends-->
-<div id="extradiv"></div>
+</div>
 </div>
 
 </body>


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca 
Institution: Harvard + GCST

### Describe the update
We have cleaned up much of the useless code (some left over from Drupal) in the GC web pages.  Specifically:

- Remove refs to style sheets that don't do anything
- Updated the menu bars in IGC*, GCA*, and GCE* pages.
    - Also added a link back to the GEOS-Chem index page
- Simplified the footer section
- Replaced tabs with spaces
- Trimmed trailing whitespace
- Ensure consistent indentation in numbered lists and tables 
- Use the GEOS-Chem logo for all IGC* pages instead of the map plot

### Expected changes
Minor improvements to the look-and-feel.  However, some of the pages still have minor issues that are not yet resolved (like the footer not going across the page in cube-sphere-comparisons.html).

### Related Github Issue(s)

- Closes #12